### PR TITLE
Fix building with -Wl,--as-needed linker option with older ld versions

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -38,14 +38,14 @@ noinst_HEADERS = \
        regression/*.h
 
 unit_tests_LDADD = \
-	$(GLOBAL_LDADD) \
 	$(top_builddir)/src/.libs/libmodsecurity.a \
 	$(CURL_LDADD) \
 	$(GEOIP_LDFLAGS) $(GEOIP_LDADD) \
 	$(PCRE_LDADD) \
 	$(YAJL_LDFLAGS) $(YAJL_LDADD) \
 	$(LMDB_LDFLAGS) $(LMDB_LDADD) \
-	$(LIBXML2_LDADD)
+	$(LIBXML2_LDADD) \
+	$(GLOBAL_LDADD)
 
 
 unit_tests_CPPFLAGS = \
@@ -74,14 +74,14 @@ regression_tests_SOURCES = \
         regression/custom_debug_log.cc
 
 regression_tests_LDADD = \
-	$(GLOBAL_LDADD) \
 	$(top_builddir)/src/.libs/libmodsecurity.a \
 	$(CURL_LDADD) \
 	$(GEOIP_LDFLAGS) $(GEOIP_LDADD) \
 	$(PCRE_LDADD) \
 	$(YAJL_LDFLAGS) $(YAJL_LDADD) \
 	$(LMDB_LDFLAGS) $(LMDB_LDADD) \
-	$(LIBXML2_LDADD)
+	$(LIBXML2_LDADD) \
+	$(GLOBAL_LDADD)
 
 
 regression_tests_CPPFLAGS = \
@@ -109,14 +109,14 @@ rules_optimization_SOURCES = \
         optimization/optimization.cc
 
 rules_optimization_LDADD = \
-	$(GLOBAL_LDADD) \
 	$(top_builddir)/src/.libs/libmodsecurity.a \
 	$(CURL_LDADD) \
 	$(GEOIP_LDFLAGS) $(GEOIP_LDADD) \
 	$(PCRE_LDADD) \
 	$(YAJL_LDFLAGS) $(YAJL_LDADD) \
 	$(LMDB_LDFLAGS) $(LMDB_LDADD) \
-	$(LIBXML2_LDADD)
+	$(LIBXML2_LDADD) \
+	$(GLOBAL_LDADD)
 
 
 rules_optimization_CPPFLAGS = \

--- a/test/benchmark/Makefile.am
+++ b/test/benchmark/Makefile.am
@@ -6,14 +6,14 @@ benchmark_SOURCES = \
         benchmark.cc
 
 benchmark_LDADD = \
-	$(GLOBAL_LDADD) \
 	$(top_builddir)/src/.libs/libmodsecurity.a \
 	$(CURL_LDADD) \
 	$(GEOIP_LDFLAGS) $(GEOIP_LDADD) \
 	$(PCRE_LDADD) \
 	$(YAJL_LDFLAGS) $(YAJL_LDADD) \
 	$(LMDB_LDFLAGS) $(LMDB_LDADD) \
-	$(LIBXML2_LDADD)
+	$(LIBXML2_LDADD) \
+	$(GLOBAL_LDADD)
 
 benchmark_CPPFLAGS = \
 	-std=c++11 \


### PR DESCRIPTION
In particular, this allows to build libmodsecurity on Debian 7 "wheezy" (it has ld version 2.22 out of the box).

Before this change, the following errors appeared during the linking:

    /usr/bin/ld: ../../src/.libs/libmodsecurity.a(libmodsecurity_la-system.o): undefined reference to symbol 'clock_gettime@@GLIBC_2.2.5'
    /usr/bin/ld: note: 'clock_gettime@@GLIBC_2.2.5' is defined in DSO /usr/lib/x86_64-linux-gnu/librt.so so try adding it to the linker command line
    /usr/lib/x86_64-linux-gnu/librt.so: could not read symbols: Invalid operation
    collect2: error: ld returned 1 exit status
