### PR TITLE
Option to disable logging of notice info at start (versions, ...) in error log.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD MMM YYYY - 2.9.2 - To be released
 ------------------------------------
 
+ * {dis|en}able-start-notice-logging: Option to disable logging of
+   notice info at start (versions, ...) in error log.
  * Cosmetics: added comments on odd looking code to prevent future
    scrutiny
    [Issue #1279 - Coty Sutherland]

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -758,6 +758,7 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
     apr_pool_cleanup_register(mp, (void *)s, module_cleanup, apr_pool_cleanup_null);
 
     /* Log our presence to the error log. */
+#ifndef LOG_NO_START_NOTICE
     if (first_time) {
         ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, s,
                 "%s configured.", MODSEC_MODULE_NAME_FULL);
@@ -782,6 +783,7 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
         }
 #endif
     }
+#endif
 
     /**
      * Checking if it is not the first time that we are in this very function.

--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,21 @@ AC_ARG_ENABLE(server-context-logging,
   log_server_context=''
 ])
 
+# Disable logging of notice info at start
+AC_ARG_ENABLE(start-notice-logging,
+              AS_HELP_STRING([--enable-start-notice-logging],
+                             [Enable logging of notice info at start (versions, ...) in error log. This is the default]),
+[
+  if test "$enableval" != "no"; then
+    log_start_notice=
+  else
+    log_start_notice="-DLOG_NO_START_NOTICE"
+  fi
+],
+[
+  log_start_notice=''
+])
+
 # Ignore configure errors
 AC_ARG_ENABLE(errors,
               AS_HELP_STRING([--disable-errors],
@@ -782,7 +797,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_contex"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $log_start_notice"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""


### PR DESCRIPTION
Also fixed typo in configure.ac in $log_server_context