### PR TITLE
Adapted patch from #977 to fix status failing to report in Nginx auditlogs

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1895,7 +1895,7 @@ void sec_audit_logger_native(modsec_rec *msr) {
 
         /* There are no response headers (or the status line) in HTTP 0.9 */
         if (msr->response_headers_sent) {
-            if (msr->status_line != NULL) {
+            if (msr->status_line != NULL && msr->status_line[0] != '\0') {
                 text = apr_psprintf(msr->mp, "%s %s\n", msr->response_protocol,
                         msr->status_line);
             } else {


### PR DESCRIPTION
Seems to work on both Nginx and Apache. It appears that somewhere along the way msr->status_line became a null terminated string instead of null. Patch from #977  should be merged into master branch :)