### PR TITLE
Fix #142, Uses addn instead of apr_table_setn

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -652,7 +652,7 @@ ngx_http_modsecurity_load_headers_out(ngx_http_request_t *r)
         buf = ngx_cpymem(buf, h[i].value.data, h[i].value.len);
         *buf++ = '\0';
 
-        apr_table_setn(req->headers_out, key, value);
+        apr_table_addn(req->headers_out, key, value);
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "ModSecurity: load headers out: \"%V: %V\"",
                        &h[i].key, &h[i].value);


### PR DESCRIPTION
The headers are represented in the format of an apr_table, which
is able to handle elements with the same key, however the function
apr_table_setn checks if the key exists before add the element, if so
it replaces the old value with the new one. This was making our
implementation to just keep the last added Cookie. The apr_table_addn
function, which is now used, just add a new item without check for
olders one.
