### PR TITLE
Read fuzzy hash db on init

### DIFF
--- a/apache2/re.h
+++ b/apache2/re.h
@@ -409,8 +409,14 @@ struct msre_cache_rec {
     apr_size_t               val_len;
 };
 
+struct fuzzy_hash_chunk {
+    const char *data;
+    struct fuzzy_hash_chunk *next;
+};
+
 struct fuzzy_hash_param_data {
     const char *file;
+    struct fuzzy_hash_chunk *head;
     int threshold;
 };
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -3828,6 +3828,7 @@ static int msre_op_fuzzy_hash_init(msre_rule *rule, char **error_msg)
 {
 #ifdef WITH_SSDEEP
     struct fuzzy_hash_param_data *param_data;
+    FILE *fp;
     char *file;
     int param_len,threshold;
 
@@ -3876,14 +3877,15 @@ static int msre_op_fuzzy_hash_init(msre_rule *rule, char **error_msg)
     }
 
     file = resolve_relative_path(rule->ruleset->mp, rule->filename, file);
-    
-    if (!fopen(file, "r"))
+
+    fp = fopen(file, "r");
+    if (!fp)
     {
         *error_msg = apr_psprintf(rule->ruleset->mp, "Not able to open file:" \
             " %s.", file);
         return -1;
     }
-
+    fclose(fp);
 
     param_data->file = file;
     param_data->threshold = threshold;


### PR DESCRIPTION
Instead of reading the fuzzy db on every invocation, read and store
the db contents during initialization and store the contents in memory.
The only significant behavior change here is that a change in db contents
now (obviously) requires a daemon restart, as no API is provided to
flush the list of ssdeep chunks.