### PR TITLE
Fixed small bug in install phase, where mod_security2.so ignores $DESTDI...

### DIFF
--- a/apache2/Makefile.am
+++ b/apache2/Makefile.am
@@ -71,5 +71,5 @@ install-exec-hook: $(pkglib_LTLIBRARIES)
 	for m in $(pkglib_LTLIBRARIES); do \
 	  base=`echo $$m | sed 's/\..*//'`; \
 	  rm -f $(DESTDIR)$(pkglibdir)/$$base.*a; \
-	  cp -p $(DESTDIR)$(pkglibdir)/$$base.so $(APXS_MODULES); \
+	  install -D -m444 $(DESTDIR)$(pkglibdir)/$$base.so $(DESTDIR)$(APXS_MODULES); \
 	done


### PR DESCRIPTION
This fixes a small bug where the install script ignores the value of $DESTDIR when installing the apache module.
