### PR TITLE
Include pre-generated parser sources into the distribution

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ CLEANFILES = \
 	parser/seclang-scanner.cc \
 	stack.hh
 
+EXTRA_DIST = $(CLEANFILES)
 
 MAINTAINERCLEANFILES = \
 	Makefile.in \


### PR DESCRIPTION
This patch addresses an issue that has not been resolved here:
https://github.com/SpiderLabs/ModSecurity/pull/1180

It allows to produce fully prepared source archive using the "make dist" target.