### PR TITLE
Remove misguided call to srand()

### DIFF
--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -237,8 +237,6 @@ static void modsecurity_persist_data(modsec_rec *msr) {
     }
 
     /* Remove stale collections. */
-    srand(time(NULL));
-
     if (rand() < RAND_MAX/100) {
         arr = apr_table_elts(msr->collections);
         te = (apr_table_entry_t *)arr->elts;


### PR DESCRIPTION
A random number generator needs to be initialized once per process after a fork, but not after each request, more so with an argument that changes only once per second.

This fixes #778 / #781.