### PR TITLE
Use global mutex instead file lock to fix issues with threaded mpm's

### DIFF
--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -657,6 +657,7 @@ struct msc_engine {
     apr_pool_t              *mp;
     apr_global_mutex_t      *auditlog_lock;
     apr_global_mutex_t      *geo_lock;
+    apr_global_mutex_t      *dbm_lock;
     msre_engine             *msre;
     unsigned int             processing_mode;
 };

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -381,6 +381,14 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
                 log_escape(msr->mp, dbm_filename));
     }
 
+    /* Need to lock to pull in the stored data again and apply deltas. */
+    rc = apr_global_mutex_lock(msr->modsecurity->dbm_lock);
+    if (rc != APR_SUCCESS) {
+        msr_log(msr, 1, "collection_store: Failed to lock proc mutex: %s",
+                get_apr_error(msr->mp, rc));
+        goto error;
+    }
+
     /* Delete IS_NEW on store. */
     apr_table_unset(col, "IS_NEW");
 
@@ -427,14 +435,6 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
         }
         var->value = apr_psprintf(msr->mp, "%d", counter + 1);
         var->value_len = strlen(var->value);
-    }
-
-    /* Need to lock to pull in the stored data again and apply deltas. */
-    rc = apr_global_mutex_lock(msr->modsecurity->dbm_lock);
-    if (rc != APR_SUCCESS) {
-        msr_log(msr, 1, "collection_store: Failed to lock proc mutex: %s",
-                get_apr_error(msr->mp, rc));
-        goto error;
     }
     
     /* ENH Make the expiration timestamp accessible in blob form so that


### PR DESCRIPTION
Patch fixes persistent storage data corruption issues with threaded mpm's for Apache Httpd. Reason for that is because the persistent storage locking is based on SDBM file locking mechanism which works only across process boundaries thus making threaded mpm's like worker or event unsafe.
Instead file lock, the patch uses global mutex which is both process and thread safe. 

We have observed this issue with
https://issues.jboss.org/browse/JWS-489
