### PR TITLE
Fix fallback for non-mapped Unicode char

### DIFF
--- a/src/actions/transformations/js_decode.cc
+++ b/src/actions/transformations/js_decode.cc
@@ -71,14 +71,21 @@ int JsDecode::inplace(unsigned char *input, uint64_t input_len) {
                 && (VALID_HEX(input[i + 4])) && (VALID_HEX(input[i + 5]))) {
                 /* \uHHHH */
 
-                /* Use only the lower byte. */
-                *d = utils::string::x2c(&input[i + 4]);
+                unsigned char lowestByte = utils::string::x2c(&input[i + 4]);
 
-                /* Full width ASCII (ff01 - ff5e) needs 0x20 added */
-                if ((*d > 0x00) && (*d < 0x5f)
+                if ((lowestByte > 0x00) && (lowestByte < 0x5f)
                     && ((input[i + 2] == 'f') || (input[i + 2] == 'F'))
-                    && ((input[i + 3] == 'f') || (input[i + 3] == 'F'))) {
-                    (*d) += 0x20;
+                    && ((input[i + 3] == 'f') || (input[i + 3] == 'F')))
+                {
+                    /* Full width ASCII (ff01 - ff5e) needs 0x20 added. */
+                    /* This is because the first printable char in ASCII is 0x20, and corresponds to 0xFF00. */
+                    *d = lowestByte + 0x20;
+                }
+                else
+                {
+                    /* There was no good ASCII character to map this unicode character to. */
+                    /* Put a placeholder that is hopefully as innocent as the unicode character. */
+                    *d = 'x';
                 }
 
                 d++;

--- a/src/actions/transformations/url_decode_uni.cc
+++ b/src/actions/transformations/url_decode_uni.cc
@@ -113,9 +113,22 @@ int UrlDecodeUni::inplace(unsigned char *input, uint64_t input_len,
                         if (hmap != -1)  {
                             *d = hmap;
                         } else {
-                            /* There was no ASCII character to map this unicode character to. */
-                            /* Put a placeholder that is hopefully as innocent as the unicode character. */
-                            *d = 'x';
+                             unsigned char lowestByte = utils::string::x2c(&input[i + 4]);
+
+                            if ((lowestByte > 0x00) && (lowestByte < 0x5f)
+                                && ((input[i + 2] == 'f') || (input[i + 2] == 'F'))
+                                && ((input[i + 3] == 'f') || (input[i + 3] == 'F')))
+                            {
+                                /* Full width ASCII (ff01 - ff5e) needs 0x20 added. */
+                                /* This is because the first printable char in ASCII is 0x20, and corresponds to 0xFF00. */
+                                *d = lowestByte + 0x20;
+                            }
+                            else
+                            {
+                                /* There was no good ASCII character to map this unicode character to. */
+                                /* Put a placeholder that is hopefully as innocent as the unicode character. */
+                                *d = 'x';
+                            }
                         }
                         d++;
                         count++;

--- a/src/actions/transformations/url_decode_uni.cc
+++ b/src/actions/transformations/url_decode_uni.cc
@@ -75,7 +75,7 @@ int UrlDecodeUni::inplace(unsigned char *input, uint64_t input_len,
         if (input[i] == '%') {
             if ((i + 1 < input_len) &&
                 ((input[i + 1] == 'u') || (input[i + 1] == 'U'))) {
-            /* Character is a percent sign. */
+                /* Character is a percent sign. */
                 /* IIS-specific %u encoding. */
                 if (i + 5 < input_len) {
                     /* We have at least 4 data bytes. */
@@ -113,19 +113,9 @@ int UrlDecodeUni::inplace(unsigned char *input, uint64_t input_len,
                         if (hmap != -1)  {
                             *d = hmap;
                         } else {
-                            /* We first make use of the lower byte here,
-                             * ignoring the higher byte. */
-                            *d = utils::string::x2c(&input[i + 4]);
-
-                            /* Full width ASCII (ff01 - ff5e)
-                             * needs 0x20 added */
-                            if ((*d > 0x00) && (*d < 0x5f)
-                                    && ((input[i + 2] == 'f')
-                                    || (input[i + 2] == 'F'))
-                                    && ((input[i + 3] == 'f')
-                                    || (input[i + 3] == 'F'))) {
-                                (*d) += 0x20;
-                            }
+                            /* There was no ASCII character to map this unicode character to. */
+                            /* Put a placeholder that is hopefully as innocent as the unicode character. */
+                            *d = 'x';
                         }
                         d++;
                         count++;


### PR DESCRIPTION
For example see this request:
```
POST / HTTP/1.1
Host: somehost:8080
Accept: */*
User-Agent: someagent
Content-Length: 30
Content-Type: application/json;charset=utf-8

{
    "a": "娧    "
}
```

t:utf8toUnicode turns this Unicode char into %u5a27 , and so the lowest byte is 0x27, which is a single quote in ASCII. This triggers false positives.

This happens with any unicode character that doesn't have a mapping in the SecUnicodeMapFile, and whose last byte in its code point happens to be 0x27. Likewise for characters that end in 0x22 would be treated as a double quote, etc.

![0x27](https://user-images.githubusercontent.com/21695978/32305141-e4d4b24c-bf30-11e7-847f-5888be36fa86.png)

The same problem exists with t:jsDecode given a request with the unicode character full width G (code point FF27).

Said differently: the last byte in the Unicode code point does not have any meaningful relation to whatever ASCII char happens to be represented by the same byte, and so we shouldn't treat it so.

I suggest replacing with an x. I also considered question marks or space, but that could also trigger false positives (too many non-alphanum in a row). Also considered just omitting the char, but that could also trigger a false positive where for example "-娧-" would have been OK but "--" is not.
