### PR TITLE
Fix apache logging limitation by using correct apache call.

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -268,7 +268,7 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
         else hostname = "";
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
-        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r->server,
+	ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
             "[client %s] ModSecurity: %s%s [uri \"%s\"]%s", r->useragent_ip ? r->useragent_ip : r->connection->client_ip, str1,
             hostname, log_escape(msr->mp, r->uri), unique_id);
 #else

--- a/standalone/server.c
+++ b/standalone/server.c
@@ -286,6 +286,31 @@ AP_DECLARE(void) ap_log_error_(const char *file, int line, int module_index,
 }
 
 #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER < 3
+AP_DECLARE(void) ap_log_rerror(const char *file, int line, int level,
+                             apr_status_t status, const request_rec *r,
+                             const char *fmt, ...)
+//			    __attribute__((format(printf,6,7)))
+#else
+AP_DECLARE(void) ap_log_rerror_(const char *file, int line, int module_index,
+                               int level, apr_status_t status,
+                               const request_rec *r, const char *fmt, ...)
+//                              __attribute__((format(printf,7,8)))
+#endif
+{
+    va_list args;
+    char errstr[MAX_STRING_LEN];
+
+    va_start(args, fmt);
+
+    apr_vsnprintf(errstr, MAX_STRING_LEN, fmt, args);
+
+	va_end(args);
+
+	if(modsecLogHook != NULL)
+		modsecLogHook(modsecLogObj, level, errstr);
+}
+
+#if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER < 3
 AP_DECLARE(void) ap_log_perror(const char *file, int line, int level, 
                              apr_status_t status, apr_pool_t *p, 
                              const char *fmt, ...)


### PR DESCRIPTION
Apache 2.4 brought the option to change the ErrorLogFormat. However, many
fields remain empty, as ModSecurity uses the wrong apache logging function.
This fixes this behaviour with the use of ap_log_rerror.