### PR TITLE
Optionally nocanon

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -2513,6 +2513,11 @@ static void msre_perform_disruptive_actions(modsec_rec *msr, msre_rule *rule,
             }
         }
     }
+    if (actionset->intercept_action_rec->metadata->type == ACTION_DISRUPTIVE) {
+        if (actionset->intercept_action_rec->metadata->execute != NULL) {
+            actionset->intercept_action_rec->metadata->execute(msr, mptmp, rule, actionset->intercept_action_rec);
+        }
+    }
 
     /* If "noauditlog" was used do not mark the transaction relevant. */
     if (actionset->auditlog != 0) {

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -664,7 +664,12 @@ static apr_status_t msre_action_proxy_execute(modsec_rec *msr, apr_pool_t *mptmp
 
     var = apr_pcalloc(mptmp, sizeof(msc_string));
     if (var == NULL) return -1;
-    var->value = (char *)action->param;
+    if (!strncmp(action->param,"[nocanon]",9)) {
+        apr_table_setn(msr->r->notes,"proxy-nocanon",1);
+        var->value = (char *)action->param+9;
+    } else {
+        var->value = (char *)action->param;
+    }
     var->value_len = strlen(var->value);
     expand_macros(msr, var, rule, mptmp);
 

--- a/tests/regression/action/00-disruptive-actions.t
+++ b/tests/regression/action/00-disruptive-actions.t
@@ -476,6 +476,37 @@
 },
 {
 	type => "action",
+	comment => "nocanon proxy in phase:1 (get)",
+	conf => qq(
+		SecRuleEngine On
+		SecRequestBodyAccess On
+		SecResponseBodyAccess On
+		SecResponseBodyMimeType null
+		SecRule REQUEST_URI "\@streq /test2.txt" "phase:1,proxy:'[nocanon]http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt',id:500005"
+	),
+	match_log => {
+		error => {
+			apache => [qr/ModSecurity: Access denied using proxy to \(phase 1\)/, 1],
+			nginx => [qr/ModSecurity: Access denied with code 500 \(phase 1\) \(Configuration Error: Proxy action to .* requested but proxy is only available in Apache version\)./, 1],
+		},
+	},
+	match_response => {
+		status => {
+			apache => qr/^200$/,
+			nginx => qr/^500$/,
+		},
+		content => {
+			apache => qr/^TEST$/,
+			nginx => qr/^*$/,
+		},
+	},
+
+	request => new HTTP::Request(
+		GET => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test2.txt",
+	),
+},
+{
+	type => "action",
 	comment => "proxy in phase:2 (get)",
 	conf => qq(
 		SecRuleEngine On


### PR DESCRIPTION
[Resubmission of pull #961 after rebasing for more alternatives.]

These two small patches fix issues I'm having when trying to do some tricky proxy actions. For example if I do:

SecDefaultAction "phase:2,log,setvar:SESSION.badness=1,proxy:'http://192.168.190.12%{REQUEST_URI_RAW}"

I've been applying them to new releases without issue for my use case. I posted them a while back as "issues" but they never got answered there? Submitting as a pull request now in case that's the preferred method. The fixes are:
1. when executing disruptive actions, it's necessary to execute the intercept action as well. I don't think this will break anything, but it certainly fixes this scenario where mod_proxy doesn't expand the REQUEST_URI_RAW macro. Maybe we should only do this for proxy actions?
2. give the user the option not to "canonicalize" the proxy URL - if we want to send the URI unchanged to the backend server to whom we are proxying, specify "[nocanon]" as the first characters in the target URL.
