### PR TITLE
Include unanmed JSON values in unnamed ARGS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 18 Jul 2017 - 2.9.2
 -------------------
 
+ * Include unanmed JSON values in unnamed ARGS
+   [Issue #1576 - Marc Stern]
  * IIS build refactoring and dependencies update
    [Issue #1487 - @victorhora]
  * Best practice: Initialize msre_var pointers

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -25,8 +25,7 @@ int json_add_argument(modsec_rec *msr, const char *value, unsigned length)
      * to reference this argument; for now we simply ignore these
      */
     if (!msr->json->current_key) {
-        msr_log(msr, 3, "Cannot add scalar value without an associated key");
-        return 1;
+        msr->json->current_key = "";
     }
 
     arg = (msc_arg *) apr_pcalloc(msr->mp, sizeof(msc_arg));


### PR DESCRIPTION
Issue #1576: unanmed JSON values are not parsed because not included in ARGS.
Include these JSON values in unnamed ARGS to include in parsing