### PR TITLE
fixed bugs in cpf_verify

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -2878,7 +2878,7 @@ static int cpf_verify(const char *cpfnumber, int len) {
         "88888888888",
         "99999999999"};
 
-    while((*cpfnumber != '\0') && ( var_len >= 0))  {
+    while((*cpfnumber != '\0') && ( var_len > 0))  {
 
         if(*cpfnumber != '-' || *cpfnumber != '.') {
             if(i < cpf_len && isdigit(*cpfnumber))  {
@@ -2892,7 +2892,7 @@ static int cpf_verify(const char *cpfnumber, int len) {
     }
 
 
-    if (strlen(s_cpf) != cpf_len || i != cpf_len-1)
+    if (i != cpf_len)
         return 0;
     else {
         for(i = 0; i< cpf_len; i++)   {


### PR DESCRIPTION
This is fix for validation logic for CPF.
1. check for var_len is wrong. original code would read one extra byte from the buffer if the string is not null terminated.
2. check for strlen(s_cpf) is unnecessary and unsafe.
   It is unnecessary because checking i does the same thing, and it is unsafe because s_cpf is not guaranteed to be zeroed.
3. check for i is wrong. It should be compared with cpf_len instead of cpf_len-1. In the original code, valid CPFs were deemed as invalid because of this.
