### PR TITLE
Allow non-unique rule ids and no id

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -799,7 +799,8 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
         return my_error_msg;
     }
 
-    /* Rules must have uniq ID */
+#ifndef ALLOW_ID_NOT_UNIQUE
+	/* Rules must have uniq ID */
     type_rule = (dcfg->tmp_chain_starter == NULL);
 #if defined(WITH_LUA)
             type_rule = (type != RULE_TYPE_LUA && type_rule);
@@ -831,6 +832,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
             //    return "ModSecurity: Found another rule with the same id";
         }
     }
+#endif
 
     /* Create default actionset if one does not already exist. */
     if (dcfg->tmp_default_actionset == NULL) {

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -800,7 +800,7 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
     }
 #endif
 
-    srand((unsigned int)(time(NULL) * getpid()));
+    srand((time(NULL) * getpid()) & 0xFFFF);
 
     return OK;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,22 @@ AC_ARG_ENABLE(request-early,
   request_early='-DREQUEST_EARLY'
 ])
 
+# Enable duplicate rules id
+AC_ARG_ENABLE(unique_id,
+              AS_HELP_STRING([--enable-unique_id],
+                             [Allow duplicate rule ids and no id. default is to disable that]),
+[
+  if test "$enableval" != "no"; then
+    unique_id="-DALLOW_ID_NOT_UNIQUE"
+    MODSEC_EXTRA_CFLAGS="$MODSEC_EXTRA_CFLAGS $unique_id"
+  else
+    unique_id=
+  fi
+],
+[
+  unique_id=''
+])
+
 # Ignore configure errors
 AC_ARG_ENABLE(errors,
               AS_HELP_STRING([--disable-errors],

--- a/configure.ac
+++ b/configure.ac
@@ -396,7 +396,7 @@ AC_ARG_ENABLE(request-early,
 ])
 
 # Enable duplicate rules id
-AC_ARG_ENABLE(unique_id,
+AC_ARG_ENABLE(rule-id-validation,
               AS_HELP_STRING([--enable-rule-id-validation],
                              [Allow duplicate rule ids and no id. default is to disable that]),
 [

--- a/configure.ac
+++ b/configure.ac
@@ -397,14 +397,14 @@ AC_ARG_ENABLE(request-early,
 
 # Enable duplicate rules id
 AC_ARG_ENABLE(unique_id,
-              AS_HELP_STRING([--enable-unique_id],
+              AS_HELP_STRING([--enable-rule-id-validation],
                              [Allow duplicate rule ids and no id. default is to disable that]),
 [
   if test "$enableval" != "no"; then
+    unique_id=
+  else
     unique_id="-DALLOW_ID_NOT_UNIQUE"
     MODSEC_EXTRA_CFLAGS="$MODSEC_EXTRA_CFLAGS $unique_id"
-  else
-    unique_id=
   fi
 ],
 [


### PR DESCRIPTION
Added --enable-not_unique_id (-DALLOW_ID_NOT_UNIQUE compile flag) to allow duplicate rule ids and no id
