### PR TITLE
Handle zero byte rule files correctly.

### DIFF
--- a/src/parser/driver.cc
+++ b/src/parser/driver.cc
@@ -134,6 +134,10 @@ int Driver::parse(const std::string &f, const std::string &ref) {
         this->ref.push_back(ref);
     }
 
+    if (f.empty()) {
+        return 1;
+    }
+
     buffer = f;
     scan_begin();
     yy::seclang_parser parser(*this);


### PR DESCRIPTION
This corrects the stalling behaviour seen when trying to parse an empty
rule file.

Fixes: #1521