### PR TITLE
Try 3 - nginx: Makes the build script to check for deps

### DIFF
--- a/nginx/modsecurity/config
+++ b/nginx/modsecurity/config
@@ -1,7 +1,79 @@
+#!/bin/sh
+
+dependencies='apr-1 apr-util-1 libxml-2.0'
+
+if [ ! -e "$ngx_addon_dir/../../standalone/.libs/standalone.a" ]
+then
+  echo "Aborting. ModSecurity must be compiled with \
+--enable-standalone-module option prior to the Nginx compilation."
+  exit 1
+fi
+
+echo -n "Checking for Apache headers using apx2... "
+apache_include_dir=`apxs2 -q INCLUDEDIR 2> /dev/null`
+RETVAL=$?
+if [ $RETVAL -eq 0 ]
+then
+  CORE_INCS="$CORE_INCS $apache_include_dir"
+  echo "Ok"
+else
+  echo "FAIL"
+  echo "Aborting. Apache apx2 is not installed or fails to point\
+Apache headers."
+  exit 1;
+fi
+
+missing=""
+for element in $dependencies;
+do
+  echo -n "Checking for $element... ";
+
+  cflags=`pkg-config --cflags-only-I $element 2> /dev/null | sed -s 's/-I//'`
+  libs=`pkg-config --libs $element 2> /dev/null`
+  RETVAL=$?
+
+  if [ $RETVAL -eq 0 ]
+  then
+    CORE_INCS="$CORE_INCS $cflags"
+    CORE_LIBS="$CORE_LIBS $libs"
+    echo "Ok"
+  else
+    echo "FAIL"
+    missing="$missing $element"
+  fi
+done
+
+if [ ! -z $missing ]
+then
+  echo "Aborting. Following dependencies are missing: $missing"
+  exit 1
+fi
+
+if [ $USE_PCRE = DISABLED ]
+then
+  echo "Aborting. PCRE support must be enabled on Nginx compilation"
+  exit 1
+fi
+
 ngx_addon_name=ngx_http_modsecurity
+
 CORE_MODULES="$CORE_MODULES ngx_pool_context_module"
+
 HTTP_AUX_FILTER_MODULES="ngx_http_modsecurity $HTTP_AUX_FILTER_MODULES"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_modsecurity.c $ngx_addon_dir/apr_bucket_nginx.c $ngx_addon_dir/ngx_pool_context.c"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/apr_bucket_nginx.h $ngx_addon_dir/ngx_pool_context.h"
-CORE_LIBS="$CORE_LIBS $ngx_addon_dir/../../standalone/.libs/standalone.a -L/usr/local/apr/lib -lapr-1  -L/usr/local/apr/lib -laprutil-1 -lpcre -lxml2 -lz -lm -ldl  "
-CORE_INCS="$CORE_INCS $ngx_addon_dir $ngx_addon_dir/../../standalone $ngx_addon_dir/../../apache2 /usr/include/libxml2  /usr/local/apache2/include /usr/local/apr/include/apr-1 /usr/local/apr/include/apr-1"
+
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
+		$ngx_addon_dir/ngx_http_modsecurity.c \
+		$ngx_addon_dir/apr_bucket_nginx.c \
+		$ngx_addon_dir/ngx_pool_context.c"
+
+NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
+		$ngx_addon_dir/apr_bucket_nginx.h \
+		$ngx_addon_dir/ngx_pool_context.h"
+
+CORE_LIBS="$ngx_addon_dir/../../standalone/.libs/standalone.a $CORE_LIBS"
+
+CORE_INCS="$CORE_INCS \
+	$ngx_addon_dir \
+	$ngx_addon_dir/../../standalone \
+	$ngx_addon_dir/../../apache2"
+


### PR DESCRIPTION
The ModSecurity module has some dependencies that may not be part of the Nginx build, and so it is not part of the configuration options. In order to resolve this dependencies automatically this `config' is now making use of the pkg-config, utility that is popular to make this compatible layer between different Linux distributions and operational systems.
