### PR TITLE
Implemented removeWhitespace transformation - Issue #972

### DIFF
--- a/src/actions/transformations/remove_comments_char.cc
+++ b/src/actions/transformations/remove_comments_char.cc
@@ -37,16 +37,29 @@ RemoveCommentsChar::RemoveCommentsChar(std::string action)
 
 std::string RemoveCommentsChar::evaluate(std::string value,
     Transaction *transaction) {
-    /**
-     * @todo Implement the transformation RemoveCommentsChar
-     */
-    if (transaction) {
-#ifndef NO_LOGS
-        transaction->debug(4, "Transformation RemoveCommentsChar " \
-            "is not implemented yet.");
-#endif
+    int64_t i;
+
+    i = 0;
+    while (i < value.size()) {
+        if (value.at(i) == '/' && (i+1 < value.size()) && value.at(i+1) == '*') {
+            value.erase(i, 2);
+        } else if (value.at(i) == '*' && (i+1 < value.size()) && value.at(i+1) == '/') {
+            value.erase(i, 2);
+        } else if (value.at(i) == '<' && (i+1 < value.size()) && value.at(i+1) == '!' &&
+                  (i+2 < value.size()) && value.at(i+2) == '-' && (i+3 < value.size()) &&
+                  value.at(i+3) == '-') {
+            value.erase(i, 4);
+        } else if (value.at(i) == '-' && (i+1 < value.size()) && value.at(i+1) == '-' &&
+                  (i+2 < value.size()) && value.at(i+2) == '>') {
+            value.erase(i, 3);
+        } else if (value.at(i) == '-' && (i+1 < value.size()) && value.at(i+1) == '-') {
+            value.erase(i, 2);
+        } else if (value.at(i) == '#') {
+            value.erase(i, 1);
+        } else {
+            i++;
+        }
     }
-    return value;
 }
 
 }  // namespace transformations

--- a/src/actions/transformations/remove_comments_char.cc
+++ b/src/actions/transformations/remove_comments_char.cc
@@ -60,6 +60,7 @@ std::string RemoveCommentsChar::evaluate(std::string value,
             i++;
         }
     }
+    return value;
 }
 
 }  // namespace transformations

--- a/src/actions/transformations/remove_whitespace.cc
+++ b/src/actions/transformations/remove_whitespace.cc
@@ -25,6 +25,7 @@
 #include "modsecurity/transaction.h"
 #include "actions/transformations/transformation.h"
 
+#define NBSP 160    // non breaking space char
 
 namespace modsecurity {
 namespace actions {
@@ -37,18 +38,27 @@ RemoveWhitespace::RemoveWhitespace(std::string action)
 
 std::string RemoveWhitespace::evaluate(std::string value,
     Transaction *transaction) {
-    /**
-     * @todo Implement the transformation RemoveWhitespace
-     */
-    if (transaction) {
-#ifndef NO_LOGS
-        transaction->debug(4, "Transformation RemoveWhitespace is " \
-            "not implemented yet.");
-#endif
+
+    long int i = 0;
+
+    // loop through all the chars
+    while(i < value.size()) {
+        // remove whitespaces and non breaking spaces (NBSP)
+        if (isspace(value[i])||(value[i] == NBSP)) {
+            value.erase(i, 1); 
+        }
+        else {
+          /* if the space is not a whitespace char, increment counter
+           counter should not be incremented if a character is erased because
+           the index erased will be replaced by the following character */
+          i++;
+        }
     }
+
     return value;
 }
 
 }  // namespace transformations
 }  // namespace actions
 }  // namespace modsecurity
+

--- a/src/actions/transformations/transformation.cc
+++ b/src/actions/transformations/transformation.cc
@@ -98,7 +98,7 @@ Transformation* Transformation::instantiate(std::string a) {
     IF_MATCH(removeCommentsChar) { return new RemoveCommentsChar(a); }
     IF_MATCH(remove_comments) { return new RemoveComments(a); }
     IF_MATCH(removeNulls) { return new RemoveNulls(a); }
-    IF_MATCH(remove_whitespace) { return new RemoveWhitespace(a); }
+    IF_MATCH(removeWhitespace) { return new RemoveWhitespace(a); }
     IF_MATCH(compressWhitespace) { return new CompressWhitespace(a); }
     IF_MATCH(replaceComments) { return new ReplaceComments(a); }
     IF_MATCH(replaceNulls) { return new ReplaceNulls(a); }


### PR DESCRIPTION
Implemented removeWhitespace transformation to address #972

Removes the following characters:
* space (' ')
* form feed ('\f')
* line feed ('\n')
* carriage return ('\r')
* horizontal tab ('\t')
* vertical tab ('\v')
* non breaking space character

This patch passes the existing unit tests from https://github.com/SpiderLabs/secrules-language-tests/blob/master/transformations/removeWhitespace.json