### PR TITLE
iis: Avoids directory link while building

### DIFF
--- a/iis/dependencies/build_curl.bat
+++ b/iis/dependencies/build_curl.bat
@@ -6,20 +6,20 @@ cd "%WORK_DIR%"
 
 set CURL_DIR=%CURL:~0,-4%
 
-mklink /D "curl" "%CURL_DIR%" 
+move "%CURL_DIR%" "curl"
 
-copy /y CMakeLists.txt "%CURL_DIR%"
-CD "%CURL_DIR%"
+:: copy /y CMakeLists.txt "curl"
+CD "curl"
 CMAKE   -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=True -DCURL_ZLIB=True
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
-:: "%WORK_DIR%\fart.exe" -r -C "%WORK_DIR%\%CURL_DIR%\include\curl\curlbuild.h" LLU ULL
+:: "%WORK_DIR%\fart.exe" -r -C "%WORK_DIR%\curl\include\curl\curlbuild.h" LLU ULL
 NMAKE
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 cd "%WORK_DIR%"
 
-copy /y "%WORK_DIR%\%CURL_DIR%\lib\libcurl.dll" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%CURL_DIR%\lib\libcurl.pdb" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%CURL_DIR%\lib\libcurl_imp.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\curl\lib\libcurl.dll" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\curl\lib\libcurl.pdb" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\curl\lib\libcurl_imp.lib" "%OUTPUT_DIR%"
 
 exit /B 0
 

--- a/iis/dependencies/build_libxml2.bat
+++ b/iis/dependencies/build_libxml2.bat
@@ -6,10 +6,10 @@ cd "%WORK_DIR%"
 
 set LIBXML2_DIR=%LIBXML2:~0,-7%
 
-mklink /D "libxml2" "%LIBXML2_DIR%"
+move "%LIBXML2_DIR%" "libxml2"
 
 :: fart.exe -r -i -C "%WORK_DIR%\%LIBXML2_DIR%\win32\*.*" \x2Fopt:nowin98 " "
-cd "%LIBXML2_DIR%\win32"
+cd "libxml2\win32"
 CSCRIPT configure.js iconv=no vcmanifest=yes zlib=yes
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 NMAKE -f Makefile.msvc
@@ -17,8 +17,8 @@ NMAKE -f Makefile.msvc
 
 cd "%WORK%"
 
-copy /y "%WORK_DIR%\%LIBXML2_DIR%\win32\bin.msvc\libxml2.dll" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%LIBXML2_DIR%\win32\bin.msvc\libxml2.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\libxml2\win32\bin.msvc\libxml2.dll" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\libxml2\win32\bin.msvc\libxml2.lib" "%OUTPUT_DIR%"
 
 @exit /B 0
 

--- a/iis/dependencies/build_lua.bat
+++ b/iis/dependencies/build_lua.bat
@@ -6,9 +6,9 @@ cd "%WORK_DIR%"
 
 set LUA_DIR=%LUA:~0,-7%
 
-mklink /D "lua" "%LUA_DIR%" 
+move "%LUA_DIR%" "lua"
 
-cd "%LUA_DIR%\src"
+cd "lua\src"
 
 CL /Ox /arch:SSE2 /GF /GL /Gy /FD /EHsc /MD  /Zi /TC /wd4005 /D "_MBCS" /D "LUA_CORE" /D "LUA_BUILD_AS_DLL" /D "_CRT_SECURE_NO_WARNINGS" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_WIN32" /D "_WINDLL" /c *.c
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
@@ -20,9 +20,9 @@ IF EXIST lua5.1.dll.manifest MT  -manifest lua5.1.dll.manifest -outputresource:l
 
 cd "%WORK_DIR%"
 
-copy /y "%WORK_DIR%\%LUA_DIR%\src\lua5.1.dll" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%LUA_DIR%\src\lua5.1.pdb" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%LUA_DIR%\src\lua5.1.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\lua\src\lua5.1.dll" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\lua\src\lua5.1.pdb" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\lua\src\lua5.1.lib" "%OUTPUT_DIR%"
 
 @exit /B 0
 

