### PR TITLE
Make regression tests' config file more portable across distros

### DIFF
--- a/tests/regression/server_root/conf/httpd.conf.in
+++ b/tests/regression/server_root/conf/httpd.conf.in
@@ -24,7 +24,7 @@
 </IfModule>
 
 <IfModule !mod_unixd.c>
-    LoadModule unixd_module /usr/lib64/httpd/modules/mod_unixd.so
+    LoadModule unixd_module @APXS_LIBEXECDIR@/mod_unixd.so
 </IfModule>
 
 


### PR DESCRIPTION
- Fix some modules' path
- Add mod_version if not enable by default (needed to check >= 2.4.x specific config)
- Add mod_unixd if not enabled
