### PR TITLE
fix error message

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1144,13 +1144,13 @@ static void hook_error_log(const char *file, int line, int level, apr_status_t s
     em->line = info->line;
     em->level = info->level;
     em->status = info->status;
-    if (info->format != NULL) em->message = apr_pstrdup(msr->mp, info->format);
+    em->message = apr_pstrdup(msr->mp, errstr);
 #else
     if (file != NULL) em->file = apr_pstrdup(msr->mp, file);
     em->line = line;
     em->level = level;
     em->status = status;
-    if (fmt != NULL) em->message = apr_pstrdup(msr->mp, fmt);
+    em->message = apr_pstrdup(msr->mp, errstr);
 #endif
     /* Remove \n from the end of the message */
     if (em->message != NULL) {

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1150,7 +1150,7 @@ static void hook_error_log(const char *file, int line, int level, apr_status_t s
     em->line = line;
     em->level = level;
     em->status = status;
-    em->message = apr_pstrdup(msr->mp, errstr);
+    if (fmt != NULL) em->message = apr_pstrdup(msr->mp, fmt);
 #endif
     /* Remove \n from the end of the message */
     if (em->message != NULL) {


### PR DESCRIPTION
_info->format_ contains the error message format but not the actual formatted error message