### PR TITLE
mlogc-batch-load.pl.in: fix searching SecAuditLogStorageDir files with A...

### DIFF
--- a/mlogc/mlogc-batch-load.pl.in
+++ b/mlogc/mlogc-batch-load.pl.in
@@ -38,7 +38,7 @@ find(
 			(($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size) = stat($_)) &&
 			-f _ &&
 ####        MODSEC-204 /^\d{8}-\d+-\w{24}$/s
-            /^\d{8}-\d+-.{24}$/s
+            /^\d{8}-\d+-.{24,}$/s
 			&& (($fn = $File::Find::name) =~ s/^\Q$ROOTDIR\E//)
 			&& push(@AUDIT, [$fn, $size]);
 		},


### PR DESCRIPTION
...pache 2.4

Setting SecAuditLogType concurrent the files created by modsecurity in the directory SecAuditLogStorageDir
are of the type

%Y%m%d-%H%M%S-UNIQUE_ID

where UNIQUE_ID is produced by the module mod_unique_id. In apache 2.2
UNIQUE_ID was 24 characters long while in apache 2.4 is 27 characters long,
as a result of the new version of mod_unique_id. This patch extends
the regular expression for searching these  log files for apache 2.4 and apache 2.2,
and also with future releases, at least with regard to the length of UNIQUE_ID

Signed-off-by: Elia Pinto <elia.pinto@gmail.com>