### PR TITLE
Add capture action to @detectXSS operator

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -2158,12 +2158,14 @@ static int msre_op_detectSQLi_execute(modsec_rec *msr, msre_rule *rule, msre_var
  */
 static int msre_op_detectXSS_execute(modsec_rec *msr, msre_rule *rule, msre_var *var,
     char **error_msg) {
-
+    int capture;
     int is_xss;
 
     is_xss = libinjection_xss(var->value, var->value_len);
+    capture = apr_table_get(rule->actionset->actions, "capture") ? 1 : 0;
 
     if (is_xss) {
+        set_match_to_tx(msr, capture, var->value, 0);
         *error_msg = apr_psprintf(msr->mp, "detected XSS using libinjection.");
 
         if (msr->txcfg->debuglog_level >= 9) {


### PR DESCRIPTION
Proposed fix for #1482.

Do notice that the API for @detectXSS in libInjection is still in Alpha stage so there's some missing features when compared with @detectSQLi.

In this case, there's no "[fingerprint](https://github.com/SpiderLabs/ModSecurity/blob/v2/master/apache2/re_operators.c#L2138)" returned from libInjection API to be fed into a "capture" action to tell us exactly what triggered the match like it's done with [libinjection_sqli](https://github.com/client9/libinjection/blob/master/src/libinjection.h#L42-L50)

So this proposed "capture" action would fill TX.0 with the full analyzed parameter value (var->value) when libinjection_xss returns true.