### PR TITLE
Compiles against ssdeep in non-standard location

### DIFF
--- a/build/find_ssdeep.m4
+++ b/build/find_ssdeep.m4
@@ -25,20 +25,23 @@ AS_IF([test "x${test_paths}" != "x"], [
 AC_MSG_CHECKING([for ssdeep path])
   
   SSDEEP_LIB_NAME="fuzzy"
+  ssdeep_dir=
 
   if test -z "$withssdeep" -o "$withssdeep" = "yes"; then
     for i in ${test_paths}; do
       if test -f "$i/include/fuzzy.h"; then
-        SSDEEP_CFLAGS="-I$i"
+        SSDEEP_CFLAGS="-I$i/include"
+        ssdeep_dir=$i
       fi
     done
   else
     if test -f "$withssdeep/include/fuzzy.h"; then
-      SSDEEP_CFLAGS="-I$i"
+      SSDEEP_CFLAGS="-I$withssdeep/include"
+      ssdeep_dir=$withssdeep
     fi
   fi
 
-  SSDEEP_LDFLAGS="-lfuzzy"
+  SSDEEP_LDFLAGS="-L$ssdeep_dir/lib -lfuzzy"
   SSDEEP_LDADD="-lfuzzy"
 
 ])  


### PR DESCRIPTION
Issue 871: (*nix) Tacks on the include and lib directory when
a the user specifies a path for ssdeep in an alternate location.