### PR TITLE
~Rule will delete chainedRule

### DIFF
--- a/src/rule.cc
+++ b/src/rule.cc
@@ -73,6 +73,10 @@ Rule::~Rule() {
     if (variables != NULL) {
         delete variables;
     }
+	
+    if (chainedRule != NULL) {
+        delete chainedRule;
+    }
 }
 
 Rule::Rule(std::string marker)


### PR DESCRIPTION
Came across this memory leak when reloading nginx with hundreds of rule chains