### PR TITLE
Fixed nginx worker segmentation fault if http context is not defined.

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -938,6 +938,12 @@ ngx_http_modsecurity_init(ngx_conf_t *cf)
 static ngx_int_t
 ngx_http_modsecurity_init_process(ngx_cycle_t *cycle)
 {
+    if (ngx_http_cycle_get_module_main_conf(cycle, ngx_http_modsecurity)
+        == NULL)
+    {
+        return NGX_OK;
+    }
+
     /* must set log hook here cf->log maybe changed */
     modsecSetLogHook(cycle->log, modsecLog);
     modsecInitProcess();


### PR DESCRIPTION
This commit fixes segmentation fault in case when there is no http context defined in nginx configuration:

(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00000000004b43be in ngx_http_modsecurity_init_process (cycle=<value optimized out>)

```
at /home/defan/src/modsecurity-2.8.0/nginx/modsecurity/ngx_http_modsecurity.c:943
```
#2  0x000000000042b9db in ngx_worker_process_init (cycle=0x14b4980, worker=<value optimized out>) at src/os/unix/ngx_process_cycle.c:979
#3  0x000000000042bf92 in ngx_worker_process_cycle (cycle=0x14b4980, data=<value optimized out>) at src/os/unix/ngx_process_cycle.c:744
#4  0x000000000042a721 in ngx_spawn_process (cycle=0x14b4980, proc=0x42bf6a <ngx_worker_process_cycle>, data=0x0, name=0x4ff403 "worker process", respawn=0)

```
at src/os/unix/ngx_process.c:198
```
#5  0x000000000042cae8 in ngx_reap_children (cycle=0x14b4980) at src/os/unix/ngx_process_cycle.c:628
#6  ngx_master_process_cycle (cycle=0x14b4980) at src/os/unix/ngx_process_cycle.c:181
#7  0x000000000040d02b in main (argc=<value optimized out>, argv=<value optimized out>) at src/core/nginx.c:407

(gdb) 
