### PR TITLE
Fix @rbl operator to correctly recognize known supported RBL providers

### DIFF
--- a/src/operators/rbl.h
+++ b/src/operators/rbl.h
@@ -64,12 +64,12 @@ class Rbl : public Operator {
         m_service(param),
         m_demandsPassword(false) {
             m_provider = RblProvider::UnknownProvider;
-            if (m_service == "httpbl.org") {
+            if (m_service.find("httpbl.org") != std::string::npos) {
                 m_demandsPassword = true;
                 m_provider = RblProvider::httpbl;
-            } else if (m_service == "uribl.com") {
+            } else if (m_service.find("uribl.com") != std::string::npos) {
                 m_provider = RblProvider::httpbl;
-            } else if (m_service == "spamhaus.org") {
+            } else if (m_service.find("spamhaus.org") != std::string::npos) {
                 m_provider = RblProvider::httpbl;
             }
         }
@@ -78,12 +78,12 @@ class Rbl : public Operator {
         m_service(param),
         m_demandsPassword(false) {
             m_provider = RblProvider::UnknownProvider;
-            if (m_service == "httpbl.org") {
+            if (m_service.find("httpbl.org") != std::string::npos) {
                 m_demandsPassword = true;
                 m_provider = RblProvider::httpbl;
-            } else if (m_service == "uribl.com") {
+            } else if (m_service.find("uribl.com") != std::string::npos) {
                 m_provider = RblProvider::httpbl;
-            } else if (m_service == "spamhaus.org") {
+            } else if (m_service.find("spamhaus.org") != std::string::npos) {
                 m_provider = RblProvider::httpbl;
             }
         }


### PR DESCRIPTION
The @rbl operator was found to not be working for some known providers including HttpBL as the current URL (dnsbl.httpbl.org) was not matching to be able to set the HttpBlKey or set the additional furtheInfo() data.

The previous string comparison was replaced with string::find to match with URLs under "httpbl.org"  (and other predefined providers) domain as opposed to replacing the provider URL with the one in the [API](https://www.projecthoneypot.org/httpbl_api.php). 

Matching the implementation of @rbl for ModSecurity v2 which uses std:strstr to scan the *string for the predefined RBL providers: https://github.com/SpiderLabs/ModSecurity/blob/v2/master/apache2/re_operators.c#L3670