### PR TITLE
Add (void) argument to be ANSI C compliant

### DIFF
--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -255,10 +255,8 @@ extern "C" void msc_cleanup(ModSecurity *msc) {
  *
  * @endcode
  */
-extern "C" ModSecurity *msc_init() {
-    ModSecurity *modsec = new ModSecurity();
-
-    return modsec;
+extern "C" ModSecurity *msc_init(void) {
+    return new ModSecurity();
 }
 
 

--- a/src/rules.cc
+++ b/src/rules.cc
@@ -303,10 +303,8 @@ void Rules::dump() {
 }
 
 
-extern "C" Rules *msc_create_rules_set() {
-    Rules *rules = new Rules();
-
-    return rules;
+extern "C" Rules *msc_create_rules_set(void) {
+    return new Rules();
 }
 
 


### PR DESCRIPTION
Add void argument has to avoid warning messages when compiling Python bindings with CFFI since it uses -Wstrict-prototypes option by default.

Modify`msc_create_rules_set` and `msc_init` internals, now it returns directly an instance like `msc_new_transaction` in transaction.cc.