### PR TITLE
fix for issues in ssn_verify such as infinite loop.

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -3170,15 +3170,15 @@ static int ssn_verify(modsec_rec *msr, const char *ssnumber, int len) {
     int area, serial, grp;
     int sequencial = 0;
     int repetitions = 0;
-    int progression = 0;
     char *str_area;
     char *str_grp;
     char *str_serial;
 
     for (i = 0; i < len; i++) {
         if (apr_isdigit(ssnumber[i])) {
-                num[i] = convert_to_int(ssnumber[i]);
-                digits++;
+            if (digits < 9)
+                num[digits] = convert_to_int(ssnumber[i]);
+            digits++;
         }
     }
 
@@ -3186,24 +3186,19 @@ static int ssn_verify(modsec_rec *msr, const char *ssnumber, int len) {
     if (digits != 9)
         goto invalid;
 
-    digits = 0;
+    for (i=0; i < 8; i++)   {
+        if (num[i] == (num[i+1]-1))
+            sequencial++;
 
-    for (i=0; i < len-1; i++)   {
-        progression = (num[i] - (num[i+1]-1));
-        repetitions = (num[i] - num[i+1]);
-
-        if (repetitions != 0 )
-            sequencial = 1;
-
-        if (progression == 0)
-            digits++;
+        if (num[i] == num[i+1])
+            repetitions++;
     }
 
-    /* We are blocking when all numbers were repeated */
-    if (sequencial == 0)
+    /* We are blocking when all numbers were sequencial or repeated */
+    if (sequencial == 8)
         goto invalid;
 
-    if (digits == 8)
+    if (repetitions == 8)
         goto invalid;
 
     str_area = apr_psprintf(msr->mp,"%d%d%d",num[0],num[1],num[2]);


### PR DESCRIPTION
This is fixes in ssn_verify, which verifies valid US social security number.
I figured that it's intention is the following.
- Reject if it does not include 9 numeric chars.
- Reject if the 9 digits are repetition of same number. ex. 111-11-1111
- Reject if the 9 digits are sequential numbers. ex. 123-45-6789
- Reject if one of the fields are all zero. ex. 235-00-4829
- Reject if the first 3 digits are 666 or larger than or equal to 740

The function ssn_verify had following issues, which I fixed in this patch.
- Infinite loop caused by mixing i (string index) and digits (digits index)
- false negative caused by mixing len-1 (string length - 1) and 8 (number of digits - 1)
  ex. 123-45-6789 was considered valid before fixing this.
- cleaned up usage of  variable names.
  For example,  variable "sequencial" was used for check
  of not being repetition of same numbers.
- For the clarity of the code, I made sequential check logic similar to repetition check logic.
  (check if the times adjacent digits are sequential/repetitive are 8 or not.)
