### PR TITLE
Bugfix: missing string terminator while mounting the charset (nginx)

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -615,7 +615,7 @@ ngx_http_modsecurity_load_headers_out(ngx_http_request_t *r)
         }
 
         ngx_snprintf(content_type, content_type_len,
-                     "%V; charset=%V",
+                     "%V; charset=%V\0",
                      &r->headers_out.content_type,
                      &r->headers_out.charset);
 


### PR DESCRIPTION
The charset in headers is mounted using ngx_snprintf which
does not place the string terminator. This patch adds the
terminator at the end of the string. The size was correctly
allocated, just missing the terminator.

This bug was report at:
- https://www.modsecurity.org/tracker/browse/MODSEC-420
- https://github.com/SpiderLabs/ModSecurity/issues/142

Both reports comes with patch, first by Veli Pekka Jutila and
second by wellumies.
