### PR TITLE
Added possibility to specify a data file with a name relative to httpd root (as include files) + conditional logging + allow duplicate rule ids and no id

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -786,6 +786,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
         return my_error_msg;
     }
 
+#ifndef ALLOW_ID_NOT_UNIQUE
     /* Rules must have uniq ID */
     if (
 #if defined(WITH_LUA)
@@ -818,6 +819,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
             //    return "ModSecurity: Found another rule with the same id";
         }
     }
+#endif
 
     /* Create default actionset if one does not already exist. */
     if (dcfg->tmp_default_actionset == NULL) {

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1507,6 +1507,8 @@ static const char *cmd_default_action(cmd_parms *cmd, void *_dcfg,
         return apr_psprintf(cmd->pool, "ModSecurity: SecDefaultAction must not "
             "contain any metadata actions (id, rev, msg, tag, severity, ver, accuracy, maturity, logdata).");
     }
+
+#ifndef LOG_NO_DEFAULT_DEPRECATED
     /* These are just a warning for now. */
     if ((dcfg->tmp_default_actionset->severity != NOT_SET)
         ||(dcfg->tmp_default_actionset->logdata != NOT_SET_P))
@@ -1525,6 +1527,7 @@ static const char *cmd_default_action(cmd_parms *cmd, void *_dcfg,
             "SecDefaultAction is deprecated (%s:%d).",
             cmd->directive->filename, cmd->directive->line_num);
     }
+#endif
 
     /* Must not use chain. */
     if (dcfg->tmp_default_actionset->is_chained != NOT_SET) {

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -339,6 +339,7 @@ char *format_error_log_message(apr_pool_t *mp, error_message_t *em) {
 
     if (em == NULL) return NULL;
 
+#ifndef LOG_NO_FILENAME
     if (em->file != NULL) {
         s_file = apr_psprintf(mp, "[file \"%s\"] ",
             log_escape(mp, (char *)em->file));
@@ -349,6 +350,7 @@ char *format_error_log_message(apr_pool_t *mp, error_message_t *em) {
         s_line = apr_psprintf(mp, "[line %d] ", em->line);
         if (s_line == NULL) return NULL;
     }
+#endif
 
     s_level = apr_psprintf(mp, "[level %d] ", em->level);
     if (s_level == NULL) return NULL;

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -739,11 +739,13 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
         if (status_engine_state != STATUS_ENGINE_DISABLED) {
             msc_status_engine_call();
         }
+#ifndef LOG_NO_WARN_STATUS
         else {
             ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
                     "Status engine is currently disabled, enable it by set " \
                     "SecStatusEngine to On.");
         }
+#endif
 #endif
     }
 

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -277,7 +277,10 @@ int perform_interception(modsec_rec *msr) {
                     log_level = 1;
                     status = HTTP_INTERNAL_SERVER_ERROR;
                     message = apr_psprintf(msr->mp, "Access denied with code 500%s "
-                        "(Error: Connection drop not implemented on this platform.",
+#ifndef NO_CON_DROP_WARN
+                        "(Error: Connection drop not implemented on this platform."
+#endif
+			,
                         phase_text);
                 } else if (modsecDropAction(msr->r) == 0) {
                     status = HTTP_FORBIDDEN;

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -956,12 +956,15 @@ void sec_audit_logger(modsec_rec *msr) {
             sec_auditlog_write(msr, text, strlen(text));
         }
 
+#ifndef LOG_NO_HANDLER
         /* Apache-Handler */
         if (msr->r->handler != NULL) {
             text = apr_psprintf(msr->mp, "Apache-Handler: %s\n", msr->r->handler);
             sec_auditlog_write(msr, text, strlen(text));
         }
+#endif
 
+#ifndef LOG_NO_STOPWATCH
         /* Stopwatch; left in for compatibility reasons */
         text = apr_psprintf(msr->mp, "Stopwatch: %" APR_TIME_T_FMT " %" APR_TIME_T_FMT " (- - -)\n",
             msr->request_time, (now - msr->request_time));
@@ -976,7 +979,9 @@ void sec_audit_logger(modsec_rec *msr) {
 
             sec_auditlog_write(msr, text, strlen(text));
         }
+#endif
 
+#ifndef LOG_NO_DECHUNK
         /* Our response body does not contain chunks */
         /* ENH Only write this when the output was chunked. */
         /* ENH Add info when request body was decompressed, dechunked too. */
@@ -984,14 +989,19 @@ void sec_audit_logger(modsec_rec *msr) {
             text = apr_psprintf(msr->mp, "Response-Body-Transformed: Dechunked\n");
             sec_auditlog_write(msr, text, strlen(text));
         }
+#endif
 
+#ifndef LOG_NO_PRODUCERS
         sec_auditlog_write_producer_header(msr);
+#endif
 
+#ifndef LOG_NO_SERVER
         /* Server */
         if (msr->server_software != NULL) {
             text = apr_psprintf(msr->mp, "Server: %s\n", msr->server_software);
             sec_auditlog_write(msr, text, strlen(text));
         }
+#endif
 
         /* Sanitised arguments */
         {

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1920,7 +1920,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             }
         }
         else {
-            msr_log(msr, 1, "Rule processing failed (id=%s, msg=%s).", rule->actionset->id, rule->actionset->msg);
+            msr_log(msr, 1, "Rule processing failed with unknown return code: %d (id=%s, msg=%s).", rc, rule->actionset->id, rule->actionset->msg);
             apr_table_clear(msr->matched_vars);
             return -1;
         }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1920,7 +1920,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             }
         }
         else {
-            msr_log(msr, 1, "Rule processing failed with unknown return code: %d.", rc);
+            msr_log(msr, 1, "Rule processing failed (id=%s, msg=%s).", rule->actionset->id, rule->actionset->msg);
             apr_table_clear(msr->matched_vars);
             return -1;
         }
