### PR TITLE
Use internal PCRE based implementation of regular expressions instead of std C++ regex library.

### DIFF
--- a/examples/multithread_c/Makefile.am
+++ b/examples/multithread_c/Makefile.am
@@ -8,6 +8,7 @@ multi_SOURCES = \
 multi_LDADD = \
 	-L$(top_builddir)/src/.libs/ \
 	-lmodsecurity \
+	-lpthread \
 	$(YAJL_LDFLAGS) \
 	$(GEOIP_LDFLAGS) \
 	$(GLOBAL_LDADD)

--- a/src/actions/ctl_audit_log_parts.cc
+++ b/src/actions/ctl_audit_log_parts.cc
@@ -31,6 +31,8 @@ bool CtlAuditLogParts::init(std::string *error) {
     } else {
         mPartsAction = 1;
     }
+
+    return true;
 }
 
 bool CtlAuditLogParts::evaluate(Rule *rule, Transaction *transaction) {

--- a/src/actions/transformations/cmd_line.cc
+++ b/src/actions/transformations/cmd_line.cc
@@ -72,7 +72,7 @@ std::string CmdLine::evaluate(std::string value,
             /* copy normal characters */
             default :
                 char b = std::tolower(a);
-                ret.append(&b);
+                ret.append(&b, 1);
                 space = 0;
                 break;
         }

--- a/src/parser/driver.cc
+++ b/src/parser/driver.cc
@@ -46,6 +46,7 @@ int Driver::addSecMarker(std::string marker) {
         rule->phase = i;
         rules[i].push_back(rule);
     }
+    return 0;
 }
 
 

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1,5 +1,5 @@
 %skeleton "lalr1.cc" /* -*- C++ -*- */
-%require "3.0"
+%require "3.0.4"
 %defines
 %define parser_class_name {seclang_parser}
 %define api.token.constructor

--- a/src/utils/regex.h
+++ b/src/utils/regex.h
@@ -42,6 +42,7 @@ class SMatch {
  public:
     SMatch() : size_(0) { }
     size_t size() { return size_; }
+    std::string str() { return match; }
     int size_;
     std::string match;
 };

--- a/test/unit/unit_test.cc
+++ b/test/unit/unit_test.cc
@@ -21,11 +21,11 @@
 #include <string>
 #include <iostream>
 #include <iterator>
-#include <regex>
 #include <string>
 
 #include "common/colors.h"
 #include "src/utils.h"
