### PR TITLE
Remove port from IPV4 address when running under IIS

### DIFF
--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -88,6 +88,10 @@ class REQUEST_STORED_CONTEXT : public IHttpStoredContext
 
 char *GetIpAddr(apr_pool_t *pool, PSOCKADDR pAddr)
 {
+	const char *format = "%15[0-9.]:%5[0-9]";
+	char ip[16] = { 0 };  // ip4 addresses have max len 15
+	char port[6] = { 0 }; // port numbers are 16bit, ie 5 digits max
+
 	DWORD len = 50;
 	char *buf = (char *)apr_palloc(pool, len);
 
@@ -97,6 +101,14 @@ char *GetIpAddr(apr_pool_t *pool, PSOCKADDR pAddr)
 	buf[0] = 0;
 
 	WSAAddressToString(pAddr, sizeof(SOCKADDR), NULL, buf, &len);
+
+	// test for IPV4 with port on the end
+	if (sscanf(buf, format, ip, port) == 2) {
+		// IPV4 but with port - remove the port
+		char* input = ":";
+		char* ipv4 = strtok(buf, input);
+		return ipv4;
+	}
 
 	return buf;
 }

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -105,9 +105,7 @@ char *GetIpAddr(apr_pool_t *pool, PSOCKADDR pAddr)
 	// test for IPV4 with port on the end
 	if (sscanf(buf, format, ip, port) == 2) {
 		// IPV4 but with port - remove the port
-		char* input = ":";
-		char* ipv4 = strtok(buf, input);
-		return ipv4;
+		return strtok(buf, ":");
 	}
 
 	return buf;
@@ -1017,6 +1015,16 @@ CMyHttpModule::OnBeginRequest(
 		r->method = "UNLOCK";
 		r->method_number = M_UNLOCK;
 		break;
+	}
+
+	if (r->method_number == M_INVALID)
+	{
+		if ((req->pUnknownVerb != NULL) && (strcmp(req->pUnknownVerb, "PATCH") == 0))
+		{
+			// this is a PATCH command and should be supported 
+			r->method = "PATCH";
+			r->method_number = M_PATCH;
+		}
 	}
 
 	if(HTTP_EQUAL_VERSION(req->Version, 0, 9))

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -1016,17 +1016,7 @@ CMyHttpModule::OnBeginRequest(
 		r->method_number = M_UNLOCK;
 		break;
 	}
-
-	if (r->method_number == M_INVALID)
-	{
-		if ((req->pUnknownVerb != NULL) && (strcmp(req->pUnknownVerb, "PATCH") == 0))
-		{
-			// this is a PATCH command and should be supported 
-			r->method = "PATCH";
-			r->method_number = M_PATCH;
-		}
-	}
-
+	
 	if(HTTP_EQUAL_VERSION(req->Version, 0, 9))
 		r->protocol = "HTTP/0.9";
 	else if(HTTP_EQUAL_VERSION(req->Version, 1, 0))


### PR DESCRIPTION
Relates to #1109 - IPV4+Port evaluated as malformed IPv6 address.
Rework of previous PR - code moved into IIS Module.