### PR TITLE
Checked return value of hashing function so we can see if injection failed.

### DIFF
--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -602,9 +602,10 @@ static int flatten_response_body(modsec_rec *msr) {
                 retval = inject_hashed_response_body(msr, retval);
                 if(retval < 0){
 		    msr_log(msr, 1, "inject_hashed_response_body: Unable to inject hash into response body. Returning response without changes." );
-		}
-		if (msr->txcfg->debuglog_level >= 4) {
-                    msr_log(msr, 4, "Hash completed in %" APR_TIME_T_FMT " usec.", (apr_time_now() - time1));
+		}else{
+		    if (msr->txcfg->debuglog_level >= 4) {
+                        msr_log(msr, 4, "Hash completed in %" APR_TIME_T_FMT " usec.", (apr_time_now() - time1));
+                    }
                 }
 
             }

--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -600,7 +600,10 @@ static int flatten_response_body(modsec_rec *msr) {
             retval = hash_response_body_links(msr);
             if(retval > 0) {
                 retval = inject_hashed_response_body(msr, retval);
-                if (msr->txcfg->debuglog_level >= 4) {
+                if(retval < 0){
+		    msr_log(msr, 1, "inject_hashed_response_body: Unable to inject hash into response body. Returning response without changes." );
+		}
+		if (msr->txcfg->debuglog_level >= 4) {
                     msr_log(msr, 4, "Hash completed in %" APR_TIME_T_FMT " usec.", (apr_time_now() - time1));
                 }
 

--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -601,9 +601,9 @@ static int flatten_response_body(modsec_rec *msr) {
             if(retval > 0) {
                 retval = inject_hashed_response_body(msr, retval);
                 if(retval < 0){
-		    msr_log(msr, 1, "inject_hashed_response_body: Unable to inject hash into response body. Returning response without changes." );
-		}else{
-		    if (msr->txcfg->debuglog_level >= 4) {
+                    msr_log(msr, 1, "inject_hashed_response_body: Unable to inject hash into response body. Returning response without changes." );
+                }else{
+                    if (msr->txcfg->debuglog_level >= 4) {
                         msr_log(msr, 4, "Hash completed in %" APR_TIME_T_FMT " usec.", (apr_time_now() - time1));
                     }
                 }


### PR DESCRIPTION
inject_hashed_response_body() never checks its return value and as a result will always report that it was successful at injection the hash into the response body, even if it wasn't. This pull fixes that issue but allows the request to continue with just a warning put into the logs (level 1).