### PR TITLE
Add debug information for mod_security on windows

### DIFF
--- a/apache2/Makefile.win
+++ b/apache2/Makefile.win
@@ -31,6 +31,7 @@ MT = mt
 DEFS = /nologo /O2 /LD /W3 /wd4244 /wd4018 -DWIN32 -DWINNT -Dinline=APR_INLINE -D$(VERSION)
 
 DLL = mod_security2.so
+PDB = $(DLL:.so=.pdb)
 
 INCLUDES = -I. -I.. \
            -I$(CURL)\include -I$(CURL) \
@@ -43,7 +44,7 @@ DEFS=$(DEFS) -DWITH_CURL -DWITH_REMOTE_RULES
 
 # Lua is optional
 !IF "$(LUA)" != ""
-LIBS = $(LIBS) $(LUA)\lua5.1.lib
+LIBS = $(LIBS) $(LUA)\lua51.lib
 DEFS=$(DEFS) -DWITH_LUA
 INCLUDES = $(INCLUDES) -I$(LUA)\include -I$(LUA) \
 !ENDIF
@@ -55,7 +56,7 @@ DEFS=$(DEFS) -DWITH_YAJL
 INCLUDES = $(INCLUDES) -I$(YAJL)\include -I$(YAJL) \
 !ENDIF
 
-CFLAGS= -MD $(INCLUDES) $(DEFS)
+CFLAGS= -MD $(INCLUDES) $(DEFS) /Zi
 
 LDFLAGS =
 
@@ -83,11 +84,11 @@ dll: $(DLL)
         $(CC) $(CFLAGS) -c $< -Fo$@
 
 $(DLL): $(OBJS)
-        $(CC) $(CFLAGS) $(LDFLAGS) -LD $(OBJS) -Fe$(DLL) $(LIBS) /link
+        $(CC) $(CFLAGS) $(LDFLAGS) -LD $(OBJS) -Fe$(DLL) /Fd$(PDB) $(LIBS) /link
         IF EXIST $(DLL).manifest $(MT) -manifest $(DLL).manifest -outputresource:$(DLL);2
 
 install: $(DLL)
-        copy /Y $(DLL) $(APACHE)\modules
+        copy /Y $(DLL) $(PDB) $(APACHE)\modules
 
 clean:
         del $(OBJS) $(DLL) *.dll *.lib *.pdb *.idb *.ilk *.exp *.res *.rc *.bin *.manifest

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -306,10 +306,14 @@ int json_complete(modsec_rec *msr, char **error_msg) {
 }
 
 /**
- * Frees the resources used for XML parsing.
+ * Frees the resources used for JSON parsing.
  */
 apr_status_t json_cleanup(modsec_rec *msr) {
     msr_log(msr, 4, "JSON: Cleaning up JSON results");
+    if (msr->json->handle != NULL) {
+        yajl_free(msr->json->handle);
+        msr->json->handle = NULL;
+    }
 
     return 1;
 }


### PR DESCRIPTION
This commit modifies Makefile.win:
1. Create and install pdb files (debug information)
2. Change the name of Lua lib to match the name created by httpd build.
