### PR TITLE
Fix multi-process example

### DIFF
--- a/examples/multiprocess_c/multi.c
+++ b/examples/multiprocess_c/multi.c
@@ -50,7 +50,8 @@ void process_special_request (int j) {
 }
 
 void process_request (int j) {
-    for (int i = 0; i < REQUESTS_PER_PROCESS; i++) {
+    int i;
+    for (i = 0; i < REQUESTS_PER_PROCESS; i++) {
         if (i == 1 && j == 1) {
             process_special_request(j);
             continue;


### PR DESCRIPTION
for loop initial declarations are only allowed in C99 mode