### PR TITLE
Fixes SecConnWriteStateLimit

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1597,7 +1597,7 @@ static int hook_connection_early(conn_rec *conn)
                     "Possible DoS Consumption Attack [Rejected]", ip_count_w,
                     conn_write_state_limit, client_ip);
 
-                if (!conn_limits_filter_state == MODSEC_ENABLED)
+                if (conn_limits_filter_state == MODSEC_ENABLED)
                     return OK;
             }
         }


### PR DESCRIPTION
Since https://github.com/SpiderLabs/ModSecurity/commit/a15f8813e98c8d3109a06f5913e3795aba79de76, I don't believe `SecConnWriteStateLimit` has been working properly, which means that "slow read" attacks are not protected against.

With ModSecurity 2.9.2 on Apache 2.4.27, I was seeing ModSecurity properly blocking a Slowloris attack (slow writing headers) via [`slowhttptest -H`](https://github.com/shekyan/slowhttptest):

```
slowhttptest -u http://127.0.0.1/a -H -c 1000
```

Apache `error_log` with `SecConnReadStateLimit 50`:

```
[Wed Aug 23 19:20:38.902507 2017] [:warn] [pid 2712] [client 127.0.0.1:21192] ModSecurity:
Access denied with code 400. Too many threads [51] of 50 allowed in READ state from
127.0.0.1 - Possible DoS Consumption Attack [Rejected]
```

We see above that the 51st and all subsequent connections are properly dropped.

However, "slow read" attacks (`slowhttptest` with `-X` or `-B`) aren't currently protected.  With `SecConnWriteStateLimit 50`, ModSecurity currently logs warnings but doesn't drop connections.

```
slowhttptest -u http://127.0.0.1/a -X -c 1000
```

```
[Wed Aug 23 17:09:50.294791 2017] [:warn] [pid 11072] [client 127.0.0.1:44254] ModSecurity:
Access denied with code 400. Too many threads [226] of 50 allowed in WRITE state from
127.0.0.1 - Possible DoS Consumption Attack [Rejected]
```

(note 226 out of 50 allowed)


It looks like the line I've changed in this PR had inversed logic (should have been the same as the [`SecConnReadStateLimit`](https://github.com/SpiderLabs/ModSecurity/blob/a15f8813e98c8d3109a06f5913e3795aba79de76/apache2/mod_security2.c#L1455) logic), but https://github.com/SpiderLabs/ModSecurity/commit/a15f8813e98c8d3109a06f5913e3795aba79de76 swapped it on accident.

With this one-character fix, I now see slow read attacks being blocked.

CC @zimmerle