### PR TITLE
GC frequency option 

### DIFF
--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -235,9 +235,9 @@ static void modsecurity_persist_data(modsec_rec *msr) {
         msr_log(msr, 4, "Recording persistent data took %" APR_TIME_T_FMT
             " microseconds.", msr->time_gc);
     }
-
+    
     /* Remove stale collections. */
-    if (ap_random_pick(0, RAND_MAX) < RAND_MAX/100) {
+    if (ap_random_pick(0, RAND_MAX) < (RAND_MAX * msr->txcfg->col_gc_freq)) {
         arr = apr_table_elts(msr->collections);
         te = (apr_table_entry_t *)arr->elts;
         for (i = 0; i < arr->nelts; i++) {

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -237,7 +237,7 @@ static void modsecurity_persist_data(modsec_rec *msr) {
     }
 
     /* Remove stale collections. */
-    if (rand() < RAND_MAX/100) {
+    if (ap_random_pick(0, RAND_MAX) < RAND_MAX/100) {
         arr = apr_table_elts(msr->collections);
         te = (apr_table_entry_t *)arr->elts;
         for (i = 0; i < arr->nelts; i++) {

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -610,6 +610,7 @@ struct directory_config {
 
     /* Collection timeout */
     int col_timeout;
+    float col_gc_freq;
 
     /* hash of ids */
     apr_hash_t          *rule_id_htab;


### PR DESCRIPTION
This pull request adds a new directive for configuring how often garbage collections run. Running less/more often can drastically improve performance based on request load.