### PR TITLE
handle invalid escape sequence passed to strmatch operator

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -2394,6 +2394,7 @@ static int msre_op_endsWith_execute(modsec_rec *msr, msre_rule *rule, msre_var *
 
 static int msre_op_strmatch_param_init(msre_rule *rule, char **error_msg) {
     const apr_strmatch_pattern *compiled_pattern;
+    char *processed = NULL;
     const char *pattern = rule->op_param;
     unsigned short int op_len;
 
@@ -2402,8 +2403,14 @@ static int msre_op_strmatch_param_init(msre_rule *rule, char **error_msg) {
 
     op_len = strlen(pattern);
 
+    /* Process pattern */
+    processed = parse_pm_content(pattern, op_len, rule, error_msg);
+    if (processed == NULL) {
+        return 0;
+    }
+
     /* Compile pattern */
-    compiled_pattern = apr_strmatch_precompile(rule->ruleset->mp, parse_pm_content(pattern, op_len, rule, error_msg), 1);
+    compiled_pattern = apr_strmatch_precompile(rule->ruleset->mp, processed, 1);
     if (compiled_pattern == NULL) {
         *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern: %s", pattern);
         return 0;


### PR DESCRIPTION
This is fix for a coredump that happens at startup time when @strmatch operator has invalid escape sequence like following. 

SecRule ARGS:value "@strmatch 89\xb6xagxga\x0a3" "phase:1,log,deny" 

I'm handling the case where parse_pm_content returns NULL because of error 
conditions like broken escape sequence or insufficient memory etc. 

After this patch, error that looks like following is printed at startup instead of segmentation fault.

Syntax error on line 2 of /scratch/hihayash/conf/modsec.conf:
Error creating rule: Unsupported escape sequence.
