### PR TITLE
Hack to show that there is an issue with the session collection's logic

### DIFF
--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -223,7 +223,13 @@ static void modsecurity_persist_data(modsec_rec *msr) {
 
         /* Only store those collections that changed. */
         if (apr_table_get(msr->collections_dirty, te[i].key)) {
-            collection_store(msr, col);
+            if (msr->txcfg->debuglog_level >= 9) {
+                msc_string *name = (msc_string *)apr_table_get(col, "__name");
+                if (name != NULL) {
+                    msr_log(msr, 9, "Storing dirty collection %s at key %s", name->value, te[i].key);
+                }
+            }
+            collection_store(msr, col, te[i].key);
         }
     }
 

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -321,7 +321,7 @@ apr_table_t *collection_retrieve(modsec_rec *msr, const char *col_name,
 /**
  *
  */
-int collection_store(modsec_rec *msr, apr_table_t *col) {
+int collection_store(modsec_rec *msr, apr_table_t *col, const char *col_name) {
     char *dbm_filename = NULL;
     msc_string *var_name = NULL, *var_key = NULL;
     unsigned char *blob = NULL;
@@ -433,7 +433,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
 
     /* If there is an original value, then create a delta and
      * apply the delta to the current value */
-    orig_col = (const apr_table_t *)apr_table_get(msr->collections_original, var_name->value);
+    orig_col = (const apr_table_t *)apr_table_get(msr->collections_original, col_name);
     if (orig_col != NULL) {
         if (msr->txcfg->debuglog_level >= 9) {
             msr_log(msr, 9, "collection_store: Re-retrieving collection prior to store: %s",

--- a/apache2/persist_dbm.h
+++ b/apache2/persist_dbm.h
@@ -21,7 +21,7 @@
 apr_table_t DSOLOCAL *collection_retrieve(modsec_rec *msr, const char *col_name,
     const char *col_value, int col_value_length);
 
-int DSOLOCAL collection_store(modsec_rec *msr, apr_table_t *collection);
+int DSOLOCAL collection_store(modsec_rec *msr, apr_table_t *collection, const char *col_name);
 
 int DSOLOCAL collections_remove_stale(modsec_rec *msr, const char *col_name);
 


### PR DESCRIPTION
This PR is a hack to show that there is an issue somewhere with the collection storage/retrieval logic for session collections (I also think this affects user and resource collections, but haven't verified this yet) which is causing #1273. After applying this change the test in #1273 always adds up to the total number of requests. I arrived at this conclusion because I noticed some inconsistencies in the logging, like:
~~~
Added collection "default_SESSION" to the list as "SESSION".
....
collection_retrieve_ex: collection_retrieve_ex: Retrieving collection (name "default_SESSION", filename "/var/lib/mod_security/default_SESSION")
~~~
and that the SESSION collection never receives delta updates like the global one does:
~~~
collection_store: Delta applied for global.counter 1->2 (1): 1 + (1) = 2 [2,1]
~~~
because orig_col in re_actions.c always returns NULL for the session collection:
~~~
458     orig_col = (const apr_table_t *)apr_table_get(msr->collections_original, var_name->value);
~~~

The only difference that I see in the way that the global and session collections are handled is in the real_col_name and col_name passed into init_collection.

Obviously I don't want this to be accepted, but I wanted to get a conversation started with someone that understands mod_security better than I do and post the results of my testing thus far. I was told that a PR is the best way to do that :)