### PR TITLE
Fix WITH_APU_CRYPTO check on 32-bit Linux platform

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,11 @@
 DD mmm YYYY - X.Y.Z (To be released)
 ------------------------------------
 
+ * Fix apr_crypto.h check on 32-bit Linux platform
+   [Issue #882 - Kurt Newman]
  * Fix compilation problem while ssdeep is installed in non-standard
    location.
-   [Issude #872 - Kurt Newman]
+   [Issue #872 - Kurt Newman]
  * Fix invalid storage reference by apr_psprintf at msc_crypt.c
    [Issue #609 - Jeff Trawick]
 

--- a/configure.ac
+++ b/configure.ac
@@ -712,7 +712,12 @@ CHECK_YAJL()
 CHECK_SSDEEP()
 #AC_SEARCH_LIBS([fuzzy_hash_buf], [fuzzy])
 
-CFLAGS="$CFLAGS $APU_CFLAGS"
+# Temporarily set cflags for apr_crypto check, then restore
+# since it's already used correctly to compile modsecurity module.
+ORIG_CFLAGS="$CFLAGS $APU_CFLAGS"
+ORIG_CPPFLAGS="$CPPFLAGS"
+CFLAGS="$CFLAGS $APR_CFLAGS"
+CPPFLAGS="$CPPFLAGS $APR_CPPFLAGS"
 AC_TRY_COMPILE(
 	[#include <apr_crypto.h>],
 	[
@@ -725,6 +730,10 @@ AC_TRY_COMPILE(
 	],
 	[ AC_MSG_WARN([APR util was not compiled with crypto support. SecRemoteRule will not support the parameter 'crypto']) ]
 )
+# Restore env vars so that we don't clutter with duplicates that
+# are eventually appended later on
+CFLAGS="$ORIG_CFLAGS"
+CPPFLAGS="$ORIG_CPPFLAGS"
 
 # Current our unique download backend is curl, furhter we can support more.
 if test ! -z "${CURL_VERSION}"; then


### PR DESCRIPTION
All of the apr flags needed to compile APU_HAVE_CRYPTO check
in configure.ac aren't passed.  While this works fine for 64-bit
machines (because _LARGEFILE64_SOURCE is already defined),
this does not work on 32-bit.  This in-turn breaks the apr_off_t
definition in apr.h.

By passing along the apr --cflags and --cppflags to compile,
32-bit machines will allow WITH_APU_CRYPTO to be set if there's
support for it.