### PR TITLE
Use nginx's parsed hostname

### DIFF
--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -265,7 +265,8 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     // req->parsed_uri.user = (char *)ngx_pstrdup0(r->pool, &r->headers_in.user);
     req->parsed_uri.fragment = (char *)ngx_pstrdup0(r->pool, &r->exten);
 
-    req->hostname = (char *)ngx_pstrdup0(r->pool, (ngx_str_t *)&ngx_cycle->hostname);
+    req->hostname = (char *)ngx_pstrdup0(r->pool, &r->headers_in.server);
+
 
     req->header_only = r->header_only ? r->header_only : (r->method == NGX_HTTP_HEAD);
 


### PR DESCRIPTION
Within the module the request structure's hostname is assigned by ngx_cycle->hostname, which in turn is assigned gethostname(). I don't understand why this is the case, it's not the same as the `Host` header which tells which virtual host is being targeted by the request.

This pull request uses nginx's parsed `Host` header for req->hostname instead.