@@ -2194,10 +2194,12 @@ char *msre_format_metadata(modsec_rec *msr, msre_actionset *actionset) {
 
     if (actionset == NULL) return "";
 
+#ifndef LOG_NO_FILENAME
     if ((actionset->rule != NULL) && (actionset->rule->filename != NULL)) {
         fn = apr_psprintf(msr->mp, " [file \"%s\"] [line \"%d\"]",
                 actionset->rule->filename, actionset->rule->line_num);
     }
+#endif
     if (actionset->id != NULL) {
         id = apr_psprintf(msr->mp, " [id \"%s\"]",
                 log_escape(msr->mp, actionset->id));

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -3,9 +3,9 @@
 * Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
 *
 * You may not use this file except in compliance with
-* the License. Â You may obtain a copy of the License at
+* the License.  You may obtain a copy of the License at
 *
-* Â  Â  http://www.apache.org/licenses/LICENSE-2.0
+*     http://www.apache.org/licenses/LICENSE-2.0
 *
 * If any of the files related to licensing are missing or if you have any
 * other questions related to licensing please contact Trustwave Holdings, Inc.

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -3,9 +3,9 @@
 * Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
 *
 * You may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
+* the License. Â You may obtain a copy of the License at
 *
-*     http://www.apache.org/licenses/LICENSE-2.0
+* Â  Â  http://www.apache.org/licenses/LICENSE-2.0
 *
 * If any of the files related to licensing are missing or if you have any
 * other questions related to licensing please contact Trustwave Holdings, Inc.
@@ -1218,8 +1218,6 @@ static int msre_op_pmFromFile_param_init(msre_rule *rule, char **error_msg) {
     /* Loop through filenames */
     /* ENH: Need to allow quoted filenames w/space */
     for (;;) {
-        const char *rootpath = NULL;
-        const char *filepath = NULL;
         int line = 0;
 
         /* Trim whitespace */
@@ -1229,16 +1227,31 @@ static int msre_op_pmFromFile_param_init(msre_rule *rule, char **error_msg) {
         while((apr_isspace(*next) == 0) && (*next != '\0')) next++;
         while((apr_isspace(*next) != 0) && (*next != '\0')) *(next++) = '\0';
 
-        /* Add path of the rule filename for a relative phrase filename */
-        filepath = fn;
-        if (apr_filepath_root(&rootpath, &filepath, APR_FILEPATH_TRUENAME, rule->ruleset->mp) != APR_SUCCESS) {
-            /* We are not an absolute path.  It could mean an error, but
-             * let that pass through to the open call for a better error */
-            apr_filepath_merge(&fn, rulefile_path, fn, APR_FILEPATH_TRUENAME, rule->ruleset->mp);
-        }
-
         /* Open file and read */
+        /* Logic to look for data file:
+            - try given filename (absolute or relative to current dir)
+            - if not absolute, try
+                - from the rule directory
+                - from apache root directory
+        */
         rc = apr_file_open(&fd, fn, APR_READ | APR_BUFFERED | APR_FILE_NOCLEANUP, 0, rule->ruleset->mp);
+        if (rc != APR_SUCCESS) {
+            const char *rootpath = NULL;
+            const char *filepath = fn;
+            if (apr_filepath_root(&rootpath, &filepath, APR_FILEPATH_TRUENAME, rule->ruleset->mp) != APR_SUCCESS) {
+                /* Add path of the rule filename for a relative phrase filename */
+                const char *fn_tmp = NULL;
+                apr_filepath_merge(&fn_tmp, rulefile_path, fn, APR_FILEPATH_TRUENAME, rule->ruleset->mp);
+                if (fn_tmp)
+                    rc = apr_file_open(&fd, fn_tmp, APR_READ | APR_BUFFERED | APR_FILE_NOCLEANUP, 0, rule->ruleset->mp);
+                if (rc != APR_SUCCESS) {
+                    /* Add path of httpd root for a relative phrase filename */
+                    fn_tmp = ap_server_root_relative(rule->ruleset->mp, fn);
+                    if (fn_tmp)
+                        rc = apr_file_open(&fd, fn_tmp, APR_READ | APR_BUFFERED | APR_FILE_NOCLEANUP, 0, rule->ruleset->mp);
+                }
+            }
+        }
         if (rc != APR_SUCCESS) {
             *error_msg = apr_psprintf(rule->ruleset->mp, "Could not open phrase file \"%s\": %s", fn, apr_strerror(rc, errstr, 1024));
             return 0;


### PR DESCRIPTION
1. Logic to look for data file:
  - try given filename (absolute or relative to current dir)
  - if not absolute, try
      - from the rule directory
      - from apache root directory

2. Pre-compiler flags for conditional logging in audit log (disable some entries like producer, file name, etc.)

3. Added rule id & msg in "Rule processing failed" log entry

4. Pre-compiler flags to allow duplicate rule ids and no id