### PR TITLE
This is fix for reborn of https://github.com/SpiderLabs/ModSecurity/i…

### DIFF
--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -208,6 +208,9 @@ apr_status_t read_request_body(modsec_rec *msr, char **error_msg) {
              *      too large and APR_EGENERAL when the client disconnects.
              */
             switch(rc) {
+                case APR_INCOMPLETE :
+                    *error_msg = apr_psprintf(msr->mp, "Error reading request body: %s", get_apr_error(msr->mp, rc));
+                    return -7;
                 case APR_EOF :
                     *error_msg = apr_psprintf(msr->mp, "Error reading request body: %s", get_apr_error(msr->mp, rc));
                     return -6;

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1030,6 +1030,13 @@ static int hook_request_late(request_rec *r) {
                 r->connection->keepalive = AP_CONN_CLOSE;
                 return HTTP_BAD_REQUEST;
                 break;
+            case -7 : /* Partial recieved */
+                if (my_error_msg != NULL) {
+                    msr_log(msr, 4, "%s", my_error_msg);
+                }
+                r->connection->keepalive = AP_CONN_CLOSE;
+                return HTTP_BAD_REQUEST;
+                break;
             default :
                 /* allow through */
                 break;


### PR DESCRIPTION
https://github.com/SpiderLabs/ModSecurity/issues/334 - has been reborn in new Apache 

This bug has been reborn, because Apache (at least in RedHat/CentOS) since version 2.2.15-47
returns in same case (connection closed before all data has been sent, so received data size is is less then Content-Length) APR_INCOMPLETE  (not APR_EOF, like before).

Based on same patch I have added handler for APR_INCOMPLETE.