### PR TITLE
add support for soap+xml

### DIFF
--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -19,7 +19,7 @@ SecRequestBodyAccess On
 # Enable XML request body parser.
 # Initiate XML Processor in case of xml content-type
 #
-SecRule REQUEST_HEADERS:Content-Type "(?:text|application)/xml" \
+SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
      "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
 
 # Enable JSON request body parser.


### PR DESCRIPTION
As was talked about by @emphazer in https://github.com/SpiderLabs/owasp-modsecurity-crs/pull/721, RFC 3902 adds support for the application/soap+xml header used by SOAP 1.2.