### PR TITLE
Increase compatibility with older versions of install(1)

### DIFF
--- a/apache2/Makefile.am
+++ b/apache2/Makefile.am
@@ -72,7 +72,7 @@ install-exec-hook: $(pkglib_LTLIBRARIES)
 	for m in $(pkglib_LTLIBRARIES); do \
 	  base=`echo $$m | sed 's/\..*//'`; \
 	  rm -f $(DESTDIR)$(pkglibdir)/$$base.*a; \
-	  install -D -m444 $(DESTDIR)$(pkglibdir)/$$base.so $(DESTDIR)$(APXS_MODULES); \
+	  install -D -m444 $(DESTDIR)$(pkglibdir)/$$base.so $(DESTDIR)$(APXS_MODULES)/$$base.so; \
 	done
 else
 install-exec-hook: $(pkglib_LTLIBRARIES)


### PR DESCRIPTION
Older versions of install(1) (e.g., the one in CentOS 4.9) will cause the build to fail, for example:

install: cannot overwrite directory `/usr/local/apache/modules' with non-directory

This explicitly adds the filename to the destination path to improve compatibility without changing the semantics.
