### PR TITLE
Fixed: ngx_http_read_client_request_body returned unexpected buffer type

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -384,7 +384,7 @@ modsecurity_read_body_cb(request_rec *r, char *outpos, unsigned int length,
             
             outpos = (char *) ngx_cpymem(outpos, buf->pos, len);
             rest -= len;
-            buf->last += len;
+            buf->pos += len;
         } else if (buf->in_file) {
             
             size = ngx_read_file(buf->file, (u_char*)outpos, len, buf->file_pos);


### PR DESCRIPTION
after request body phase, POSTed request body is saved in memory buffer chain and request_body_in_file_only option is ignored, so if other module set request_body_in_file_only on and call ngx_http_read_client_request_body after modsecurity handler, the module will receive unexpected buffer. for example http_dav_handler for PUT request.
