### PR TITLE
Clean the garbage character after the duplicated charset property

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -615,7 +615,7 @@ ngx_http_modsecurity_load_headers_out(ngx_http_request_t *r)
         }
 
         ngx_snprintf(content_type, content_type_len,
-                     "%V; charset=%V",
+                     "%V; charset=%V%Z",
                      &r->headers_out.content_type,
                      &r->headers_out.charset);
 


### PR DESCRIPTION
Pull request #148 by zimmerle doesn't fix the problem. '\0' in format
string won't be processed by "ngx_vslprintf".
When the garbage character is '\n' or '\r', http response is cracked and
browsers may go crashing.
