### PR TITLE
Remove logdata and msg fields from JSON audit log rule elements

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -559,35 +559,8 @@ static void write_rule_json(modsec_rec *msr, const msre_rule *rule, yajl_gen g) 
     if (rule->actionset->rev) {
         yajl_kv_string(g, "rev", log_escape(msr->mp, rule->actionset->rev));
     }
-    if (rule->actionset->msg) {
-        msc_string *var = (msc_string *)apr_palloc(msr->mp, sizeof(msc_string));
-        var->value = (char *)rule->actionset->msg;
-        var->value_len = strlen(rule->actionset->msg);
-        expand_macros(msr, var, NULL, msr->mp);
-
-        yajl_kv_string(g, "msg", log_escape_ex(msr->mp, var->value, var->value_len));
-    }
     if (rule->actionset->version) {
         yajl_kv_string(g, "version", log_escape(msr->mp, rule->actionset->version));
-    }
-    if (rule->actionset->logdata) {
-        char *logdata = NULL;
-        msc_string *var = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
-        var->value = (char *)rule->actionset->logdata;
-        var->value_len = strlen(rule->actionset->logdata);
-        expand_macros(msr, var, NULL, msr->mp);
-
-        logdata = apr_pstrdup(msr->mp, log_escape_hex(msr->mp, (unsigned char *)var->value, var->value_len));
-
-        // if it is > 512 bytes, then truncate at 512 with ellipsis.
-        if (strlen(logdata) > 515) {
-            logdata[512] = '.';
-            logdata[513] = '.';
-            logdata[514] = '.';
-            logdata[515] = '\0';
-        }
-
-        yajl_kv_string(g, "logdata", logdata);
     }
     if (rule->actionset->severity != NOT_SET) {
         yajl_kv_int(g, "severity", rule->actionset->severity);


### PR DESCRIPTION
Writing macro-expanded strings to JSON elements during the post-logging
phase can be misleading, because it's possible that variable contents
(such as MATCHED_VAR) could have changed after the rule match, altering
their expected contents. Writing macro-epanded audit data really only
makes sense when the macros are expanded immediately following the
rule match. See issue #1174 for more details.