### PR TITLE
Optional JIT support in PCRE

### DIFF
--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -65,6 +65,31 @@ else
     AC_MSG_RESULT([no])
 fi
 
+if test -n "${PCRE_VERSION}"; then
+    AC_MSG_CHECKING(for PCRE JIT)
+    save_CFLAGS=$CFLAGS
+    save_LDFLAGS=$LDFLAGS
+    CFLAGS="${PCRE_CFLAGS} ${CFLAGS}"
+    LDFLAGS="${LDFLAGS} ${PCRE_LDADD}"
+    AC_TRY_COMPILE([ #include <stdio.h>
+                     #include <pcre.h> ],
+        [ int jit = 0;
+          pcre_free_study(NULL);
+          pcre_config(PCRE_CONFIG_JIT, &jit);
+          if (jit != 1) return 1; ],
+        [ pcre_jit_available=yes ], [:]
+    )
+
+    if test "x$pcre_jit_available" = "xyes"; then
+        AC_MSG_RESULT(yes)
+        PCRE_CFLAGS="${PCRE_CFLAGS} -DPCRE_HAVE_JIT"
+    else
+        AC_MSG_RESULT(no)
+    fi
+    CFLAGS=$save_CFLAGS
+    LDFLAGS=$save_$LDFLAGS
+fi
+
 AC_SUBST(PCRE_CONFIG)
 AC_SUBST(PCRE_VERSION)
 AC_SUBST(PCRE_CPPFLAGS)

--- a/src/operators/verify_cc.cc
+++ b/src/operators/verify_cc.cc
@@ -22,6 +22,12 @@
 
 #include "operators/operator.h"
 
+#if PCRE_HAVE_JIT
+#define pcre_study_opt PCRE_STUDY_JIT_COMPILE
+#else
+#define pcre_study_opt 0
+#endif
+
 
 namespace modsecurity {
 namespace operators {
@@ -32,7 +38,11 @@ VerifyCC::~VerifyCC() {
         m_pc = NULL;
     }
     if (m_pce != NULL) {
+#if PCRE_HAVE_JIT
         pcre_free_study(m_pce);
+#else
+        pcre_free(m_pce);
+#endif
         m_pce = NULL;
     }
 }
@@ -90,7 +100,7 @@ bool VerifyCC::init(const std::string &param2, std::string *error) {
         return false;
     }
 
-    m_pce = pcre_study(m_pc, PCRE_STUDY_JIT_COMPILE, &errptr);
+    m_pce = pcre_study(m_pc, pcre_study_opt, &errptr);
     if (m_pce == NULL) {
         if (errptr == NULL) {
             /*

--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -27,6 +27,12 @@
 
 #include "utils/geo_lookup.h"
 
+#if PCRE_HAVE_JIT
+#define pcre_study_opt PCRE_STUDY_JIT_COMPILE
+#else
+#define pcre_study_opt 0
+#endif
+
 namespace modsecurity {
 namespace Utils {
 
@@ -42,7 +48,7 @@ Regex::Regex(const std::string& pattern_)
 
     m_pc = pcre_compile(pattern.c_str(), PCRE_DOTALL|PCRE_MULTILINE,
         &errptr, &erroffset, NULL);
-    m_pce = pcre_study(m_pc, PCRE_STUDY_JIT_COMPILE, &errptr);
+    m_pce = pcre_study(m_pc, pcre_study_opt, &errptr);
 }
 
 
@@ -52,7 +58,11 @@ Regex::~Regex() {
         m_pc = NULL;
     }
     if (m_pce != NULL) {
+#if PCRE_HAVE_JIT
         pcre_free_study(m_pce);
+#else
+        pcre_free(m_pce);
+#endif
         m_pce = NULL;
     }
 }


### PR DESCRIPTION
May be useful for everyone who's attempting to build libmodsecurity on systems with pcre < 8.20 (such as RHEL/CentOS/OEL 6.x).