### PR TITLE
Adding comments around odd looking code to prevent future scrutiny

### DIFF
--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -479,10 +479,12 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
             }
         }
 
+        // Allocate blob_size for keys
         len = var->name_len + 1;
         if (len >= 65536) len = 65536;
         blob_size += len + 2;
 
+        // Allocate blob_size for values
         len = var->value_len + 1;
         if (len >= 65536) len = 65536;
         blob_size += len + 2;


### PR DESCRIPTION
This comment is a result of #1278 :) Adding a comment will make it a bit easier to identify the difference because the duplicated block looks like an error.