### PR TITLE
Fix missing status_line when logging in nginx.

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1278,7 +1278,7 @@ static int hook_log_transaction(request_rec *r) {
 
     msr->r = r;
     msr->response_status = r->status;
-    msr->status_line = ((r->status_line != NULL)
+    msr->status_line = ((r->status_line != NULL) && (*r->status_line != '\0')
             ? r->status_line : ap_get_status_line(r->status));
     msr->response_protocol = get_response_protocol(origr);
     msr->response_headers = apr_table_copy(msr->mp, r->headers_out);


### PR DESCRIPTION
In nginx, audit log messages do not contain response status information due to a blank status_line in request_rec. The change proposed change checks whether status_line is blank after it has checked if it is  NULL pointer. 