### PR TITLE
Declaring variable outside the for loop

### DIFF
--- a/examples/multiprocess_c/multi.c
+++ b/examples/multiprocess_c/multi.c
@@ -50,7 +50,9 @@ void process_special_request (int j) {
 }
 
 void process_request (int j) {
-    for (int i = 0; i < REQUESTS_PER_PROCESS; i++) {
+    int i;
+    
+    for (i = 0; i < REQUESTS_PER_PROCESS; i++) {
         if (i == 1 && j == 1) {
             process_special_request(j);
             continue;


### PR DESCRIPTION
Hi,
This PR fixes the minor compile errors that I was getting while building libmodsecurity. I was getting the following error:
```
make[2]: Entering directory `/opt/ModSecurity/examples/multiprocess_c'
gcc -DHAVE_CONFIG_H -I. -I../../src    -I../../headers -I../..  -g -O2 -MT multi-multi.o -MD -MP -MF .deps/multi-multi.Tpo -c -o multi-multi.o `test -f 'multi.c' || echo './'`multi.c
multi.c: In function ‘process_request’:
multi.c:53:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < REQUESTS_PER_PROCESS; i++) {
     ^
multi.c:53:5: note: use option -std=c99 or -std=gnu99 to compile your code
make[2]: *** [multi-multi.o] Error 1
make[2]: Leaving directory `/opt/ModSecurity/examples/multiprocess_c'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/opt/ModSecurity/examples'
make: *** [all-recursive] Error 1
```