### PR TITLE
Fix compilation error

### DIFF
--- a/src/collection/backend/lmdb.h
+++ b/src/collection/backend/lmdb.h
@@ -16,6 +16,7 @@
 
 #ifdef __cplusplus
 #include <string>
+#include <cstring>
 #include <iostream>
 #include <unordered_map>
 #include <list>


### PR DESCRIPTION
lmdb.cc fails to compile following commit c680ddf.