### PR TITLE
Few missing headers, in the <arpa/inet.h> inclusions ones

### DIFF
--- a/apache2/msc_status_engine.c
+++ b/apache2/msc_status_engine.c
@@ -19,6 +19,9 @@
 #ifdef WIN32
 #include <winsock2.h>
 #include <iphlpapi.h>
+#else
+#include <sys/ioctl.h>
+#include <netdb.h>
 #endif
 
 #ifdef DARWIN

--- a/apache2/msc_tree.c
+++ b/apache2/msc_tree.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <apr.h>
 #if APR_HAVE_STDINT_H
 #include <stdint.h>
 #endif

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -22,6 +22,10 @@
 #include "msc_release.h"
 #include "msc_util.h"
 
+#include <apr.h>
+#if APR_HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
 #include <apr_lib.h>
 #include <apr_sha1.h>
 #include "modsecurity_config.h"

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -401,7 +401,7 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
                     param = opt;
                     is_counting = 1;
                 } else  {
-                    param = target;
+                    param = apr_pstrdup(msr->mp, target);
                 }
 
                 opt = strchr(param,':');
@@ -415,6 +415,8 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
                 if(apr_table_get(ruleset->engine->variables, name) == NULL)   {
                     if(target_list != NULL)
                         free(target_list);
+                    if (target != NULL)
+                        free(target);
                     if(replace != NULL)
                         free(replace);
                     if(msr) {

--- a/standalone/config.c
+++ b/standalone/config.c
@@ -1104,7 +1104,7 @@ ProcessInclude:
 				incpath = w;
 
 				/* locate the start of the directories proper */
-				status = apr_filepath_root(&rootpath, &incpath, APR_FILEPATH_TRUENAME | APR_FILEPATH_NATIVE, ptemp);
+				status = apr_filepath_root((const char **)&rootpath, (const char **)&incpath, APR_FILEPATH_TRUENAME | APR_FILEPATH_NATIVE, ptemp);
 
 				/* we allow APR_SUCCESS and APR_EINCOMPLETE */
 				if (APR_ERELATIVE == status) {


### PR DESCRIPTION
mainly due to the fact APR_HAVE* constants are simply into apr.h
in addition a small memory leak fix.