### PR TITLE
Fix #1528: add macro expansion for @rx operator

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -128,6 +128,7 @@ TESTS+=test/test-cases/regression/variable-TIME_MIN.json
 TESTS+=test/test-cases/regression/action-setuid.json
 TESTS+=test/test-cases/regression/action-setrsc.json
 TESTS+=test/test-cases/regression/issue-1152.json
+TESTS+=test/test-cases/regression/issue-1528.json
 TESTS+=test/test-cases/regression/config-calling_phases_by_name.json
 TESTS+=test/test-cases/regression/variable-USERID.json
 TESTS+=test/test-cases/regression/request-body-parser-multipart.json

--- a/src/operators/rx.cc
+++ b/src/operators/rx.cc
@@ -39,10 +39,12 @@ bool Rx::evaluate(Transaction *transaction, Rule *rule,
         return true;
     }
 
-    std::string eparam = MacroExpansion::expand(m_param, transaction);
+    if (m_macro_expansion_possible) {
+        std::string eparam = MacroExpansion::expand(m_param, transaction);
 
-    if (eparam != m_param) {
-        re = new Regex(eparam);
+        if (eparam != m_param) {
+            re = new Regex(eparam);
+        }
     }
 
     matches = re->searchAll(input);
@@ -72,6 +74,18 @@ bool Rx::evaluate(Transaction *transaction, Rule *rule,
     }
 
     return false;
+}
+
+
+void Rx::checkIfMacroExpansionPossible() {
+    size_t pos = m_param.find("%{");
+
+    if (pos == std::string::npos) {
+        m_macro_expansion_possible = false;
+        return;
+    }
+
+    m_macro_expansion_possible = (m_param.find('}', pos) != std::string::npos);
 }
 
 

--- a/src/operators/rx.cc
+++ b/src/operators/rx.cc
@@ -33,12 +33,19 @@ bool Rx::evaluate(Transaction *transaction, Rule *rule,
     const std::string& input, std::shared_ptr<RuleMessage> ruleMessage) {
     SMatch match;
     std::list<SMatch> matches;
+    Regex * re = m_re;
 
     if (m_param.empty()) {
         return true;
     }
 
-    matches = m_re->searchAll(input);
+    std::string eparam = MacroExpansion::expand(m_param, transaction);
+
+    if (eparam != m_param) {
+        re = new Regex(eparam);
+    }
+
+    matches = re->searchAll(input);
     if (rule && rule->getActionsByName("capture").size() > 0 && transaction) {
         int i = 0;
         matches.reverse();
@@ -54,6 +61,10 @@ bool Rx::evaluate(Transaction *transaction, Rule *rule,
 
     for (const auto & i : matches) {
         logOffset(ruleMessage, i.m_offset, i.m_length);
+    }
+
+    if (re != m_re) {
+        delete re;
     }
 
     if (matches.size() > 0) {

--- a/src/operators/rx.h
+++ b/src/operators/rx.h
@@ -38,14 +38,20 @@ class Rx : public Operator {
     Rx(std::string op, std::string param, bool negation)
         : Operator(op, param, negation) {
         m_re = new Regex(param);
+
+        checkIfMacroExpansionPossible();
         }
     Rx(std::string name, std::string param)
         : Operator(name, param) {
         m_re = new Regex(param);
+
+        checkIfMacroExpansionPossible();
     }
     explicit Rx(std::string param)
         : Operator("Rx", param) {
         m_re = new Regex(param);
+
+        checkIfMacroExpansionPossible();
     }
 
     ~Rx() {
@@ -65,6 +71,9 @@ class Rx : public Operator {
 
  private:
     Regex *m_re;
+    bool m_macro_expansion_possible;
+
+    void checkIfMacroExpansionPossible();
 };
 
 

--- a/test/test-cases/regression/issue-1528.json
+++ b/test/test-cases/regression/issue-1528.json
@@ -1,0 +1,38 @@
+[
+{
+  "enabled": 1,
+  "version_min": 209000,
+  "version_max": -1,
+  "title": "Macro expansion inside regex does not work",
+  "url": "https:\/\/github.com\/SpiderLabs\/ModSecurity\/issues\/1528",
+  "gihub_issue": 1528,
+  "client": {
+    "ip": "200.249.12.31",
+    "port": 2313
+  },
+  "server": {
+    "ip": "200.249.12.31",
+    "port": 80
+  },
+  "request": {
+    "uri":"/?param=attack",
+    "headers": "",
+    "body": "",
+    "method": "GET",
+    "http_version": 1.1
+  },
+  "response": {
+    "headers": "",
+    "body": ""
+  },
+  "expected": {
+    "debug_log": "Rule returned 1",
+    "error_log": "Matched \"Operator `Rx' with parameter `\\^%{tx\\.bad_value}\\$' against variable `ARGS:param' \\(Value: `attack' "
+  },
+  "rules": [
+    "SecRuleEngine On",
+    "SecAction \"id:1, nolog, setvar:tx.bad_value=attack\"",
+    "SecRule ARGS:param \"@rx ^%{tx.bad_value}$\" id:2"
+  ]
+}
+]


### PR DESCRIPTION
There is a problem that macro expansion in regex of `@rx` operator does not work (see #1528).

This pull request adds a code that tries macro expansion on regex before matching, and, if regex text changed after expansion, create new Regex object from it and use that for matching.

Also, add an optimization: in Rx constructor, check if macro expansion is possible at all for regex (`%{...}` present in it), cache the result of this check (save it in a boolean field of Rx object) and try macro expansion before matching only if check was positive. This should avoid macro expansion attempts + string compares for most regexes (at least, for most regexes in OWASP CRS).

Also, add a regression test.

Fixes #1528