### PR TITLE
Include apr-util's LDFLAGS

### DIFF
--- a/build/find_apu.m4
+++ b/build/find_apu.m4
@@ -58,7 +58,8 @@ if test -n "${apu_path}"; then
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(apu VERSION: $APU_VERSION); fi
     APU_CFLAGS="`${APU_CONFIG} --includes`"
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(apu CFLAGS: $APU_CFLAGS); fi
-    APU_LDFLAGS="`${APU_CONFIG} --libs`"
+    APU_LDFLAGS="`${APU_CONFIG} --ldflags`"
+    APU_LDFLAGS="$APU_LDFLAGS `${APU_CONFIG} --libs`"
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(apu LDFLAGS: $APU_LDFLAGS); fi
     APU_LDADD="`${APU_CONFIG} --link-libtool`"
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(apu LDADD: $APU_LDADD); fi


### PR DESCRIPTION
Using apr-util installed by Macports results in build failure because apr-util uses BerkeleyDB that MacPorts installs into a subdir of $prefix/lib and $prefix/include (so that multiple versions of BerkeleyDB can be installed simultaneously). apu-1-config's --ldflags output includes the -L/path/to/bdb that's needed.
