### PR TITLE
Fix operator @validateByteRange working with bytes > 127

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -217,6 +217,7 @@ TESTS+=test/test-cases/regression/variable-TX.json
 TESTS+=test/test-cases/regression/variable-ENV.json
 TESTS+=test/test-cases/regression/variable-STATUS.json
 TESTS+=test/test-cases/regression/action-tag.json
+TESTS+=test/test-cases/regression/operator-validate-byte-range.json
 TESTS+=test/test-cases/secrules-language-tests/transformations/base64Encode.json
 TESTS+=test/test-cases/secrules-language-tests/transformations/trimRight.json
 TESTS+=test/test-cases/secrules-language-tests/transformations/parityEven7bit.json

--- a/src/operators/validate_byte_range.cc
+++ b/src/operators/validate_byte_range.cc
@@ -116,7 +116,7 @@ bool ValidateByteRange::evaluate(Transaction *transaction, Rule *rule,
 
     size_t count = 0;
     for (int i = 0; i < input.length(); i++) {
-        int x = input.at(i);
+        int x = (unsigned char) input.at(i);
         if (!(table[x >> 3] & (1 << (x & 0x7)))) {
             // debug(9, "Value " + std::to_string(x) + " in " +
             //     input + " ouside range: " + param);

--- a/test/test-cases/regression/operator-validate-byte-range.json
+++ b/test/test-cases/regression/operator-validate-byte-range.json
@@ -1,0 +1,40 @@
+[
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Operator :: @validateByteRange with bytes > 127",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length": "27",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/%D0%A2%D0%B0%D1%80%D0%B0%D0%B1%D0%B0%D0%BD",
+      "method":"GET",
+      "body": [ ]
+    },
+    "response":{
+      "headers":{},
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"Rule returned 0."
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule REQUEST_URI \"@validateByteRange 37-102, 127-255\" \"id:1,phase:2,pass,t:trim\""
+    ]
+  }
+]


### PR DESCRIPTION
`ValidateByteRange::evaluate()` acquires bytes it validates by indexing `std::string`:
```C++
bool ValidateByteRange::evaluate(Transaction *transaction, Rule *rule,
    const std::string &input, std::shared_ptr<RuleMessage> ruleMessage) {
    bool ret = true;

    size_t count = 0;
    for (int i = 0; i < input.length(); i++) {
        int x = input.at(i);
        if (!(table[x >> 3] & (1 << (x & 0x7)))) {
            ...
            count++;
        }
    }

    ret = (count != 0);
    // ...
    return ret;
}
```
The problem is that indexing a string gives a `char`, which is signed, so bytes with codes > 127 will appear as negative integers, resulting in incorrect validation. This can be illustrated by this minimal example:
```C++
#include "modsecurity/modsecurity.h"
#include "modsecurity/rules.h"

static void logCb(void *data, const void *ruleMessagev) {
    std::cout << (char *) ruleMessagev << std::endl;
}

const char * req_uri = "/test?param=%D0%A2%D0%B0%D1%80%D0%B0%D0%B1%D0%B0%D0%BD";

int main() {
    modsecurity::ModSecurity *modsec = new modsecurity::ModSecurity();
    modsecurity::Rules *rules = new modsecurity::Rules();
    modsecurity::Transaction * modsecTransaction;

    modsec->setServerLogCb(logCb, modsecurity::TextLogProperty);

    rules->loadFromUri("test.conf");

    modsecTransaction = new modsecurity::Transaction(modsec, rules, NULL);
    modsecTransaction->processURI(req_uri, "GET", "1.1");
    modsecTransaction->processRequestHeaders();
    modsecTransaction->processRequestBody();

    delete modsecTransaction;
    delete rules;
    delete modsec;
    return 0;
}
```
And this test config:
```
SecRule REQUEST_URI "@validateByteRange 1-255" \
  id:920270
```
Even though this config allows any byte except NULL byte, URI in test will fail the check resulting in alert, because bytes `\xd0`, `\xa2` etc are considered negative, hence < 1 and out of range. This breaks rules `920270` , `920271` etc from OWASP CRS (in fact, config including those rules with `tx.paranoia_level=2` can be used as test.conf in the above example, the rules will be mistakenly triggered).

The proposed solution is to cast a byte from input string to `unsigned char` before further processing - bytes will then fall in range [0;255] and be validated as expected. In fact, the same thing is done in v2 (https://github.com/SpiderLabs/ModSecurity/blob/v2/master/apache2/re_operators.c#L4168):
```C++
int x = ((unsigned char *)var->value)[i];
```