### PR TITLE
Fix typo causing build issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,7 @@ cppcheck:
 	cppcheck . --enable=all --force 2>&1 | sed 's/^/warning: /g' 1>&2;
 
 check-coding-style:
-	for i in `(find . -iname "*.c" ; find . -iname "*.h")`; \ 
+	for i in `(find . -iname "*.c" ; find . -iname "*.h")`; \
 	    do echo $$i...; \
 	    vera++ -rule L004 -param max-line-length=80 $$i 2>&1 | sed 's/^/warning: /g' 1>&2; \
 	    vera++ -rule L001 $$i 2>&1 | sed 's/^/warning: /g' 1>&2; \


### PR DESCRIPTION
This looks like a small typo but it was causing 

```
$ ./autogen.sh 
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, `build'.
libtoolize: copying file `build/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `build'.
libtoolize: copying file `build/libtool.m4'
libtoolize: copying file `build/ltoptions.m4'
libtoolize: copying file `build/ltsugar.m4'
libtoolize: copying file `build/ltversion.m4'
libtoolize: copying file `build/lt~obsolete.m4'
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, `build'.
libtoolize: copying file `build/config.guess'
libtoolize: copying file `build/config.sub'
libtoolize: copying file `build/install-sh'
configure.ac:18: installing `build/ar-lib'
configure.ac:17: installing `build/missing'
alp2/Makefile.am: installing `build/depcomp'
standalone/Makefile.am:77: whitespace following trailing backslash
Makefile.am:43: whitespace following trailing backslash
standalone/Makefile.am:77: whitespace following trailing backslash
Makefile.am:43: whitespace following trailing backslash
$ sudo dpkg -l | grep -P "  (libtool|automake)"
ii  automake                   1:1.11.3-1ubuntu2            Tool for generating GNU Standards-compliant Makefiles
ii  libtool                    2.4.2-1ubuntu1               Generic library support script
$
```