+#include "src/utils/regex.h"
 
 namespace modsecurity_test {
 
@@ -44,7 +44,6 @@ std::string string_to_hex(const std::string& input) {
     return output;
 }
 
-
 void replaceAll(std::string *s, const std::string &search,
     const char replace) {
     for (size_t pos = 0; ; pos += 0) {
@@ -59,18 +58,19 @@ void replaceAll(std::string *s, const std::string &search,
 
 
 void json2bin(std::string *str) {
-    std::regex re("\\\\x([a-z0-9A-Z]{2})");
-    std::regex re2("\\\\u([a-z0-9A-Z]{4})");
-    std::smatch match;
+    modsecurity::Utils::Regex re("\\\\x([a-z0-9A-Z]{2})");
+    modsecurity::Utils::Regex re2("\\\\u([a-z0-9A-Z]{4})");
+    modsecurity::Utils::SMatch match;
 
-    while (std::regex_search(*str, match, re) && match.size() > 1) {
+    while (modsecurity::Utils::regex_search(*str, &match, re) && match.size() > 0) {
         unsigned int p;
         std::string toBeReplaced = match.str();
         toBeReplaced.erase(0, 2);
         sscanf(toBeReplaced.c_str(), "%x", &p);
         replaceAll(str, match.str(), p);
     }
-    while (std::regex_search(*str, match, re2) && match.size() > 1) {
+
+    while (modsecurity::Utils::regex_search(*str, &match, re2) && match.size() > 0) {
         unsigned int p;
         std::string toBeReplaced = match.str();
         toBeReplaced.erase(0, 2);

--- a/test/unit/unit_test.cc
+++ b/test/unit/unit_test.cc
@@ -13,15 +13,29 @@
  *
  */
 
+/*
+ * Enforce using PCRE for regular expressions instead of C++ regex library.
+ *
+ * Since regex library proven to be unusable for gcc 4.8 and earlier versions,
+ * this define is required to build workable version of executable for CentOS 7,
+ * RHRL 7, Ubuntu 14.04 and SUSE Linux 12.
+ */
+#define PCRE_ONLY	1
+
 #include "unit/unit_test.h"
 
 #include <string.h>
+#ifdef PCRE_ONLY
+#include <pcre.h>
+#endif
 
 #include <sstream>
 #include <string>
 #include <iostream>
 #include <iterator>
+#ifndef PCRE_ONLY
 #include <regex>
+#endif
 #include <string>
 
 #include "common/colors.h"
@@ -44,7 +58,19 @@ std::string string_to_hex(const std::string& input) {
     return output;
 }
 
-
+#ifdef PCRE_ONLY
+void replaceAll(std::string *s, char *search,
+    const char replace) {
+    for (size_t pos = 0; ; pos += 0) {
+        pos = s->find(search, pos);
+        if (pos == std::string::npos) {
+            break;
+        }
+        s->erase(pos, strlen(search));
+        s->insert(pos, &replace, 1);
+    }
+}
+#else
 void replaceAll(std::string *s, const std::string &search,
     const char replace) {
     for (size_t pos = 0; ; pos += 0) {
@@ -56,9 +82,49 @@ void replaceAll(std::string *s, const std::string &search,
         s->insert(pos, &replace, 1);
     }
 }
+#endif
 
 
 void json2bin(std::string *str) {
+#ifdef PCRE_ONLY
+    pcre *re;
+    const char *emsg;
+    int ov[5], eoffs, rc;
+    char u[7], *cptr;
+
+    re = pcre_compile("\\\\x([a-z0-9A-Z]{2})", 0, &emsg, &eoffs, NULL);
+    if (!re)
+	return;
+
+    while ((rc = pcre_exec(re, NULL, str->c_str(), str->length(), 0, 0, ov, 5)) >= 0) {
+	unsigned int p;
+
+	memset(u, 0, sizeof(u));
+	cptr = (char *) str->c_str();  cptr += ov[0];
+	for (p = 0; p < (ov[1]-ov[0]); p++) { u[p] = *(cptr+p); }
+
+	sscanf((char *)(u+2), "%x", &p);
+	replaceAll(str, (char *)u, p);
+    }
+    pcre_free(re);
+
+    re = pcre_compile("\\\\u([a-z0-9A-Z]{4})", 0, &emsg, &eoffs, NULL);
+    if (!re)
+	return;
+
+    while ((rc = pcre_exec(re, NULL, str->c_str(), str->length(), 0, 0, ov, 5)) >= 0) {
+	unsigned int p;
+
+	memset(u, 0, sizeof(u));
+	cptr = (char *) str->c_str();  cptr += ov[0];
+	for (p = 0; p < (ov[1]-ov[0]); p++) { u[p] = *(cptr+p); }
+
+	sscanf((char *)(u+2), "%4x", &p);
+	replaceAll(str, (char *)u, p);
+    }
+    pcre_free(re);
+
+#else
     std::regex re("\\\\x([a-z0-9A-Z]{2})");
     std::regex re2("\\\\u([a-z0-9A-Z]{4})");
     std::smatch match;
@@ -70,6 +136,7 @@ void json2bin(std::string *str) {
         sscanf(toBeReplaced.c_str(), "%x", &p);
         replaceAll(str, match.str(), p);
     }
+
     while (std::regex_search(*str, match, re2) && match.size() > 1) {
         unsigned int p;
         std::string toBeReplaced = match.str();
@@ -77,6 +144,7 @@ void json2bin(std::string *str) {
         sscanf(toBeReplaced.c_str(), "%4x", &p);
         replaceAll(str, match.str(), p);
     }
+#endif
 
     /*
     replaceAll(str, "\\0", '\0');


### PR DESCRIPTION
With that change https://github.com/SpiderLabs/ModSecurity/commit/d83987c2fc4ca5b2dab4e3ac0d3014704116d336 we move from std c++ implementation of regex to custom (pcre driven) version of regex.  Unbreaking unit_test runtime for gcc 4.8 based OSes