### PR TITLE
Allow $1, $2 ... $9 in @rsub replacement string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 DD MMM YYYY - 2.9.2 - To be released
 ------------------------------------
 
+ * Allow $1, $2 ... $9 in @rsub replacement string
  * Cosmetics: added comments on odd looking code to prevent future
    scrutiny
    [Issue #1279 - Coty Sutherland]

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -564,7 +564,7 @@ nextround:
         //Copy of regex match with replacing data \1..\9
         for(i=0;i<str->value_len;)  {
             char *x = str->value+i;
-            if (*x == '\\' && *(x + 1) > '0' && *(x + 1) <= '9') {
+            if ( (*x == '\\' || *x == '$') && (*(x + 1) > '0') && (*(x + 1) <= '9') ) {
                 int capture=*(x + 1) - 48;
                 int capture_len=pmatch[capture].rm_eo-pmatch[capture].rm_so;
 


### PR DESCRIPTION
PCRE supports \1 and $1 for capture groups in replacement string.
ModSecurity only supports \1.
Although the \1 syntax works most of the time, it is incompatible with mod_macro, as \ are stripped from parameters. To use \1 in a parameter, you need to use \\\\1. It's even worse: if you don't know how many macros are nested (it's the case most of the time), you don't know how many \ to use.
This adds the support for the $1 syntax, that works nicely with mod_macro (or without it).