### PR TITLE
added remove_comments_char transformation to address issue #971

### DIFF
--- a/src/actions/transformations/remove_comments_char.cc
+++ b/src/actions/transformations/remove_comments_char.cc
@@ -37,16 +37,29 @@ RemoveCommentsChar::RemoveCommentsChar(std::string action)
 
 std::string RemoveCommentsChar::evaluate(std::string value,
     Transaction *transaction) {
-    /**
-     * @todo Implement the transformation RemoveCommentsChar
-     */
-    if (transaction) {
-#ifndef NO_LOGS
-        transaction->debug(4, "Transformation RemoveCommentsChar " \
-            "is not implemented yet.");
-#endif
+    int64_t i;
+
+    i = 0;
+    while (i < value.size()) {
+        if (value.at(i) == '/' && (i+1 < value.size()) && value.at(i+1) == '*') {
+            value.erase(i, 2);
+        } else if (value.at(i) == '*' && (i+1 < value.size()) && value.at(i+1) == '/') {
+            value.erase(i, 2);
+        } else if (value.at(i) == '<' && (i+1 < value.size()) && value.at(i+1) == '!' &&
+                  (i+2 < value.size()) && value.at(i+2) == '-' && (i+3 < value.size()) &&
+                  value.at(i+3) == '-') {
+            value.erase(i, 4);
+        } else if (value.at(i) == '-' && (i+1 < value.size()) && value.at(i+1) == '-' &&
+                  (i+2 < value.size()) && value.at(i+2) == '>') {
+            value.erase(i, 3);
+        } else if (value.at(i) == '-' && (i+1 < value.size()) && value.at(i+1) == '-') {
+            value.erase(i, 2);
+        } else if (value.at(i) == '#') {
+            value.erase(i, 1);
+        } else {
+            i++;
+        }
     }
-    return value;
 }
 
 }  // namespace transformations

--- a/src/actions/transformations/remove_comments_char.cc
+++ b/src/actions/transformations/remove_comments_char.cc
@@ -60,6 +60,7 @@ std::string RemoveCommentsChar::evaluate(std::string value,
             i++;
         }
     }
+    return value;
 }
 
 }  // namespace transformations


### PR DESCRIPTION
Implemented remove_comments_char transformation for libmodsecurity.

Removes the following characters

- /*
- */ 
- <!--
- -->
- # 

These are the characters that the function msre_fn_removeCommentsChar_execute in https://github.com/SpiderLabs/ModSecurity/blob/master/apache2/re_tfns.c removes.