### PR TITLE
Replacing include subdirectory name, transaction --> collection

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ BUILT_SOURCES= \
 
 lib_LTLIBRARIES = libmodsecurity.la
 libmodsecurity_ladir = $(prefix)/include
-libmodsecurity_includesubdir = $(pkgincludedir)/transaction/
+libmodsecurity_includesubdir = $(pkgincludedir)/collection/
 
 CLEANFILES = \
 	location.hh \


### PR DESCRIPTION
Hi!
From what I understood from this commit https://github.com/SpiderLabs/ModSecurity/commit/5643d2fa287ce51cf3041b0afe3b9e41daa49011, its seems like it require some minor change in `/src/Makefile.am` namely replacing `transaction` with `collection`.