### PR TITLE
Rename FromNowOneAllowType to FromNowOnAllowType.

### DIFF
--- a/src/actions/disruptive/allow.cc
+++ b/src/actions/disruptive/allow.cc
@@ -37,7 +37,7 @@ bool Allow::init(std::string *error) {
     } else if (a == "request") {
         m_allowType = RequestAllowType;
     } else if (a == "") {
-        m_allowType = FromNowOneAllowType;
+        m_allowType = FromNowOnAllowType;
     } else {
         error->assign("Allow: if specified, the parameter " \
             "most be: phase, request");

--- a/src/actions/disruptive/allow.h
+++ b/src/actions/disruptive/allow.h
@@ -47,7 +47,7 @@ enum AllowType : int {
   /**
    *
    */
-  FromNowOneAllowType,
+  FromNowOnAllowType,
 };
 
 
@@ -71,8 +71,8 @@ class Allow : public Action {
             return "Request";
         } else if (a == PhaseAllowType) {
             return "Phase";
-        } else if (a == FromNowOneAllowType) {
-            return "FromNowOne";
+        } else if (a == FromNowOnAllowType) {
+            return "FromNowOn";
         } else {
             return "Unknown";
         }

--- a/src/rules.cc
+++ b/src/rules.cc
@@ -167,7 +167,7 @@ int Rules::evaluate(int phase, Transaction *transaction) {
     debug(9, "This phase consists of " + std::to_string(rules.size()) + \
         " rule(s).");
 
-    if (transaction->m_allowType == actions::disruptive::FromNowOneAllowType
+    if (transaction->m_allowType == actions::disruptive::FromNowOnAllowType
         && phase != modsecurity::Phases::LoggingPhase) {
         debug(9, "Skipping all rules evaluation on this phase as request " \
             "through the utilization of an `allow' action.");


### PR DESCRIPTION
This misspelling is confusing (is it allow one more rule, or all of
them?) and since v3 isn't released yet, use the major version bump
opportunity to rectify it.