### PR TITLE
preliminary support for "make dist" target

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,13 +274,16 @@ AC_CONFIG_FILES([\
     doc/Makefile \
     src/Makefile \
     others/Makefile \
-    test/Makefile \
-    test/benchmark/Makefile \
-    test/fuzzer/Makefile \
     examples/Makefile \
     examples/simple_example_using_c/Makefile \
     examples/multithread_c/Makefile \
     ])
+
+AM_COND_IF([TEST_UTILITIES],
+       [AC_CONFIG_FILES([test/Makefile test/benchmark/Makefile])])
+
+AM_COND_IF([AFL_FUZZER],
+       [AC_CONFIG_FILES([test/fuzzer/Makefile])])
 
 AC_CONFIG_HEADERS([src/config.h])
 

--- a/others/Makefile.am
+++ b/others/Makefile.am
@@ -4,3 +4,9 @@ libinjection_la_SOURCES = \
 	libinjection/src/libinjection_html5.c \
     libinjection/src/libinjection_sqli.c \
     libinjection/src/libinjection_xss.c
+
+pkginclude_HEADERS = libinjection/src/libinjection.h \
+       libinjection/src/libinjection_html5.h \
+       libinjection/src/libinjection_sqli.h \
+       libinjection/src/libinjection_sqli_data.h \
+       libinjection/src/libinjection_xss.h

--- a/others/Makefile.am
+++ b/others/Makefile.am
@@ -5,7 +5,7 @@ libinjection_la_SOURCES = \
     libinjection/src/libinjection_sqli.c \
     libinjection/src/libinjection_xss.c
 
-pkginclude_HEADERS = libinjection/src/libinjection.h \
+noinst_HEADERS = libinjection/src/libinjection.h \
        libinjection/src/libinjection_html5.h \
        libinjection/src/libinjection_sqli.h \
        libinjection/src/libinjection_sqli_data.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,20 @@ pkginclude_HEADERS = \
 	../headers/modsecurity/modsecurity.h \
 	../headers/modsecurity/rule.h \
 	../headers/modsecurity/rules.h \
-	../headers/modsecurity/rules_properties.h
+	../headers/modsecurity/rules_properties.h \
+	actions/*.h \
+	actions/transformations/*.h \
+	audit_log/*.h \
+	audit_log/writer/*.h \
+	collection/backend/*.h \
+	operators/*.h \
+	parser/*.h \
+	request_body_processor/*.h \
+	utils/*.h \
+	utils/mbedtls/*.h \
+	variables/*.h \
+	variables/variations/*.h \
+	*.h
 
 
 libmodsecurity_includesub_HEADERS = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,16 @@ pkginclude_HEADERS = \
 	../headers/modsecurity/modsecurity.h \
 	../headers/modsecurity/rule.h \
 	../headers/modsecurity/rules.h \
-	../headers/modsecurity/rules_properties.h \
+	../headers/modsecurity/rules_properties.h
+
+
+libmodsecurity_includesub_HEADERS = \
+	../headers/modsecurity/collection/collection.h \
+	../headers/modsecurity/collection/collections.h \
+	../headers/modsecurity/collection/variable.h
+
+
+noinst_HEADERS = \
 	actions/*.h \
 	actions/transformations/*.h \
 	audit_log/*.h \
@@ -55,14 +64,6 @@ pkginclude_HEADERS = \
 	variables/*.h \
 	variables/variations/*.h \
 	*.h
-
-
-libmodsecurity_includesub_HEADERS = \
-	../headers/modsecurity/collection/collection.h \
-	../headers/modsecurity/collection/collections.h \
-	../headers/modsecurity/collection/variable.h
-
-
 
 
 VARIABLES = \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -20,6 +20,9 @@ MAINTAINERCLEANFILES = \
 bin_PROGRAMS =
 noinst_PROGRAMS =
 
+EXTRA_DIST = \
+	test-cases/*
+
 
 # unit_tests
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -28,7 +28,7 @@ unit_tests_SOURCES = \
         unit/unit.cc \
         unit/unit_test.cc
 
-pkginclude_HEADERS = \
+noinst_HEADERS = \
        common/modsecurity_test.cc \
        common/*.h \
        unit/*.h \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,8 +25,14 @@ noinst_PROGRAMS =
 
 noinst_PROGRAMS += unit_tests
 unit_tests_SOURCES = \
+        common/modsecurity_test.cc \
         unit/unit.cc \
         unit/unit_test.cc
+
+pkginclude_HEADERS = \
+       common/*.h \
+       unit/*.h \
+       regression/*.h
 
 unit_tests_LDADD = \
 	$(GLOBAL_LDADD) \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,11 +25,11 @@ noinst_PROGRAMS =
 
 noinst_PROGRAMS += unit_tests
 unit_tests_SOURCES = \
-        common/modsecurity_test.cc \
         unit/unit.cc \
         unit/unit_test.cc
 
 pkginclude_HEADERS = \
+       common/modsecurity_test.cc \
        common/*.h \
        unit/*.h \
        regression/*.h


### PR DESCRIPTION
The commits in this request make able to use "make dist" target in order to create archive with libmodsecurity sources that can be used later without "./build.sh" step.

There are still some unresolved things like the "BUILT_SOURCES" defined in the src/Makefile.am which doesn't work: the seclang-parser.cc and seclang-scanner.cc files are coming to the final distdir regardless of the "BUILT_SOURCES" value (I have also tried things like "nodist_*" for those files, but had no luck). I.e., in the source tree extracted from the archive generated by "make dist" command, you have to run "make clean" before "make" in order to get all the things done.