### PR TITLE
Change from using rand() to thread-safe ap_random_pick.

### DIFF
--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -237,7 +237,7 @@ static void modsecurity_persist_data(modsec_rec *msr) {
     }
 
     /* Remove stale collections. */
-    if (rand() < RAND_MAX/100) {
+    if (ap_random_pick(0, RAND_MAX) < RAND_MAX/100) {
         arr = apr_table_elts(msr->collections);
         te = (apr_table_entry_t *)arr->elts;
         for (i = 0; i < arr->nelts; i++) {


### PR DESCRIPTION
Use of `rand()` led to possibility of multiple threads performing GC all at once. I temporarily added some debug logging to show this (this pull request does not include logging):

````
@@ -212,6 +212,7 @@ static void modsecurity_persist_data(modsec_rec *msr) {
     apr_table_entry_t *te;
     apr_time_t time_before, time_after;
     int i;
+    int rvalue;
 
     time_before = apr_time_now();
 
@@ -237,7 +238,9 @@ static void modsecurity_persist_data(modsec_rec *msr) {
     }
 
     /* Remove stale collections. */
-    if (rand() < RAND_MAX/100) {
+    rvalue = rand();
+    if (rvalue < RAND_MAX/100) {
+        msr_log(msr, 9, "Garbage collection initiated with rvalue: %d < %d/100", rvalue, RAND_MAX);
         arr = apr_table_elts(msr->collections);
         te = (apr_table_entry_t *)arr->elts;
         for (i = 0; i < arr->nelts; i++) {
````

````
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][9] Garbage collection initiated with rvalue: 15337631 < 2147483647/100
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][4] Garbage collection took 42 microseconds.
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389ea670][/index.html][9] Garbage collection initiated with rvalue: 15337631 < 2147483647/100
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389ea670][/index.html][4] Garbage collection took 122 microseconds.
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][9] Garbage collection initiated with rvalue: 15337631 < 2147483647/100
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][4] Garbage collection took 74 microseconds.
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][9] Garbage collection initiated with rvalue: 15337631 < 2147483647/100
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][4] Garbage collection took 123 microseconds.
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][9] Garbage collection initiated with rvalue: 15337631 < 2147483647/100
[18/Dec/2016:13:29:29 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][4] Garbage collection took 160 microseconds.
[18/Dec/2016:13:29:36 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][9] Garbage collection initiated with rvalue: 15337631 < 2147483647/100
[18/Dec/2016:13:29:36 --0500] [localhost/sid#5621386b7400][rid#5621389e8660][/index.html][4] Garbage collection took 53 microseconds.
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][9] Garbage collection initiated with rvalue: 6841472 < 2147483647/100
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][4] Garbage collection took 63 microseconds.
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d24e0][/index.html][9] Garbage collection initiated with rvalue: 6841472 < 2147483647/100
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d24e0][/index.html][4] Garbage collection took 68 microseconds.
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][9] Garbage collection initiated with rvalue: 6841472 < 2147483647/100
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][4] Garbage collection took 43 microseconds.
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][9] Garbage collection initiated with rvalue: 6841472 < 2147483647/100
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][4] Garbage collection took 114 microseconds.
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][9] Garbage collection initiated with rvalue: 6841472 < 2147483647/100
[18/Dec/2016:13:29:37 --0500] [localhost/sid#5621386b7400][rid#5621389d04d0][/index.html][4] Garbage collection took 46 microseconds.
````

Notice multiple threads having same `rand()` result. 

Finally, changing to `ap_random_pick`, as mentioned in #1286, resulted in no duplicate runs of GC:

````
[18/Dec/2016:13:33:08 --0500] [localhost/sid#56385f3c6400][rid#56385f6ed5d0][/index.html][9] Garbage collection initiated with rvalue: 8426056 < 2147483647/100
[18/Dec/2016:13:33:08 --0500] [localhost/sid#56385f3c6400][rid#56385f6ed5d0][/index.html][4] Garbage collection took 58 microseconds.
[18/Dec/2016:13:33:10 --0500] [localhost/sid#56385f3c6400][rid#56385f6e14a0][/index.html][9] Garbage collection initiated with rvalue: 12418543 < 2147483647/100
[18/Dec/2016:13:33:10 --0500] [localhost/sid#56385f3c6400][rid#56385f6e14a0][/index.html][4] Garbage collection took 87 microseconds.
[18/Dec/2016:13:33:11 --0500] [localhost/sid#56385f3c6400][rid#56385f6ef5e0][/index.html][9] Garbage collection initiated with rvalue: 7706903 < 2147483647/100
[18/Dec/2016:13:33:11 --0500] [localhost/sid#56385f3c6400][rid#56385f6ef5e0][/index.html][4] Garbage collection took 87 microseconds.
[18/Dec/2016:13:33:12 --0500] [localhost/sid#56385f3c6400][rid#56385f6f7620][/index.html][9] Garbage collection initiated with rvalue: 15493977 < 2147483647/100
[18/Dec/2016:13:33:12 --0500] [localhost/sid#56385f3c6400][rid#56385f6f7620][/index.html][4] Garbage collection took 53 microseconds.
````