### PR TITLE
Fix invalid storage reference in getkey()

### DIFF
--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -152,14 +152,14 @@ char *getkey(apr_pool_t *mp) {
     char salt[64];
 
     apr_generate_random_bytes(salt, sizeof(salt));
-    key = apr_psprintf(mp,"%s",salt);
+    key = apr_psprintf(mp,"%.*s",(int)sizeof(salt),salt);
 
     apr_sha1_init (&ctx);
     apr_sha1_update (&ctx, (const char*)key, strlen(key));
     apr_sha1_update (&ctx, "\0", 1);
 
     apr_generate_random_bytes(salt, sizeof(salt));
-    value = apr_psprintf(mp,"%s",salt);
+    value = apr_psprintf(mp,"%.*s",(int)sizeof(salt),salt);
 
     apr_sha1_update (&ctx, value, strlen (value));
     apr_sha1_final (digest, &ctx);


### PR DESCRIPTION
Fix invalid storage reference by apr_psprintf() when creating a string from salt[].  salt[] is not
'\0'-terminated, so apr_psprintf() needs to be told the extent of the bytes to read.

It is easy to test old/new code standalone with valgrind; just insert the getkey() function into this template:

#include <stdio.h>

#include "apr_general.h"
#include "apr_strings.h"

#include "apr_base64.h"
#include "apr_sha1.h"

    <<<<getkey() goes here>>>>

int main(void)
{
    apr_pool_t *p;

    apr_initialize();
    apr_pool_create(&p, NULL);

    printf("%s\n", getkey(p));
    return 0;
}