### PR TITLE
Option to disable logging of Apache handler in audit log

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ DD MMM YYYY - 2.9.2 - To be released
 
  * {dis|en}able-handler-logging: Option to disable logging of
    Apache handler in audit log when log level < 9.
-   [Issue #1070 - Marc Stern]
+   [Issue #1066 - Marc Stern]
  * {dis|en}able-filename-logging: Option to disable logging of filename
    in audit log.
    [Issue #1065 - Marc Stern]

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 DD MMM YYYY - 2.9.2 - To be released
 ------------------------------------
 
+ * {dis|en}able-handler-logging: Option to disable logging of
+   Apache handler in audit log when log level < 9.
+   [Issue #1070 - Marc Stern]
  * {dis|en}able-filename-logging: Option to disable logging of filename
    in audit log.
    [Issue #1065 - Marc Stern]

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1974,7 +1974,10 @@ void sec_audit_logger_native(modsec_rec *msr) {
         }
 
         /* Apache-Handler */
-        if (msr->r->handler != NULL) {
+#ifdef LOG_NO_HANDLER
+		if (msr->txcfg->debuglog_level >= 9)
+#endif
+		if (msr->r->handler != NULL) {
             text = apr_psprintf(msr->mp, "Apache-Handler: %s\n", msr->r->handler);
             sec_auditlog_write(msr, text, strlen(text));
         }

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1156,6 +1156,9 @@ void sec_audit_logger_json(modsec_rec *msr) {
         }
 
         /* Apache-Handler */
+#ifdef LOG_NO_HANDLER
+        if (msr->txcfg->debuglog_level >= 9)
+#endif
         if (msr->r->handler != NULL) {
             yajl_kv_string(g, "handler", msr->r->handler);
         }

--- a/configure.ac
+++ b/configure.ac
@@ -443,7 +443,7 @@ AC_ARG_ENABLE(filename-logging,
 ])
 
 # Disable logging of Apache handler
-AC_ARG_ENABLE(filename-logging,
+AC_ARG_ENABLE(handler-logging,
               AS_HELP_STRING([--enable-handler-logging],
                              [Enable logging of Apache handler in audit log when log level < 9. This is the default]),
 [

--- a/configure.ac
+++ b/configure.ac
@@ -442,6 +442,21 @@ AC_ARG_ENABLE(filename-logging,
   log_filename=''
 ])
 
+# Disable logging of Apache handler
+AC_ARG_ENABLE(filename-logging,
+              AS_HELP_STRING([--enable-handler-logging],
+                             [Enable logging of Apache handler in audit log when log level < 9. This is the default]),
+[
+  if test "$enableval" != "no"; then
+    log_handler=
+  else
+    log_handler="-DLOG_NO_HANDLER"
+  fi
+],
+[
+  log_handler=''
+])
+
 # Ignore configure errors
 AC_ARG_ENABLE(errors,
               AS_HELP_STRING([--disable-errors],
@@ -692,7 +707,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_handler"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""


### PR DESCRIPTION
when log level < 9
[Issue #1070 - Marc Stern]