### PR TITLE
Declaring variable outside the for loop

### DIFF
--- a/examples/multithread_c/multi.c
+++ b/examples/multithread_c/multi.c
@@ -85,7 +85,8 @@ int main (int argc, char **argv)
     int i = 0;
     pid_t pid;
     int shmid;
-
+    int h;
+    
     modsec = msc_init();
 
     key = ftok("shmdemo.c", 'R');
@@ -110,7 +111,7 @@ int main (int argc, char **argv)
 
     msc_rules_dump(rules);
 
-    for (int h = 0; h < FORKS; h++) {
+    for (h = 0; h < FORKS; h++) {
         pid = fork();
         if (pid == 0) {
             pthread_create (&thread[h*TRHREADS], NULL, (void *) &process_request, (void *) NULL);


### PR DESCRIPTION
This patch, fixes the following error while building modsecurity:
```
make[2]: Entering directory `/opt/ModSecurity/examples/multithread_c'
gcc -DHAVE_CONFIG_H -I. -I../../src    -I../../headers -I../..  -g -O2 -MT multi-multi.o -MD -MP -MF .deps/multi-multi.Tpo -c -o multi-multi.o `test -f 'multi.c' || echo './'`multi.c
multi.c: In function 'main':
multi.c:113:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int h = 0; h < FORKS; h++) {
     ^
multi.c:113:5: note: use option -std=c99 or -std=gnu99 to compile your code
make[2]: *** [multi-multi.o] Error 1
make[2]: Leaving directory `/opt/ModSecurity/examples/multithread_c'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/opt/ModSecurity/examples'
make: *** [all-recursive] Error 1
```