### PR TITLE
Option to disable logging of dechunking in audit log

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 DD MMM YYYY - 2.9.2 - To be released
 ------------------------------------
 
- * {dis|en}able-dechunking: Option to disable logging of
+ * {dis|en}able-dechunk-logging: Option to disable logging of
    dechunking in audit log when log level < 9.
    [Issue #1068 - Marc Stern]
  * {dis|en}able-filename-logging: Option to disable logging of filename

--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,9 @@
 DD MMM YYYY - 2.9.2 - To be released
 ------------------------------------
 
- * {dis|en}able-log-producer-logging: Option to disable logging of
-   log producer in audit log when log level < 9.
-   [Issue #1069 - Marc Stern]
+ * {dis|en}able-dechunking: Option to disable logging of
+   dechunking in audit log when log level < 9.
+   [Issue #1068 - Marc Stern]
  * {dis|en}able-filename-logging: Option to disable logging of filename
    in audit log.
    [Issue #1065 - Marc Stern]

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 DD MMM YYYY - 2.9.2 - To be released
 ------------------------------------
 
+ * {dis|en}able-log-producer-logging: Option to disable logging of
+   log producer in audit log when log level < 9.
+   [Issue #1069 - Marc Stern]
  * {dis|en}able-filename-logging: Option to disable logging of filename
    in audit log.
    [Issue #1065 - Marc Stern]

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -363,6 +363,9 @@ static void sec_auditlog_write_producer_header(modsec_rec *msr) {
     char *text = NULL;
     int i;
 
+#ifdef LOG_NO_PRODUCER
+	if (msr->txcfg->debuglog_level < 9) return;
+#endif
     /* Try to write everything in one go. */
     if (msr->txcfg->component_signatures->nelts == 0) {
         text = apr_psprintf(msr->mp, "Producer: %s.\n", MODSEC_MODULE_NAME_FULL);

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1167,6 +1167,9 @@ void sec_audit_logger_json(modsec_rec *msr) {
         /* Our response body does not contain chunks */
         /* ENH Only write this when the output was chunked. */
         /* ENH Add info when request body was decompressed, dechunked too. */
+#ifdef LOG_NO_DECHUNK
+        if (msr->txcfg->debuglog_level >= 9)
+#endif
         if (wrote_response_body) {
             yajl_kv_bool(g, "response_body_dechunked", 1);
         }

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -363,9 +363,6 @@ static void sec_auditlog_write_producer_header(modsec_rec *msr) {
     char *text = NULL;
     int i;
 
-#ifdef LOG_NO_PRODUCER
-	if (msr->txcfg->debuglog_level < 9) return;
-#endif
     /* Try to write everything in one go. */
     if (msr->txcfg->component_signatures->nelts == 0) {
         text = apr_psprintf(msr->mp, "Producer: %s.\n", MODSEC_MODULE_NAME_FULL);
@@ -1999,7 +1996,10 @@ void sec_audit_logger_native(modsec_rec *msr) {
         /* Our response body does not contain chunks */
         /* ENH Only write this when the output was chunked. */
         /* ENH Add info when request body was decompressed, dechunked too. */
-        if (wrote_response_body) {
+#ifdef LOG_NO_DECHUNK
+		if (msr->txcfg->debuglog_level >= 9)
+#endif
+		if (wrote_response_body) {
             text = apr_psprintf(msr->mp, "Response-Body-Transformed: Dechunked\n");
             sec_auditlog_write(msr, text, strlen(text));
         }

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1999,7 +1999,7 @@ void sec_audit_logger_native(modsec_rec *msr) {
 #ifdef LOG_NO_DECHUNK
 		if (msr->txcfg->debuglog_level >= 9)
 #endif
-		if (wrote_response_body) {
+        if (wrote_response_body) {
             text = apr_psprintf(msr->mp, "Response-Body-Transformed: Dechunked\n");
             sec_auditlog_write(msr, text, strlen(text));
         }

--- a/configure.ac
+++ b/configure.ac
@@ -442,6 +442,21 @@ AC_ARG_ENABLE(filename-logging,
   log_filename=''
 ])
 
+# Disable logging of log producer
+AC_ARG_ENABLE(log-producer-logging,
+              AS_HELP_STRING([--enable-log-producer-logging],
+                             [Enable logging of log producer in audit log when log level < 9. This is the default]),
+[
+  if test "$enableval" != "no"; then
+    log_producer=
+  else
+    log_producer="-DLOG_NO_PRODUCER"
+  fi
+],
+[
+  log_producer=''
+])
+
 # Ignore configure errors
 AC_ARG_ENABLE(errors,
               AS_HELP_STRING([--disable-errors],
@@ -692,7 +707,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_producer"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""

--- a/configure.ac
+++ b/configure.ac
@@ -443,8 +443,8 @@ AC_ARG_ENABLE(filename-logging,
 ])
 
 # Disable logging of dechunking
-AC_ARG_ENABLE(log-dechunking,
-              AS_HELP_STRING([--enable-log-dechunking],
+AC_ARG_ENABLE(dechunk-logging,
+              AS_HELP_STRING([--enable-dechunk-logging],
                              [Enable logging of dechunking in audit log when log level < 9. This is the default]),
 [
   if test "$enableval" != "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -442,19 +442,19 @@ AC_ARG_ENABLE(filename-logging,
   log_filename=''
 ])
 
-# Disable logging of log producer
-AC_ARG_ENABLE(log-producer-logging,
-              AS_HELP_STRING([--enable-log-producer-logging],
-                             [Enable logging of log producer in audit log when log level < 9. This is the default]),
+# Disable logging of dechunking
+AC_ARG_ENABLE(log-dechunking,
+              AS_HELP_STRING([--enable-log-dechunking],
+                             [Enable logging of dechunking in audit log when log level < 9. This is the default]),
 [
   if test "$enableval" != "no"; then
-    log_producer=
+    log_dechunk=
   else
-    log_producer="-DLOG_NO_PRODUCER"
+    log_dechunk="-DLOG_NO_DECHUNK"
   fi
 ],
 [
-  log_producer=''
+  log_dechunk=''
 ])
 
 # Ignore configure errors
@@ -707,7 +707,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_producer"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_dechunk"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""


### PR DESCRIPTION
when log level < 9.
[Issue #1068 - Marc Stern]