### PR TITLE
Add mod_extract_forwarded.c to run before mod_security2.c

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1468,6 +1468,7 @@ static void register_hooks(apr_pool_t *mp) {
     static const char *const postread_beforeme_list[] = {
         "mod_rpaf.c",
         "mod_rpaf-2.0.c",
+        "mod_extract_forwarded.c",
         "mod_extract_forwarded2.c",
         "mod_remoteip.c",
         "mod_custom_header.c",


### PR DESCRIPTION
mod_extract_forwarded2.c is already present in this list, but there is a
(seemingly better) alternative for Apache 2.2 which is distributed in
Fedora EPEL that is called mod_extract_forwarded.c.
