### PR TITLE
Stop buffering when the request is larger than SecRequestBodyLimit in ProcessPartial mode

### DIFF
--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -257,6 +257,7 @@ struct modsec_rec {
     unsigned int         phase_request_body_complete;
 
     apr_bucket_brigade  *if_brigade;
+    unsigned int         if_seen_eos;
     unsigned int         if_status;
     unsigned int         if_started_forwarding;
 


### PR DESCRIPTION
This change should address #705. It will cause ModSec to stop buffering the incoming request body if it is larger than the configured request limit and in ProcessPartial mode. It will not send an EOS bucket in the forwarding phase of the input filter if it did not read an EOS bucket.

A side effect of handling buffering like this is that request body parsers will sometimes throw errors if they cannot see all of the request data.