### PR TITLE
SecLang uses RESPONSE_STATUS as variable, not STATUS

### DIFF
--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -876,7 +876,7 @@ int Transaction::processResponseHeaders(int code, const std::string& proto) {
 #endif
 
     this->m_httpCodeReturned = code;
-    this->m_collections.store("STATUS", std::to_string(code));
+    this->m_collections.store("RESPONSE_STATUS", std::to_string(code));
     m_collections.store("RESPONSE_PROTOCOL", proto);
 
     if (m_rules->m_secRuleEngine == Rules::DisabledRuleEngine) {

--- a/test/test-cases/regression/variable-STATUS.json
+++ b/test/test-cases/regression/variable-STATUS.json
@@ -36,13 +36,13 @@
       ]
     },
     "expected":{
-      "debug_log":"Target value: \"200\" \\(Variable: STATUS\\)"
+      "debug_log":"Target value: \"200\" \\(Variable: RESPONSE_STATUS\\)"
     },
     "rules":[
       "SecRuleEngine On",
       "SecDebugLog \/tmp\/modsec_debug.log",
       "SecDebugLogLevel 9",
-      "SecRule STATUS \"@contains test\" \"id:1,phase:5,rev:1.3,pass,t:trim\""
+      "SecRule RESPONSE_STATUS \"@contains test\" \"id:1,phase:5,rev:1.3,pass,t:trim\""
     ]
   },
   {
@@ -82,7 +82,7 @@
       ]
     },
     "expected":{
-      "debug_log":"Target value: \"500\" \\(Variable: STATUS\\)",
+      "debug_log":"Target value: \"500\" \\(Variable: RESPONSE_STATUS\\)",
       "http_code": 500
     },
     "rules":[
@@ -90,7 +90,7 @@
       "SecDebugLog \/tmp\/modsec_debug.log",
       "SecDebugLogLevel 9",
       "SecRule ARGS \"@pm value\" \"id:1,phase:2,t:trim,status:500,deny\"",
-      "SecRule STATUS \"@contains test\" \"id:2,phase:5,rev:1.3,pass,t:trim\""
+      "SecRule RESPONSE_STATUS \"@contains test\" \"id:2,phase:5,rev:1.3,pass,t:trim\""
     ]
   }
 ]


### PR DESCRIPTION
Seclang uses RESPONSE_STATUS as variable to encode the status code for the
request.
https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#RESPONSE_STATUS

The CRS v3.0.0-dev rules, for instance, uses the RESPONSE_STATUS variable.
https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.0.0-dev/rules/RESPONSE-50-DATA-LEAKAGES-IIS.conf

When processing response headers, the variable was named STATUS when creating/storing
it in the collection. Fix it, and update regression testcases.