### PR TITLE
Correctly handle the case when implicit @rx starts with "!" (negation).

### DIFF
--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -1443,7 +1443,7 @@ namespace yy {
   case 33:
 #line 849 "seclang-parser.yy" // lalr1.cc:859
     {
-        OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Rx("!" + utils::string::removeBracketsIfNeeded(yystack_[0].value.as< std::string > ())));
+        OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Rx("Rx", utils::string::removeBracketsIfNeeded(yystack_[0].value.as< std::string > ()), true));
         std::string error;
         if (yylhs.value.as< std::unique_ptr<Operator> > ()->init(driver.ref.back(), &error) == false) {
             driver.error(yystack_[2].location, error);

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -847,7 +847,7 @@ op:
       }
     | NOT OPERATOR_RX_CONTENT_ONLY
       {
-        OPERATOR_CONTAINER($$, new operators::Rx("!" + utils::string::removeBracketsIfNeeded($2)));
+        OPERATOR_CONTAINER($$, new operators::Rx("Rx", utils::string::removeBracketsIfNeeded($2), true));
         std::string error;
         if ($$->init(driver.ref.back(), &error) == false) {
             driver.error(@0, error);

--- a/test/test-cases/regression/operator-rx.json
+++ b/test/test-cases/regression/operator-rx.json
@@ -42,5 +42,48 @@
       "SecRuleEngine On",
       "SecRule ARGS \"@rx (value1)\" \"id:1,phase:2,pass,t:trim\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Operator :: @rx in implicit form with negation ('!')",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length": "27",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "method":"HEAD",
+      "body": [ ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"Executing operator \"Rx\" with param \"\\^0\\$\"",
+      "error_log":"Matched \"Operator `Rx' with parameter `\\^0\\$'"
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule REQUEST_HEADERS:Content-Length \"!^0$\" \"id:1,phase:2,pass,t:trim\""
+    ]
   }
 ]


### PR DESCRIPTION
When a parser saw a token `NOT` followed by `OPERATOR_RX_CONTENT_ONLY` (implicit `@rx`), it used the following rules (https://github.com/SpiderLabs/ModSecurity/blob/0508395/src/parser/seclang-parser.yy#L848):
```C++
| NOT OPERATOR_RX_CONTENT_ONLY
      {
        OPERATOR_CONTAINER($$, new operators::Rx("!" + utils::string::removeBracketsIfNeeded($2)));
```
This code creates an operator Rx with regular expression starting with `!`, while it should create a negated Rx with regex not containing the initial `!`. The following code can be used to demonstrate it:
```C++
#include "modsecurity/modsecurity.h"
#include "modsecurity/rules.h"

static void logCb(void *data, const void *ruleMessagev) {
    std::cout << (char *) ruleMessagev << std::endl;
}

const char * req_uri = "/test?param=invalid";

int main() {
    modsecurity::ModSecurity *modsec = new modsecurity::ModSecurity();
    modsecurity::Rules *rules = new modsecurity::Rules();
    modsecurity::Transaction * modsecTransaction;

    modsec->setServerLogCb(logCb, modsecurity::TextLogProperty);

    rules->loadFromUri("test.conf");

    modsecTransaction = new modsecurity::Transaction(modsec, rules, NULL);
    modsecTransaction->processURI(req_uri, "GET", "1.1");
    modsecTransaction->processRequestHeaders();
    modsecTransaction->processRequestBody();

    delete modsecTransaction;
    delete rules;
    delete modsec;
    return 0;
}
```
With `test.conf`:
```
SecRule ARGS:param "!^valid$" id:1
```
This code should produce an alert because the rule only allows `param` to have value `valid`. Instead, it will print nothing, because the rule checks `param` against regex `!^valid$`.

This breaks OWASP CRS rules that use negation of implicit `@rx`, for example rule `920170` (which contains `SecRule REQUEST_HEADERS:Content-Length "!^0?$"`), that ensures that value of `Content-Length` header can't be other than zero when request method is `GET` or `POST`. In fact this rule will never fire because no header value can satisfy regex `"!^0?$"` (exclamation mark before beginning of the line).

The proposed fix is to let parser use the Rx constructor that accepts 3 arguments (` Rx(std::string op, std::string param, bool negation)`) and pass `true` as negation value:
```C++
 | NOT OPERATOR_RX_CONTENT_ONLY
      {
        OPERATOR_CONTAINER($$, new operators::Rx("Rx", utils::string::removeBracketsIfNeeded($2), true));
```