### PR TITLE
Windows build, fixed duplicate YAJL dir in script

### DIFF
--- a/iis/build_modsecurity.bat
+++ b/iis/build_modsecurity.bat
@@ -15,21 +15,21 @@ set CURRENT_DIR=%cd%
 cd ..\apache2
 del *.obj *.dll *.lib
 del libinjection\*.obj libinjection\*.dll libinjection\*.lib
-NMAKE -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre LIBXML2=..\iis\%DEPENDENCIES_DIR%\libxml2 LUA=..\iis\%DEPENDENCIES_DIR%\lua\src VERSION=VERSION_IIS YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\%YAJL_DIR%\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep CURL=..\iis\%DEPENDENCIES_DIR%\curl IIS_BUILD=yes
+NMAKE -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre LIBXML2=..\iis\%DEPENDENCIES_DIR%\libxml2 LUA=..\iis\%DEPENDENCIES_DIR%\lua\src VERSION=VERSION_IIS YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep CURL=..\iis\%DEPENDENCIES_DIR%\curl IIS_BUILD=yes
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 
 @echo mlogc...
 cd ..\mlogc
 del *.obj *.dll *.lib
 nmake -f Makefile.win clean
-nmake -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre CURL=..\iis\%DEPENDENCIES_DIR%\curl YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\%YAJL_DIR%\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep VERSION=VERSION_IIS
+nmake -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre CURL=..\iis\%DEPENDENCIES_DIR%\curl YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep VERSION=VERSION_IIS
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 
 @echo iis...
 cd ..\iis
 del *.obj *.dll *.lib
 nmake -f Makefile.win clean
-NMAKE -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre LIBXML2=..\iis\%DEPENDENCIES_DIR%\libxml2 LUA=..\iis\%DEPENDENCIES_DIR%\lua\src VERSION=VERSION_IIS YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\%YAJL_DIR%\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep CURL=..\iis\%DEPENDENCIES_DIR%\curl
+NMAKE -f Makefile.win APACHE=..\iis\%DEPENDENCIES_DIR%\Apache24 PCRE=..\iis\%DEPENDENCIES_DIR%\pcre LIBXML2=..\iis\%DEPENDENCIES_DIR%\libxml2 LUA=..\iis\%DEPENDENCIES_DIR%\lua\src VERSION=VERSION_IIS YAJL=..\iis\%DEPENDENCIES_DIR%\yajl\build\yajl-2.1.0 SSDEEP=..\iis\%DEPENDENCIES_DIR%\ssdeep CURL=..\iis\%DEPENDENCIES_DIR%\curl
 @if NOT (%ERRORLEVEL%) == (0) goto build_failed
 
 cd %CURRENT_DIR%


### PR DESCRIPTION
Hi Felipe. I see you recently did this change https://github.com/SpiderLabs/ModSecurity/commit/c917df0f2a8acb0fb31262a5ad222d6d78394fe3 , but I think there might be a problem with the YAJL path. When building via build_modsecurity.bat directly, all is fine, because the path becomes ....\yajl\build\\yajl-2.1.0 . But when building via build_release.bat , build_yajl.bat gets invoked, which sets the YAJL_DIR env variable, and so the path becomes ....\yajl\build\yajl-2.1.0\yajl-2.1.0 and the build fails.

Changing build_modsecurity.bat to let YAJL align with the other dependencies, where only the %DEPENDENCIES_DIR% env variable is used, and the rest is hardcoded.