### PR TITLE
Add independent modsecFinishConnection API that allows you to independen...

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -67,6 +67,10 @@ class REQUEST_STORED_CONTEXT : public IHttpStoredContext
 		{
 			modsecFinishRequest(m_pRequestRec);
 			m_pRequestRec = NULL;
+		}
+		if(m_pConnRec != NULL)
+		{
+			modsecFinishConnection(m_pConnRec);
 			m_pConnRec = NULL;
 		}
 	}

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -1376,6 +1376,10 @@ ngx_http_modsecurity_cleanup(void *data)
     if (ctx->req != NULL) {
         (void) modsecFinishRequest(ctx->req);
     }
+    if (ctx->connection != NULL) {
+        (void) modsecFinishConnection(ctx->connection);
+    }
+    
 }
 
     static char *

--- a/standalone/api.c
+++ b/standalone/api.c
@@ -644,10 +644,19 @@ int modsecFinishRequest(request_rec *r) {
     // make sure you cleanup before calling apr_terminate()
     // otherwise double-free might occur, because of the request body pool cleanup function
     //
-    apr_pool_destroy(r->connection->pool);
+    apr_pool_destroy(r->pool);
 
     return DECLINED;
 }
+
+// destroy only the connection pool
+int modsecFinishConnection(conn_rec *c)
+{
+
+    apr_pool_destroy(c->pool);
+
+}
+
 
 void modsecSetLogHook(void *obj, void (*hook)(void *obj, int level, char *str)) {
     modsecLogObj = obj;

--- a/standalone/api.h
+++ b/standalone/api.h
@@ -58,6 +58,7 @@ void modsecInitProcess();
 
 conn_rec *modsecNewConnection();
 void modsecProcessConnection(conn_rec *c);
+int modsecFinishConnection(conn_rec *c);
 
 request_rec *modsecNewRequest(conn_rec *connection, directory_config *config);
 


### PR DESCRIPTION
This adds an independent API call to free the connection allocations, independently from the request objects.  Additionally updates the existing modsecFinishRequest to only free up the request's allocations.

This should facilitate better memory management by user libraries (though this is not in this pull request) to not needlessly reallocate connection objects on a per-request basis.

I tested that this builds properly using nginx stable (1.4.4).

```
        objs/addon/modsecurity/ngx_http_modsecurity.o \
        objs/addon/modsecurity/apr_bucket_nginx.o \
        objs/addon/modsecurity/ngx_pool_context.o \
        objs/ngx_modules.o \
        -lpthread -lcrypt ../ModSecurity/nginx/modsecurity/../../standalone/.libs/standalone.a -L/usr/lib -lapr-1 -L/usr/lib -laprutil-1 -L/usr/lib/x86_64-linux-gnu -lpcre -L/usr/lib/x86_64-linux-gnu -lxml2 -llua5.1 -lpcre -lcrypto -lcrypto -lz -lfuzzy
make[1]: Leaving directory `~/Work/dev/git/nginx-1.4.4'
make -f objs/Makefile manpage
make[1]: Entering directory `~/Work/dev/git/nginx-1.4.4'
sed -e "s|%%PREFIX%%|/usr/local/nginx|" \
                -e "s|%%PID_PATH%%|/usr/local/nginx/logs/nginx.pid|" \
                -e "s|%%CONF_PATH%%|/usr/local/nginx/conf/nginx.conf|" \
                -e "s|%%ERROR_LOG_PATH%%|/usr/local/nginx/logs/error.log|" \
                < man/nginx.8 > objs/nginx.8
make[1]: Leaving directory `~/Work/dev/git/nginx-1.4.4'
~/Work/dev/git/nginx-1.4.4$
```
