### PR TITLE
Fix "make dist" after recent changes to parser

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -8,6 +8,9 @@ SUBDIRS = \
 	reading_logs_with_offset \
 	reading_logs_via_rule_message
 
+pkginclude_HEADERS = \
+	reading_logs_via_rule_message/reading_logs_via_rule_message.h
+
 # make clean
 CLEANFILES = 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,18 @@ libmodsecurity_includesub_collectiondir = $(pkgincludedir)/collection/
 libmodsecurity_includesub_actionsdir = $(pkgincludedir)/actions/
 
 
-EXTRA_DIST = $(CLEANFILES)
+# pregenerated parser + parser sources
+EXTRA_DIST = \
+	parser/Makefile.am \
+	parser/Makefile.in \
+	parser/location.hh \
+	parser/position.hh \
+	parser/seclang-parser.cc \
+	parser/seclang-parser.hh \
+	parser/seclang-parser.yy \
+	parser/seclang-scanner.cc \
+	parser/seclang-scanner.ll \
+	parser/stack.hh
 
 MAINTAINERCLEANFILES = \
 	Makefile.in \


### PR DESCRIPTION
In particular, it is now possible to either build ModSecurity with pre-generated parser, or use `--enable-parser-generation` configure option to rebuild parser from sources.