### PR TITLE
 Fix return value of msc_rules_merge()  and fix typos

### DIFF
--- a/src/rules.cc
+++ b/src/rules.cc
@@ -317,9 +317,7 @@ extern "C" void msc_rules_dump(Rules *rules) {
 
 extern "C" int msc_rules_merge(Rules *rules_dst,
     Rules *rules_from) {
-    rules_dst->merge(rules_from);
-
-    return 0;
+    return rules_dst->merge(rules_from);
 }
 
 

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -358,7 +358,7 @@ bool Transaction::addArgument(const std::string& orig, const std::string& key,
  * @param transaction ModSecurity transaction.
  * @param uri   Uri.
  * @param method   Method (GET, POST, PUT).
- * @param http_version   Http version (1.0, 1.2, 2.0).
+ * @param http_version   Http version (1.0, 1.1, 2.0).
  *
  * @returns If the operation was successful or not.
  * @retval true Operation was successful.
@@ -1725,7 +1725,7 @@ extern "C" int msc_process_request_headers(Transaction *transaction) {
 
 /**
  * @name    msc_process_request_body
- * @brief   Perform the request body (if any)
+ * @brief   Perform the analysis on the request body (if any)
  *
  * This function perform the analysis on the request body. It is optional to
  * call that function. If this API consumer already know that there isn't a
@@ -1809,13 +1809,13 @@ extern "C" int msc_process_response_headers(Transaction *transaction,
 
 /**
  * @name    msc_process_response_body
- * @brief   Perform the request body (if any)
+ * @brief   Perform the analysis on the response body (if any)
  *
- * This function perform the analysis on the request body. It is optional to
+ * This function perform the analysis on the response body. It is optional to
  * call that function. If this API consumer already know that there isn't a
  * body for inspect it is recommended to skip this step.
  *
- * @note It is necessary to "append" the request body prior to the execution
+ * @note It is necessary to "append" the response body prior to the execution
  *       of this function.
  * @note Remember to check for a possible intervention.
  *


### PR DESCRIPTION
Hi all,

Regarding to the documentation msc_rules_merge() should
return the number of merged rules instead of 0 in all cases.

Fix typos in documentation.