### PR TITLE
Fixes issue #1432 by not logging normal behaviour to error.log and using APLOG_DEBUG instead

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1494,7 +1494,7 @@ static int hook_connection_early(conn_rec *conn)
             }
         }
 
-        ap_log_cerror(APLOG_MARK, APLOG_WARNING, 0, conn,
+        ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, conn,
             "ModSecurity: going to loop through %d servers with %d threads",
             server_limit, thread_limit);
         for (i = 0; i < server_limit; ++i) {
@@ -1526,7 +1526,7 @@ static int hook_connection_early(conn_rec *conn)
             }
         }
 
-        ap_log_cerror(APLOG_MARK, APLOG_WARNING, 0, conn,
+        ap_log_cerror(APLOG_MARK, APLOG_DEBUG, 0, conn,
             "ModSecurity: threads in READ: %ld of %ld, WRITE: %ld of %ld, IP: %s",
             ip_count_r, conn_read_state_limit, ip_count_w, conn_write_state_limit, client_ip);
 


### PR DESCRIPTION
Apparently APLOG_TRACE3 is not supported on older versions of Apache/APR (2.2.x) so AP_LOG_WARNING was used on #1340 but caused logs to flood. This patch suggests using [APLOG_DEBUG](https://ci.apache.org/projects/httpd/trunk/doxygen/group__APACHE__CORE__LOG.html#gadfcef90537539cf2b7d35cfbbbafeb93) which should be safe for all supported versions of Apache/APR.