### PR TITLE
Fix error on older systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,8 @@ SUBDIRS = \
 # make clean
 CLEANFILES = 
 
+ACLOCAL_AMFLAGS = -I build
+
 # make maintainer-clean
 MAINTAINERCLEANFILES = \
 	Makefile.in \


### PR DESCRIPTION
Add support for older versions as noted in https://www.gnu.org/software/libtool/manual/html_node/Invoking-libtoolize.html 