### PR TITLE
Fixed typos in conditional compile

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1165,7 +1165,7 @@ void sec_audit_logger_json(modsec_rec *msr) {
 
 
         /* Stopwatch2 */
-#ifdef DLOG_NO_STOPWATCH
+#ifdef LOG_NO_STOPWATCH
         if (msr->txcfg->debuglog_level >= 9)
 #endif
         format_performance_variables_json(msr, g);
@@ -1998,7 +1998,7 @@ void sec_audit_logger_native(modsec_rec *msr) {
         }
 
         /* Stopwatch; left in for compatibility reasons */
-#ifdef DLOG_NO_STOPWATCH
+#ifdef LOG_NO_STOPWATCH
 	if (msr->txcfg->debuglog_level >= 9) {
 #endif
         text = apr_psprintf(msr->mp, "Stopwatch: %" APR_TIME_T_FMT " %" APR_TIME_T_FMT " (- - -)\n",
@@ -2013,7 +2013,7 @@ void sec_audit_logger_native(modsec_rec *msr) {
                 "; %s\n", msr->request_time, (now - msr->request_time), perf_all);
             sec_auditlog_write(msr, text, strlen(text));
         }
-#ifdef DLOG_NO_STOPWATCH
+#ifdef LOG_NO_STOPWATCH
         }
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -812,7 +812,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_contex $collection_global_lock"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""


### PR DESCRIPTION
LOG_NO_STOPWATCH instead of DLOG_NO_STOPWATCH
$log_server_context instead of $log_server_contex