### PR TITLE
Store the connection and url parameters in std::string

### DIFF
--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -348,22 +348,22 @@ class Transaction : public TransactionAnchoredVariables {
     /**
      * Holds the client IP address.
      */
-    const char *m_clientIpAddress;
+    std::string m_clientIpAddress;
 
     /**
      * Holds the HTTP version: 1.2, 2.0, 3.0 and so on....
      */
-    const char *m_httpVersion;
+    std::string m_httpVersion;
 
     /**
      * Holds the server IP Address
      */
-    const char *m_serverIpAddress;
+    std::string m_serverIpAddress;
 
     /**
      * Holds the raw URI that was requested.
      */
-    const char *m_uri;
+    std::string m_uri;
 
     /**
      * Holds the URI that was requests (without the query string).


### PR DESCRIPTION
Passing stack allocated strings to the Transaction object could lead to memory corruption when the Transaction object outlive the stack. In this case the _m_clientIpAddress_, _m_serverIpAddress_, _m_httpVersion_ and the _m_uri_ pointers will point to invalid addresses.
I bumped into this when I made a transaction cache and one of my thread initialized the transactions (did the request phases) and a other finalized them (response phases, logging, free).