--- a/iis/dependencies/build_pcre.bat
+++ b/iis/dependencies/build_pcre.bat
@@ -5,18 +5,18 @@ cd "%WORK_DIR%"
 7z.exe x "%SOURCE_DIR%\%PCRE%"
 set PCRE_DIR=%PCRE:~0,-4%
 
-mklink /D "pcre" "%PCRE_DIR%"
+move "%PCRE_DIR%" "pcre"
 
-cd "%PCRE_DIR%"
+cd "pcre"
 CMAKE -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=True
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 NMAKE
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 cd "%WORK%"
 
-copy /y "%WORK_DIR%\%PCRE_DIR%\pcre.dll" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%PCRE_DIR%\pcre.pdb" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%PCRE_DIR%\pcre.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\pcre\pcre.dll" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\pcre\pcre.pdb" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\pcre\pcre.lib" "%OUTPUT_DIR%"
 echo "a"
 @exit /B 0
 

--- a/iis/dependencies/build_yajl.bat
+++ b/iis/dependencies/build_yajl.bat
@@ -5,8 +5,9 @@ lloyd-yajl-f4b2b1a
 7z.exe x "%SOURCE_DIR%\%YAJL%"
 set YAJL_DIR=%YAJL:~0,-4%
 
-mklink /D "yajl" "%YAJL_DIR%"
-cd "%YAJL_DIR%"
+move "%YAJL_DIR%" "yajl"
+
+cd "yajl"
 
 mkdir build
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
@@ -19,10 +20,10 @@ nmake
 
 cd "%WORK%"
 
-copy /y "%WORK_DIR%\%YAJL_DIR%\build\yajl-2.0.1\lib\yajl.dll" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%YAJL_DIR%\build\yajl-2.0.1\lib\yajl.pdb" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%YAJL_DIR%\build\yajl-2.0.1\lib\yajl.lib" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%YAJL_DIR%\build\yajl-2.0.1\lib\yajl_s.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\yajl\build\yajl-2.0.1\lib\yajl.dll" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\yajl\build\yajl-2.0.1\lib\yajl.pdb" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\yajl\build\yajl-2.0.1\lib\yajl.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\yajl\build\yajl-2.0.1\lib\yajl_s.lib" "%OUTPUT_DIR%"
 
 @exit /B 0
 

--- a/iis/dependencies/build_zlib.bat
+++ b/iis/dependencies/build_zlib.bat
@@ -7,18 +7,18 @@ cd "%WORK_DIR%"
 
 set ZLIB_DIR=%ZLIB:~0,-7%
 
-mklink /D "zlib" "%ZLIB_DIR%"
+move "%ZLIB_DIR%" "zlib"
 
-cd "%ZLIB_DIR%"
+cd "zlib"
 nmake -f win32\Makefile.msc
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
-SET INCLUDE=%INCLUDE%;%WORK_DIR%\%ZLIB_DIR%
-SET LIB=%LIB%;%WORK_DIR%\%ZLIB_DIR%
+SET INCLUDE=%INCLUDE%;%WORK_DIR%\zlib
+SET LIB=%LIB%;%WORK_DIR%\zlib
 cd "%WORK_DIR%"
 
-copy /y "%WORK_DIR%\%ZLIB_DIR%\zlib1.dll" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%ZLIB_DIR%\zlib1.pdb" "%OUTPUT_DIR%"
-copy /y "%WORK_DIR%\%ZLIB_DIR%\zdll.lib" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\zlib\zlib1.dll" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\zlib\zlib1.pdb" "%OUTPUT_DIR%"
+copy /y "%WORK_DIR%\zlib\zdll.lib" "%OUTPUT_DIR%"
 
 @exit /B 0
 


### PR DESCRIPTION
Build scripts was creating links allowing the project to
be loaded into Visual Studio without care about the
dependencies versions. Sometimes windows refuse to delete
those links leading the script to fail. This patch
moves the sources directories instead of create links
to it.
