### PR TITLE
Disallow 'block' as a default action

### DIFF
--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -877,7 +877,7 @@ namespace yy {
 
 
     // User initialization code.
-    #line 343 "/home/zimmerle/core-trustwave/ModSecurity/src/parser/seclang-parser.yy" // lalr1.cc:741
+    #line 343 "/home/michael/public-ModSecurity/src/parser/seclang-parser.yy" // lalr1.cc:741
 {
   // Initialize the initial location.
   yyla.location.begin.filename = yyla.location.end.filename = &driver.file;
@@ -1926,6 +1926,11 @@ namespace yy {
                     driver.error(yystack_[2].location, "The transformation none is not suitable to be part of the SecDefaultActions");
                     YYERROR;
                 }
+                actions::disruptive::Block *block = dynamic_cast<actions::disruptive::Block *>(a);
+                if (block != NULL) {
+                    driver.error(yystack_[2].location, "The 'block' action cannot be used as a default action");
+                    YYERROR;
+                }
                 checkedActions.push_back(a);
             } else {
                 driver.error(yystack_[2].location, "The action '" + a->m_name + "' is not suitable to be part of the SecDefaultActions");
@@ -1951,75 +1956,75 @@ namespace yy {
 
         delete actions;
       }
-#line 1955 "seclang-parser.cc" // lalr1.cc:859
+#line 1960 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 77:
-#line 1185 "seclang-parser.yy" // lalr1.cc:859
+#line 1190 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as< std::string > ()));
       }
-#line 1963 "seclang-parser.cc" // lalr1.cc:859
+#line 1968 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 78:
-#line 1189 "seclang-parser.yy" // lalr1.cc:859
+#line 1194 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secRuleEngine = modsecurity::Rules::DisabledRuleEngine;
       }
-#line 1971 "seclang-parser.cc" // lalr1.cc:859
+#line 1976 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 79:
-#line 1193 "seclang-parser.yy" // lalr1.cc:859
+#line 1198 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secRuleEngine = modsecurity::Rules::EnabledRuleEngine;
       }
-#line 1979 "seclang-parser.cc" // lalr1.cc:859
+#line 1984 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 80:
-#line 1197 "seclang-parser.yy" // lalr1.cc:859
+#line 1202 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secRuleEngine = modsecurity::Rules::DetectionOnlyRuleEngine;
       }
-#line 1987 "seclang-parser.cc" // lalr1.cc:859
+#line 1992 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 81:
-#line 1201 "seclang-parser.yy" // lalr1.cc:859
+#line 1206 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secRequestBodyAccess = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 1995 "seclang-parser.cc" // lalr1.cc:859
+#line 2000 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 82:
-#line 1205 "seclang-parser.yy" // lalr1.cc:859
+#line 1210 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secRequestBodyAccess = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 2003 "seclang-parser.cc" // lalr1.cc:859
+#line 2008 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 83:
-#line 1209 "seclang-parser.yy" // lalr1.cc:859
+#line 1214 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secResponseBodyAccess = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 2011 "seclang-parser.cc" // lalr1.cc:859
+#line 2016 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 84:
-#line 1213 "seclang-parser.yy" // lalr1.cc:859
+#line 1218 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secResponseBodyAccess = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 2019 "seclang-parser.cc" // lalr1.cc:859
+#line 2024 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 85:
-#line 1217 "seclang-parser.yy" // lalr1.cc:859
+#line 1222 "seclang-parser.yy" // lalr1.cc:859
     {
         if (yystack_[0].value.as< std::string > ().length() != 1) {
           driver.error(yystack_[1].location, "Argument separator should be set to a single character.");
@@ -2028,64 +2033,64 @@ namespace yy {
         driver.m_secArgumentSeparator.m_value = yystack_[0].value.as< std::string > ();
         driver.m_secArgumentSeparator.m_set = true;
       }
-#line 2032 "seclang-parser.cc" // lalr1.cc:859
+#line 2037 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 86:
-#line 1226 "seclang-parser.yy" // lalr1.cc:859
+#line 1231 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_components.push_back(yystack_[0].value.as< std::string > ());
       }
-#line 2040 "seclang-parser.cc" // lalr1.cc:859
+#line 2045 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 87:
-#line 1230 "seclang-parser.yy" // lalr1.cc:859
+#line 1235 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.error(yystack_[1].location, "SecWebAppId is not supported.");
         YYERROR;
       }
-#line 2049 "seclang-parser.cc" // lalr1.cc:859
+#line 2054 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 88:
-#line 1235 "seclang-parser.yy" // lalr1.cc:859
+#line 1240 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.error(yystack_[1].location, "SecServerSignature is not supported.");
         YYERROR;
       }
-#line 2058 "seclang-parser.cc" // lalr1.cc:859
+#line 2063 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 89:
-#line 1240 "seclang-parser.yy" // lalr1.cc:859
+#line 1245 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.error(yystack_[2].location, "ContentInjection is not yet supported.");
         YYERROR;
       }
-#line 2067 "seclang-parser.cc" // lalr1.cc:859
+#line 2072 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 90:
-#line 1245 "seclang-parser.yy" // lalr1.cc:859
+#line 1250 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.error(yystack_[1].location, "SecCacheTransformations is not supported.");
         YYERROR;
       }
-#line 2076 "seclang-parser.cc" // lalr1.cc:859
+#line 2081 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 91:
-#line 1250 "seclang-parser.yy" // lalr1.cc:859
+#line 1255 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.error(yystack_[2].location, "ContentInjection is not yet supported.");
         YYERROR;
       }
-#line 2085 "seclang-parser.cc" // lalr1.cc:859
+#line 2090 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 92:
-#line 1255 "seclang-parser.yy" // lalr1.cc:859
+#line 1260 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string error;
         if (driver.m_exceptions.load(yystack_[0].value.as< std::string > (), &error) == false) {
@@ -2098,11 +2103,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2102 "seclang-parser.cc" // lalr1.cc:859
+#line 2107 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 93:
-#line 1268 "seclang-parser.yy" // lalr1.cc:859
+#line 1273 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByMsg(yystack_[0].value.as< std::string > (), &error) == false) {
@@ -2115,11 +2120,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2119 "seclang-parser.cc" // lalr1.cc:859
+#line 2124 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 94:
-#line 1281 "seclang-parser.yy" // lalr1.cc:859
+#line 1286 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByTag(yystack_[1].value.as< std::string > (), std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2132,11 +2137,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2136 "seclang-parser.cc" // lalr1.cc:859
+#line 2141 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 95:
-#line 1294 "seclang-parser.yy" // lalr1.cc:859
+#line 1299 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByMsg(yystack_[1].value.as< std::string > (), std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2149,11 +2154,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2153 "seclang-parser.cc" // lalr1.cc:859
+#line 2158 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 96:
-#line 1307 "seclang-parser.yy" // lalr1.cc:859
+#line 1312 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string error;
         double ruleId;
@@ -2179,11 +2184,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2183 "seclang-parser.cc" // lalr1.cc:859
+#line 2188 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 97:
-#line 1333 "seclang-parser.yy" // lalr1.cc:859
+#line 1338 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string error;
         double ruleId;
@@ -2208,11 +2213,11 @@ namespace yy {
         driver.error(yystack_[2].location, "SecRuleUpdateActionById is not yet supported");
         YYERROR;
       }
-#line 2212 "seclang-parser.cc" // lalr1.cc:859
+#line 2217 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 98:
-#line 1359 "seclang-parser.yy" // lalr1.cc:859
+#line 1364 "seclang-parser.yy" // lalr1.cc:859
     {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as< std::string > ().c_str()));
@@ -2224,11 +2229,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2228 "seclang-parser.cc" // lalr1.cc:859
+#line 2233 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 99:
-#line 1371 "seclang-parser.yy" // lalr1.cc:859
+#line 1376 "seclang-parser.yy" // lalr1.cc:859
     {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -2247,11 +2252,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2251 "seclang-parser.cc" // lalr1.cc:859
+#line 2256 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 100:
-#line 1391 "seclang-parser.yy" // lalr1.cc:859
+#line 1396 "seclang-parser.yy" // lalr1.cc:859
     {
 #ifdef WITH_GEOIP
         std::string err;
@@ -2278,29 +2283,29 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 2282 "seclang-parser.cc" // lalr1.cc:859
+#line 2287 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 101:
-#line 1419 "seclang-parser.yy" // lalr1.cc:859
+#line 1424 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_requestBodyLimit.m_set = true;
         driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as< std::string > ().c_str());
       }
-#line 2291 "seclang-parser.cc" // lalr1.cc:859
+#line 2296 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 102:
-#line 1424 "seclang-parser.yy" // lalr1.cc:859
+#line 1429 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_requestBodyNoFilesLimit.m_set = true;
         driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as< std::string > ().c_str());
       }
-#line 2300 "seclang-parser.cc" // lalr1.cc:859
+#line 2305 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 103:
-#line 1429 "seclang-parser.yy" // lalr1.cc:859
+#line 1434 "seclang-parser.yy" // lalr1.cc:859
     {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -2309,68 +2314,68 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 2313 "seclang-parser.cc" // lalr1.cc:859
+#line 2318 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 104:
-#line 1438 "seclang-parser.yy" // lalr1.cc:859
+#line 1443 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_responseBodyLimit.m_set = true;
         driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as< std::string > ().c_str());
       }
-#line 2322 "seclang-parser.cc" // lalr1.cc:859
+#line 2327 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 105:
-#line 1443 "seclang-parser.yy" // lalr1.cc:859
+#line 1448 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_requestBodyLimitAction = modsecurity::Rules::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 2330 "seclang-parser.cc" // lalr1.cc:859
+#line 2335 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 106:
-#line 1447 "seclang-parser.yy" // lalr1.cc:859
+#line 1452 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_requestBodyLimitAction = modsecurity::Rules::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 2338 "seclang-parser.cc" // lalr1.cc:859
+#line 2343 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 107:
-#line 1451 "seclang-parser.yy" // lalr1.cc:859
+#line 1456 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_responseBodyLimitAction = modsecurity::Rules::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 2346 "seclang-parser.cc" // lalr1.cc:859
+#line 2351 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 108:
-#line 1455 "seclang-parser.yy" // lalr1.cc:859
+#line 1460 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_responseBodyLimitAction = modsecurity::Rules::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 2354 "seclang-parser.cc" // lalr1.cc:859
+#line 2359 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 109:
-#line 1459 "seclang-parser.yy" // lalr1.cc:859
+#line 1464 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_remoteRulesActionOnFailed = Rules::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 2362 "seclang-parser.cc" // lalr1.cc:859
+#line 2367 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 110:
-#line 1463 "seclang-parser.yy" // lalr1.cc:859
+#line 1468 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_remoteRulesActionOnFailed = Rules::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 2370 "seclang-parser.cc" // lalr1.cc:859
+#line 2375 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 113:
-#line 1469 "seclang-parser.yy" // lalr1.cc:859
+#line 1474 "seclang-parser.yy" // lalr1.cc:859
     {
         std::istringstream buf(yystack_[0].value.as< std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -2382,2184 +2387,2184 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 2386 "seclang-parser.cc" // lalr1.cc:859
+#line 2391 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 114:
-#line 1481 "seclang-parser.yy" // lalr1.cc:859
+#line 1486 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 2396 "seclang-parser.cc" // lalr1.cc:859
+#line 2401 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 115:
-#line 1487 "seclang-parser.yy" // lalr1.cc:859
+#line 1492 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secXMLExternalEntity = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 2404 "seclang-parser.cc" // lalr1.cc:859
+#line 2409 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 116:
-#line 1491 "seclang-parser.yy" // lalr1.cc:859
+#line 1496 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_secXMLExternalEntity = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 2412 "seclang-parser.cc" // lalr1.cc:859
+#line 2417 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 123:
-#line 1501 "seclang-parser.yy" // lalr1.cc:859
+#line 1506 "seclang-parser.yy" // lalr1.cc:859
     {
       }
-#line 2419 "seclang-parser.cc" // lalr1.cc:859
+#line 2424 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 124:
-#line 1504 "seclang-parser.yy" // lalr1.cc:859
+#line 1509 "seclang-parser.yy" // lalr1.cc:859
     {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as< std::string > ();
       }
-#line 2428 "seclang-parser.cc" // lalr1.cc:859
+#line 2433 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 125:
-#line 1512 "seclang-parser.yy" // lalr1.cc:859
+#line 1517 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2436 "seclang-parser.cc" // lalr1.cc:859
+#line 2441 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 126:
-#line 1516 "seclang-parser.yy" // lalr1.cc:859
+#line 1521 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2444 "seclang-parser.cc" // lalr1.cc:859
+#line 2449 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 127:
-#line 1523 "seclang-parser.yy" // lalr1.cc:859
+#line 1528 "seclang-parser.yy" // lalr1.cc:859
     {
         yystack_[2].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ()));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2453 "seclang-parser.cc" // lalr1.cc:859
+#line 2458 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 128:
-#line 1528 "seclang-parser.yy" // lalr1.cc:859
+#line 1533 "seclang-parser.yy" // lalr1.cc:859
     {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2463 "seclang-parser.cc" // lalr1.cc:859
+#line 2468 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 129:
-#line 1534 "seclang-parser.yy" // lalr1.cc:859
+#line 1539 "seclang-parser.yy" // lalr1.cc:859
     {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2473 "seclang-parser.cc" // lalr1.cc:859
+#line 2478 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 130:
-#line 1540 "seclang-parser.yy" // lalr1.cc:859
+#line 1545 "seclang-parser.yy" // lalr1.cc:859
     {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ()));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 2483 "seclang-parser.cc" // lalr1.cc:859
+#line 2488 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 131:
-#line 1546 "seclang-parser.yy" // lalr1.cc:859
+#line 1551 "seclang-parser.yy" // lalr1.cc:859
     {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 2494 "seclang-parser.cc" // lalr1.cc:859
+#line 2499 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 132:
-#line 1553 "seclang-parser.yy" // lalr1.cc:859
+#line 1558 "seclang-parser.yy" // lalr1.cc:859
     {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 2505 "seclang-parser.cc" // lalr1.cc:859
+#line 2510 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 133:
-#line 1563 "seclang-parser.yy" // lalr1.cc:859
+#line 1568 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Args_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2513 "seclang-parser.cc" // lalr1.cc:859
+#line 2518 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 134:
-#line 1567 "seclang-parser.yy" // lalr1.cc:859
+#line 1572 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Args_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2521 "seclang-parser.cc" // lalr1.cc:859
+#line 2526 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 135:
-#line 1571 "seclang-parser.yy" // lalr1.cc:859
+#line 1576 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Args_NoDictElement());
       }
-#line 2529 "seclang-parser.cc" // lalr1.cc:859
+#line 2534 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 136:
-#line 1575 "seclang-parser.yy" // lalr1.cc:859
+#line 1580 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPost_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2537 "seclang-parser.cc" // lalr1.cc:859
+#line 2542 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 137:
-#line 1579 "seclang-parser.yy" // lalr1.cc:859
+#line 1584 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPost_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2545 "seclang-parser.cc" // lalr1.cc:859
+#line 2550 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 138:
-#line 1583 "seclang-parser.yy" // lalr1.cc:859
+#line 1588 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPost_NoDictElement());
       }
-#line 2553 "seclang-parser.cc" // lalr1.cc:859
+#line 2558 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 139:
-#line 1587 "seclang-parser.yy" // lalr1.cc:859
+#line 1592 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGet_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2561 "seclang-parser.cc" // lalr1.cc:859
+#line 2566 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 140:
-#line 1591 "seclang-parser.yy" // lalr1.cc:859
+#line 1596 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGet_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2569 "seclang-parser.cc" // lalr1.cc:859
+#line 2574 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 141:
-#line 1595 "seclang-parser.yy" // lalr1.cc:859
+#line 1600 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGet_NoDictElement());
       }
-#line 2577 "seclang-parser.cc" // lalr1.cc:859
+#line 2582 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 142:
-#line 1599 "seclang-parser.yy" // lalr1.cc:859
+#line 1604 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesSizes_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2585 "seclang-parser.cc" // lalr1.cc:859
+#line 2590 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 143:
-#line 1603 "seclang-parser.yy" // lalr1.cc:859
+#line 1608 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesSizes_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2593 "seclang-parser.cc" // lalr1.cc:859
+#line 2598 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 144:
-#line 1607 "seclang-parser.yy" // lalr1.cc:859
+#line 1612 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesSizes_NoDictElement());
       }
-#line 2601 "seclang-parser.cc" // lalr1.cc:859
+#line 2606 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 145:
-#line 1611 "seclang-parser.yy" // lalr1.cc:859
+#line 1616 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2609 "seclang-parser.cc" // lalr1.cc:859
+#line 2614 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 146:
-#line 1615 "seclang-parser.yy" // lalr1.cc:859
+#line 1620 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2617 "seclang-parser.cc" // lalr1.cc:859
+#line 2622 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 147:
-#line 1619 "seclang-parser.yy" // lalr1.cc:859
+#line 1624 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesNames_NoDictElement());
       }
-#line 2625 "seclang-parser.cc" // lalr1.cc:859
+#line 2630 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 148:
-#line 1623 "seclang-parser.yy" // lalr1.cc:859
+#line 1628 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpContent_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2633 "seclang-parser.cc" // lalr1.cc:859
+#line 2638 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 149:
-#line 1627 "seclang-parser.yy" // lalr1.cc:859
+#line 1632 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2641 "seclang-parser.cc" // lalr1.cc:859
+#line 2646 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 150:
-#line 1631 "seclang-parser.yy" // lalr1.cc:859
+#line 1636 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpContent_NoDictElement());
       }
-#line 2649 "seclang-parser.cc" // lalr1.cc:859
+#line 2654 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 151:
-#line 1635 "seclang-parser.yy" // lalr1.cc:859
+#line 1640 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartFileName_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2657 "seclang-parser.cc" // lalr1.cc:859
+#line 2662 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 152:
-#line 1639 "seclang-parser.yy" // lalr1.cc:859
+#line 1644 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2665 "seclang-parser.cc" // lalr1.cc:859
+#line 2670 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 153:
-#line 1643 "seclang-parser.yy" // lalr1.cc:859
+#line 1648 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartFileName_NoDictElement());
       }
-#line 2673 "seclang-parser.cc" // lalr1.cc:859
+#line 2678 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 154:
-#line 1647 "seclang-parser.yy" // lalr1.cc:859
+#line 1652 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartName_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2681 "seclang-parser.cc" // lalr1.cc:859
+#line 2686 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 155:
-#line 1651 "seclang-parser.yy" // lalr1.cc:859
+#line 1656 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartName_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2689 "seclang-parser.cc" // lalr1.cc:859
+#line 2694 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 156:
-#line 1655 "seclang-parser.yy" // lalr1.cc:859
+#line 1660 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartName_NoDictElement());
       }
-#line 2697 "seclang-parser.cc" // lalr1.cc:859
+#line 2702 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 157:
-#line 1659 "seclang-parser.yy" // lalr1.cc:859
+#line 1664 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarsNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2705 "seclang-parser.cc" // lalr1.cc:859
+#line 2710 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 158:
-#line 1663 "seclang-parser.yy" // lalr1.cc:859
+#line 1668 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2713 "seclang-parser.cc" // lalr1.cc:859
+#line 2718 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 159:
-#line 1667 "seclang-parser.yy" // lalr1.cc:859
+#line 1672 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarsNames_NoDictElement());
       }
-#line 2721 "seclang-parser.cc" // lalr1.cc:859
+#line 2726 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 160:
-#line 1671 "seclang-parser.yy" // lalr1.cc:859
+#line 1676 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVars_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2729 "seclang-parser.cc" // lalr1.cc:859
+#line 2734 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 161:
-#line 1675 "seclang-parser.yy" // lalr1.cc:859
+#line 1680 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVars_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2737 "seclang-parser.cc" // lalr1.cc:859
+#line 2742 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 162:
-#line 1679 "seclang-parser.yy" // lalr1.cc:859
+#line 1684 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVars_NoDictElement());
       }
-#line 2745 "seclang-parser.cc" // lalr1.cc:859
+#line 2750 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 163:
-#line 1683 "seclang-parser.yy" // lalr1.cc:859
+#line 1688 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Files_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2753 "seclang-parser.cc" // lalr1.cc:859
+#line 2758 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 164:
-#line 1687 "seclang-parser.yy" // lalr1.cc:859
+#line 1692 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Files_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2761 "seclang-parser.cc" // lalr1.cc:859
+#line 2766 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 165:
-#line 1691 "seclang-parser.yy" // lalr1.cc:859
+#line 1696 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Files_NoDictElement());
       }
-#line 2769 "seclang-parser.cc" // lalr1.cc:859
+#line 2774 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 166:
-#line 1695 "seclang-parser.yy" // lalr1.cc:859
+#line 1700 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookies_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2777 "seclang-parser.cc" // lalr1.cc:859
+#line 2782 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 167:
-#line 1699 "seclang-parser.yy" // lalr1.cc:859
+#line 1704 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookies_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2785 "seclang-parser.cc" // lalr1.cc:859
+#line 2790 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 168:
-#line 1703 "seclang-parser.yy" // lalr1.cc:859
+#line 1708 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookies_NoDictElement());
       }
-#line 2793 "seclang-parser.cc" // lalr1.cc:859
+#line 2798 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 169:
-#line 1707 "seclang-parser.yy" // lalr1.cc:859
+#line 1712 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeaders_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2801 "seclang-parser.cc" // lalr1.cc:859
+#line 2806 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 170:
-#line 1711 "seclang-parser.yy" // lalr1.cc:859
+#line 1716 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2809 "seclang-parser.cc" // lalr1.cc:859
+#line 2814 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 171:
-#line 1715 "seclang-parser.yy" // lalr1.cc:859
+#line 1720 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeaders_NoDictElement());
       }
-#line 2817 "seclang-parser.cc" // lalr1.cc:859
+#line 2822 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 172:
-#line 1719 "seclang-parser.yy" // lalr1.cc:859
+#line 1724 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeaders_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2825 "seclang-parser.cc" // lalr1.cc:859
+#line 2830 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 173:
-#line 1723 "seclang-parser.yy" // lalr1.cc:859
+#line 1728 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2833 "seclang-parser.cc" // lalr1.cc:859
+#line 2838 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 174:
-#line 1727 "seclang-parser.yy" // lalr1.cc:859
+#line 1732 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeaders_NoDictElement());
       }
-#line 2841 "seclang-parser.cc" // lalr1.cc:859
+#line 2846 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 175:
-#line 1731 "seclang-parser.yy" // lalr1.cc:859
+#line 1736 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Geo_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2849 "seclang-parser.cc" // lalr1.cc:859
+#line 2854 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 176:
-#line 1735 "seclang-parser.yy" // lalr1.cc:859
+#line 1740 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Geo_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2857 "seclang-parser.cc" // lalr1.cc:859
+#line 2862 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 177:
-#line 1739 "seclang-parser.yy" // lalr1.cc:859
+#line 1744 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Geo_NoDictElement());
       }
-#line 2865 "seclang-parser.cc" // lalr1.cc:859
+#line 2870 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 178:
-#line 1743 "seclang-parser.yy" // lalr1.cc:859
+#line 1748 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookiesNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2873 "seclang-parser.cc" // lalr1.cc:859
+#line 2878 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 179:
-#line 1747 "seclang-parser.yy" // lalr1.cc:859
+#line 1752 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2881 "seclang-parser.cc" // lalr1.cc:859
+#line 2886 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 180:
-#line 1751 "seclang-parser.yy" // lalr1.cc:859
+#line 1756 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookiesNames_NoDictElement());
       }
-#line 2889 "seclang-parser.cc" // lalr1.cc:859
+#line 2894 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 181:
-#line 1755 "seclang-parser.yy" // lalr1.cc:859
+#line 1760 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Rule_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2897 "seclang-parser.cc" // lalr1.cc:859
+#line 2902 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 182:
-#line 1759 "seclang-parser.yy" // lalr1.cc:859
+#line 1764 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Rule_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2905 "seclang-parser.cc" // lalr1.cc:859
+#line 2910 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 183:
-#line 1763 "seclang-parser.yy" // lalr1.cc:859
+#line 1768 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Rule_NoDictElement());
       }
-#line 2913 "seclang-parser.cc" // lalr1.cc:859
+#line 2918 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 184:
-#line 1767 "seclang-parser.yy" // lalr1.cc:859
+#line 1772 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Env("ENV:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2921 "seclang-parser.cc" // lalr1.cc:859
+#line 2926 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 185:
-#line 1771 "seclang-parser.yy" // lalr1.cc:859
+#line 1776 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Env("ENV:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2929 "seclang-parser.cc" // lalr1.cc:859
+#line 2934 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 186:
-#line 1775 "seclang-parser.yy" // lalr1.cc:859
+#line 1780 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Env("ENV"));
       }
-#line 2937 "seclang-parser.cc" // lalr1.cc:859
+#line 2942 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 187:
-#line 1779 "seclang-parser.yy" // lalr1.cc:859
+#line 1784 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::XML("XML:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2945 "seclang-parser.cc" // lalr1.cc:859
+#line 2950 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 188:
-#line 1783 "seclang-parser.yy" // lalr1.cc:859
+#line 1788 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::XML("XML:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2953 "seclang-parser.cc" // lalr1.cc:859
+#line 2958 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 189:
-#line 1787 "seclang-parser.yy" // lalr1.cc:859
+#line 1792 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::XML_NoDictElement());
       }
-#line 2961 "seclang-parser.cc" // lalr1.cc:859
+#line 2966 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 190:
-#line 1791 "seclang-parser.yy" // lalr1.cc:859
+#line 1796 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2969 "seclang-parser.cc" // lalr1.cc:859
+#line 2974 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 191:
-#line 1795 "seclang-parser.yy" // lalr1.cc:859
+#line 1800 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2977 "seclang-parser.cc" // lalr1.cc:859
+#line 2982 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 192:
-#line 1799 "seclang-parser.yy" // lalr1.cc:859
+#line 1804 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpNames_NoDictElement());
       }
-#line 2985 "seclang-parser.cc" // lalr1.cc:859
+#line 2990 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 193:
-#line 1803 "seclang-parser.yy" // lalr1.cc:859
+#line 1808 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2993 "seclang-parser.cc" // lalr1.cc:859
+#line 2998 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 194:
-#line 1807 "seclang-parser.yy" // lalr1.cc:859
+#line 1812 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3001 "seclang-parser.cc" // lalr1.cc:859
+#line 3006 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 195:
-#line 1811 "seclang-parser.yy" // lalr1.cc:859
+#line 1816 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_NoDictElement());
       }
-#line 3009 "seclang-parser.cc" // lalr1.cc:859
+#line 3014 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 196:
-#line 1816 "seclang-parser.yy" // lalr1.cc:859
+#line 1821 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3017 "seclang-parser.cc" // lalr1.cc:859
+#line 3022 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 197:
-#line 1820 "seclang-parser.yy" // lalr1.cc:859
+#line 1825 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3025 "seclang-parser.cc" // lalr1.cc:859
+#line 3030 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 198:
-#line 1824 "seclang-parser.yy" // lalr1.cc:859
+#line 1829 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_NoDictElement());
       }
-#line 3033 "seclang-parser.cc" // lalr1.cc:859
+#line 3038 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 199:
-#line 1829 "seclang-parser.yy" // lalr1.cc:859
+#line 1834 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3041 "seclang-parser.cc" // lalr1.cc:859
+#line 3046 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 200:
-#line 1833 "seclang-parser.yy" // lalr1.cc:859
+#line 1838 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3049 "seclang-parser.cc" // lalr1.cc:859
+#line 3054 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 201:
-#line 1837 "seclang-parser.yy" // lalr1.cc:859
+#line 1842 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_NoDictElement());
       }
-#line 3057 "seclang-parser.cc" // lalr1.cc:859
+#line 3062 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 202:
-#line 1842 "seclang-parser.yy" // lalr1.cc:859
+#line 1847 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3065 "seclang-parser.cc" // lalr1.cc:859
+#line 3070 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 203:
-#line 1846 "seclang-parser.yy" // lalr1.cc:859
+#line 1851 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3073 "seclang-parser.cc" // lalr1.cc:859
+#line 3078 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 204:
-#line 1850 "seclang-parser.yy" // lalr1.cc:859
+#line 1855 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_NoDictElement());
       }
-#line 3081 "seclang-parser.cc" // lalr1.cc:859
+#line 3086 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 205:
-#line 1855 "seclang-parser.yy" // lalr1.cc:859
+#line 1860 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3089 "seclang-parser.cc" // lalr1.cc:859
+#line 3094 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 206:
-#line 1859 "seclang-parser.yy" // lalr1.cc:859
+#line 1864 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3097 "seclang-parser.cc" // lalr1.cc:859
+#line 3102 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 207:
-#line 1863 "seclang-parser.yy" // lalr1.cc:859
+#line 1868 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_NoDictElement());
       }
-#line 3105 "seclang-parser.cc" // lalr1.cc:859
+#line 3110 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 208:
-#line 1868 "seclang-parser.yy" // lalr1.cc:859
+#line 1873 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3113 "seclang-parser.cc" // lalr1.cc:859
+#line 3118 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 209:
-#line 1872 "seclang-parser.yy" // lalr1.cc:859
+#line 1877 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3121 "seclang-parser.cc" // lalr1.cc:859
+#line 3126 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 210:
-#line 1876 "seclang-parser.yy" // lalr1.cc:859
+#line 1881 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsNames_NoDictElement());
       }
-#line 3129 "seclang-parser.cc" // lalr1.cc:859
+#line 3134 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 211:
-#line 1880 "seclang-parser.yy" // lalr1.cc:859
+#line 1885 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGetNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3137 "seclang-parser.cc" // lalr1.cc:859
+#line 3142 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 212:
-#line 1884 "seclang-parser.yy" // lalr1.cc:859
+#line 1889 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3145 "seclang-parser.cc" // lalr1.cc:859
+#line 3150 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 213:
-#line 1888 "seclang-parser.yy" // lalr1.cc:859
+#line 1893 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGetNames_NoDictElement());
       }
-#line 3153 "seclang-parser.cc" // lalr1.cc:859
+#line 3158 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 214:
-#line 1893 "seclang-parser.yy" // lalr1.cc:859
+#line 1898 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPostNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3161 "seclang-parser.cc" // lalr1.cc:859
+#line 3166 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 215:
-#line 1897 "seclang-parser.yy" // lalr1.cc:859
+#line 1902 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3169 "seclang-parser.cc" // lalr1.cc:859
+#line 3174 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 216:
-#line 1901 "seclang-parser.yy" // lalr1.cc:859
+#line 1906 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPostNames_NoDictElement());
       }
-#line 3177 "seclang-parser.cc" // lalr1.cc:859
+#line 3182 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 217:
-#line 1906 "seclang-parser.yy" // lalr1.cc:859
+#line 1911 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeadersNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3185 "seclang-parser.cc" // lalr1.cc:859
+#line 3190 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 218:
-#line 1910 "seclang-parser.yy" // lalr1.cc:859
+#line 1915 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3193 "seclang-parser.cc" // lalr1.cc:859
+#line 3198 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 219:
-#line 1914 "seclang-parser.yy" // lalr1.cc:859
+#line 1919 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeadersNames_NoDictElement());
       }
-#line 3201 "seclang-parser.cc" // lalr1.cc:859
+#line 3206 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 220:
-#line 1919 "seclang-parser.yy" // lalr1.cc:859
+#line 1924 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseContentType());
       }
-#line 3209 "seclang-parser.cc" // lalr1.cc:859
+#line 3214 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 221:
-#line 1924 "seclang-parser.yy" // lalr1.cc:859
+#line 1929 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeadersNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3217 "seclang-parser.cc" // lalr1.cc:859
+#line 3222 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 222:
-#line 1928 "seclang-parser.yy" // lalr1.cc:859
+#line 1933 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3225 "seclang-parser.cc" // lalr1.cc:859
+#line 3230 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 223:
-#line 1932 "seclang-parser.yy" // lalr1.cc:859
+#line 1937 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeadersNames_NoDictElement());
       }
-#line 3233 "seclang-parser.cc" // lalr1.cc:859
+#line 3238 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 224:
-#line 1936 "seclang-parser.yy" // lalr1.cc:859
+#line 1941 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsCombinedSize());
       }
-#line 3241 "seclang-parser.cc" // lalr1.cc:859
+#line 3246 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 225:
-#line 1940 "seclang-parser.yy" // lalr1.cc:859
+#line 1945 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::AuthType());
       }
-#line 3249 "seclang-parser.cc" // lalr1.cc:859
+#line 3254 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 226:
-#line 1944 "seclang-parser.yy" // lalr1.cc:859
+#line 1949 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesCombinedSize());
       }
-#line 3257 "seclang-parser.cc" // lalr1.cc:859
+#line 3262 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 227:
-#line 1948 "seclang-parser.yy" // lalr1.cc:859
+#line 1953 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FullRequest());
       }
-#line 3265 "seclang-parser.cc" // lalr1.cc:859
+#line 3270 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 228:
-#line 1952 "seclang-parser.yy" // lalr1.cc:859
+#line 1957 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FullRequestLength());
       }
-#line 3273 "seclang-parser.cc" // lalr1.cc:859
+#line 3278 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 229:
-#line 1956 "seclang-parser.yy" // lalr1.cc:859
+#line 1961 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::InboundDataError());
       }
-#line 3281 "seclang-parser.cc" // lalr1.cc:859
+#line 3286 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 230:
-#line 1960 "seclang-parser.yy" // lalr1.cc:859
+#line 1965 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVar());
       }
-#line 3289 "seclang-parser.cc" // lalr1.cc:859
+#line 3294 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 231:
-#line 1964 "seclang-parser.yy" // lalr1.cc:859
+#line 1969 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarName());
       }
-#line 3297 "seclang-parser.cc" // lalr1.cc:859
+#line 3302 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 232:
-#line 1968 "seclang-parser.yy" // lalr1.cc:859
+#line 1973 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartCrlfLFLines());
       }
-#line 3305 "seclang-parser.cc" // lalr1.cc:859
+#line 3310 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 233:
-#line 1972 "seclang-parser.yy" // lalr1.cc:859
+#line 1977 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartDateAfter());
       }
-#line 3313 "seclang-parser.cc" // lalr1.cc:859
+#line 3318 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 234:
-#line 1976 "seclang-parser.yy" // lalr1.cc:859
+#line 1981 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartFileLimitExceeded());
       }
-#line 3321 "seclang-parser.cc" // lalr1.cc:859
+#line 3326 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 235:
-#line 1980 "seclang-parser.yy" // lalr1.cc:859
+#line 1985 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartHeaderFolding());
       }
-#line 3329 "seclang-parser.cc" // lalr1.cc:859
+#line 3334 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 236:
-#line 1984 "seclang-parser.yy" // lalr1.cc:859
+#line 1989 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartInvalidHeaderFolding());
       }
-#line 3337 "seclang-parser.cc" // lalr1.cc:859
+#line 3342 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 237:
-#line 1988 "seclang-parser.yy" // lalr1.cc:859
+#line 1993 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartInvalidQuoting());
       }
-#line 3345 "seclang-parser.cc" // lalr1.cc:859
+#line 3350 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 238:
-#line 1992 "seclang-parser.yy" // lalr1.cc:859
+#line 1997 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartStrictError());
       }
-#line 3353 "seclang-parser.cc" // lalr1.cc:859
+#line 3358 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 239:
-#line 1996 "seclang-parser.yy" // lalr1.cc:859
+#line 2001 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartUnmatchedBoundary());
       }
-#line 3361 "seclang-parser.cc" // lalr1.cc:859
+#line 3366 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 240:
-#line 2000 "seclang-parser.yy" // lalr1.cc:859
+#line 2005 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::OutboundDataError());
       }
-#line 3369 "seclang-parser.cc" // lalr1.cc:859
+#line 3374 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 241:
-#line 2004 "seclang-parser.yy" // lalr1.cc:859
+#line 2009 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::PathInfo());
       }
-#line 3377 "seclang-parser.cc" // lalr1.cc:859
+#line 3382 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 242:
-#line 2008 "seclang-parser.yy" // lalr1.cc:859
+#line 2013 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::QueryString());
       }
-#line 3385 "seclang-parser.cc" // lalr1.cc:859
+#line 3390 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 243:
-#line 2012 "seclang-parser.yy" // lalr1.cc:859
+#line 2017 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RemoteAddr());
       }
-#line 3393 "seclang-parser.cc" // lalr1.cc:859
+#line 3398 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 244:
-#line 2016 "seclang-parser.yy" // lalr1.cc:859
+#line 2021 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RemoteHost());
       }
-#line 3401 "seclang-parser.cc" // lalr1.cc:859
+#line 3406 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 245:
-#line 2020 "seclang-parser.yy" // lalr1.cc:859
+#line 2025 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RemotePort());
       }
-#line 3409 "seclang-parser.cc" // lalr1.cc:859
+#line 3414 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 246:
-#line 2024 "seclang-parser.yy" // lalr1.cc:859
+#line 2029 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyError());
       }
-#line 3417 "seclang-parser.cc" // lalr1.cc:859
+#line 3422 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 247:
-#line 2028 "seclang-parser.yy" // lalr1.cc:859
+#line 2033 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyErrorMsg());
       }
-#line 3425 "seclang-parser.cc" // lalr1.cc:859
+#line 3430 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 248:
-#line 2032 "seclang-parser.yy" // lalr1.cc:859
+#line 2037 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyProcessor());
       }
-#line 3433 "seclang-parser.cc" // lalr1.cc:859
+#line 3438 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 249:
-#line 2036 "seclang-parser.yy" // lalr1.cc:859
+#line 2041 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyProcessorError());
       }
-#line 3441 "seclang-parser.cc" // lalr1.cc:859
+#line 3446 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 250:
-#line 2040 "seclang-parser.yy" // lalr1.cc:859
+#line 2045 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyProcessorErrorMsg());
       }
-#line 3449 "seclang-parser.cc" // lalr1.cc:859
+#line 3454 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 251:
-#line 2044 "seclang-parser.yy" // lalr1.cc:859
+#line 2049 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestBasename());
       }
-#line 3457 "seclang-parser.cc" // lalr1.cc:859
+#line 3462 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 252:
-#line 2048 "seclang-parser.yy" // lalr1.cc:859
+#line 2053 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestBody());
       }
-#line 3465 "seclang-parser.cc" // lalr1.cc:859
+#line 3470 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 253:
-#line 2052 "seclang-parser.yy" // lalr1.cc:859
+#line 2057 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestBodyLength());
       }
-#line 3473 "seclang-parser.cc" // lalr1.cc:859
+#line 3478 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 254:
-#line 2056 "seclang-parser.yy" // lalr1.cc:859
+#line 2061 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestFilename());
       }
-#line 3481 "seclang-parser.cc" // lalr1.cc:859
+#line 3486 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 255:
-#line 2060 "seclang-parser.yy" // lalr1.cc:859
+#line 2065 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestLine());
       }
-#line 3489 "seclang-parser.cc" // lalr1.cc:859
+#line 3494 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 256:
-#line 2064 "seclang-parser.yy" // lalr1.cc:859
+#line 2069 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestMethod());
       }
-#line 3497 "seclang-parser.cc" // lalr1.cc:859
+#line 3502 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 257:
-#line 2068 "seclang-parser.yy" // lalr1.cc:859
+#line 2073 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestProtocol());
       }
-#line 3505 "seclang-parser.cc" // lalr1.cc:859
+#line 3510 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 258:
-#line 2072 "seclang-parser.yy" // lalr1.cc:859
+#line 2077 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestURI());
       }
-#line 3513 "seclang-parser.cc" // lalr1.cc:859
+#line 3518 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 259:
-#line 2076 "seclang-parser.yy" // lalr1.cc:859
+#line 2081 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestURIRaw());
       }
-#line 3521 "seclang-parser.cc" // lalr1.cc:859
+#line 3526 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 260:
-#line 2080 "seclang-parser.yy" // lalr1.cc:859
+#line 2085 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseBody());
       }
-#line 3529 "seclang-parser.cc" // lalr1.cc:859
+#line 3534 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 261:
-#line 2084 "seclang-parser.yy" // lalr1.cc:859
+#line 2089 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseContentLength());
       }
-#line 3537 "seclang-parser.cc" // lalr1.cc:859
+#line 3542 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 262:
-#line 2088 "seclang-parser.yy" // lalr1.cc:859
+#line 2093 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseProtocol());
       }
-#line 3545 "seclang-parser.cc" // lalr1.cc:859
+#line 3550 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 263:
-#line 2092 "seclang-parser.yy" // lalr1.cc:859
+#line 2097 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseStatus());
       }
-#line 3553 "seclang-parser.cc" // lalr1.cc:859
+#line 3558 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 264:
-#line 2096 "seclang-parser.yy" // lalr1.cc:859
+#line 2101 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ServerAddr());
       }
-#line 3561 "seclang-parser.cc" // lalr1.cc:859
+#line 3566 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 265:
-#line 2100 "seclang-parser.yy" // lalr1.cc:859
+#line 2105 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ServerName());
       }
-#line 3569 "seclang-parser.cc" // lalr1.cc:859
+#line 3574 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 266:
-#line 2104 "seclang-parser.yy" // lalr1.cc:859
+#line 2109 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ServerPort());
       }
-#line 3577 "seclang-parser.cc" // lalr1.cc:859
+#line 3582 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 267:
-#line 2108 "seclang-parser.yy" // lalr1.cc:859
+#line 2113 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::SessionID());
       }
-#line 3585 "seclang-parser.cc" // lalr1.cc:859
+#line 3590 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 268:
-#line 2112 "seclang-parser.yy" // lalr1.cc:859
+#line 2117 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::UniqueID());
       }
-#line 3593 "seclang-parser.cc" // lalr1.cc:859
+#line 3598 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 269:
-#line 2116 "seclang-parser.yy" // lalr1.cc:859
+#line 2121 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::UrlEncodedError());
       }
-#line 3601 "seclang-parser.cc" // lalr1.cc:859
+#line 3606 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 270:
-#line 2120 "seclang-parser.yy" // lalr1.cc:859
+#line 2125 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::UserID());
       }
-#line 3609 "seclang-parser.cc" // lalr1.cc:859
+#line 3614 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 271:
-#line 2124 "seclang-parser.yy" // lalr1.cc:859
+#line 2129 "seclang-parser.yy" // lalr1.cc:859
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Status());
       }
-#line 3617 "seclang-parser.cc" // lalr1.cc:859
+#line 3622 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 272:
-#line 2128 "seclang-parser.yy" // lalr1.cc:859
+#line 2133 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3628 "seclang-parser.cc" // lalr1.cc:859
+#line 3633 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 273:
-#line 2136 "seclang-parser.yy" // lalr1.cc:859
+#line 2141 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3639 "seclang-parser.cc" // lalr1.cc:859
+#line 3644 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 274:
-#line 2143 "seclang-parser.yy" // lalr1.cc:859
+#line 2148 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3650 "seclang-parser.cc" // lalr1.cc:859
+#line 3655 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 275:
-#line 2150 "seclang-parser.yy" // lalr1.cc:859
+#line 2155 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3661 "seclang-parser.cc" // lalr1.cc:859
+#line 3666 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 276:
-#line 2157 "seclang-parser.yy" // lalr1.cc:859
+#line 2162 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3672 "seclang-parser.cc" // lalr1.cc:859
+#line 3677 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 277:
-#line 2164 "seclang-parser.yy" // lalr1.cc:859
+#line 2169 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3683 "seclang-parser.cc" // lalr1.cc:859
+#line 3688 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 278:
-#line 2171 "seclang-parser.yy" // lalr1.cc:859
+#line 2176 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3694 "seclang-parser.cc" // lalr1.cc:859
+#line 3699 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 279:
-#line 2178 "seclang-parser.yy" // lalr1.cc:859
+#line 2183 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3705 "seclang-parser.cc" // lalr1.cc:859
+#line 3710 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 280:
-#line 2185 "seclang-parser.yy" // lalr1.cc:859
+#line 2190 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3716 "seclang-parser.cc" // lalr1.cc:859
+#line 3721 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 281:
-#line 2192 "seclang-parser.yy" // lalr1.cc:859
+#line 2197 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3727 "seclang-parser.cc" // lalr1.cc:859
+#line 3732 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 282:
-#line 2199 "seclang-parser.yy" // lalr1.cc:859
+#line 2204 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3738 "seclang-parser.cc" // lalr1.cc:859
+#line 3743 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 283:
-#line 2206 "seclang-parser.yy" // lalr1.cc:859
+#line 2211 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3749 "seclang-parser.cc" // lalr1.cc:859
+#line 3754 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 284:
-#line 2213 "seclang-parser.yy" // lalr1.cc:859
+#line 2218 "seclang-parser.yy" // lalr1.cc:859
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3760 "seclang-parser.cc" // lalr1.cc:859
+#line 3765 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 285:
-#line 2223 "seclang-parser.yy" // lalr1.cc:859
+#line 2228 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as< std::string > ()));
       }
-#line 3768 "seclang-parser.cc" // lalr1.cc:859
+#line 3773 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 286:
-#line 2227 "seclang-parser.yy" // lalr1.cc:859
+#line 2232 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as< std::string > ()));
       }
-#line 3776 "seclang-parser.cc" // lalr1.cc:859
+#line 3781 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 287:
-#line 2231 "seclang-parser.yy" // lalr1.cc:859
+#line 2236 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 3784 "seclang-parser.cc" // lalr1.cc:859
+#line 3789 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 288:
-#line 2235 "seclang-parser.yy" // lalr1.cc:859
+#line 2240 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as< std::string > ()));
       }
-#line 3792 "seclang-parser.cc" // lalr1.cc:859
+#line 3797 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 289:
-#line 2239 "seclang-parser.yy" // lalr1.cc:859
+#line 2244 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Block(yystack_[0].value.as< std::string > ()));
       }
-#line 3800 "seclang-parser.cc" // lalr1.cc:859
+#line 3805 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 290:
-#line 2243 "seclang-parser.yy" // lalr1.cc:859
+#line 2248 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as< std::string > ()));
       }
-#line 3808 "seclang-parser.cc" // lalr1.cc:859
+#line 3813 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 291:
-#line 2247 "seclang-parser.yy" // lalr1.cc:859
+#line 2252 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as< std::string > ()));
       }
-#line 3816 "seclang-parser.cc" // lalr1.cc:859
+#line 3821 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 292:
-#line 2251 "seclang-parser.yy" // lalr1.cc:859
-    {
-        //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
-        ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
-      }
-#line 3825 "seclang-parser.cc" // lalr1.cc:859
-    break;
-
-  case 293:
 #line 2256 "seclang-parser.yy" // lalr1.cc:859
     {
         //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3834 "seclang-parser.cc" // lalr1.cc:859
+#line 3830 "seclang-parser.cc" // lalr1.cc:859
     break;
 
-  case 294:
+  case 293:
 #line 2261 "seclang-parser.yy" // lalr1.cc:859
     {
         //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3843 "seclang-parser.cc" // lalr1.cc:859
+#line 3839 "seclang-parser.cc" // lalr1.cc:859
+    break;
+
+  case 294:
+#line 2266 "seclang-parser.yy" // lalr1.cc:859
+    {
+        //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
+        ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
+      }
+#line 3848 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 295:
-#line 2266 "seclang-parser.yy" // lalr1.cc:859
+#line 2271 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as< std::string > ()));
       }
-#line 3851 "seclang-parser.cc" // lalr1.cc:859
+#line 3856 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 296:
-#line 2270 "seclang-parser.yy" // lalr1.cc:859
+#line 2275 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as< std::string > ()));
       }
-#line 3859 "seclang-parser.cc" // lalr1.cc:859
+#line 3864 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 297:
-#line 2274 "seclang-parser.yy" // lalr1.cc:859
+#line 2279 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as< std::string > ()));
       }
-#line 3867 "seclang-parser.cc" // lalr1.cc:859
+#line 3872 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 298:
-#line 2278 "seclang-parser.yy" // lalr1.cc:859
-    {
-        //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
-        ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
-      }
-#line 3876 "seclang-parser.cc" // lalr1.cc:859
-    break;
-
-  case 299:
 #line 2283 "seclang-parser.yy" // lalr1.cc:859
     {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3885 "seclang-parser.cc" // lalr1.cc:859
+#line 3881 "seclang-parser.cc" // lalr1.cc:859
+    break;
+
+  case 299:
+#line 2288 "seclang-parser.yy" // lalr1.cc:859
+    {
+        //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
+        ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
+      }
+#line 3890 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 300:
-#line 2288 "seclang-parser.yy" // lalr1.cc:859
+#line 2293 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as< std::string > () + "true"));
       }
-#line 3893 "seclang-parser.cc" // lalr1.cc:859
+#line 3898 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 301:
-#line 2292 "seclang-parser.yy" // lalr1.cc:859
+#line 2297 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as< std::string > () + "false"));
       }
-#line 3901 "seclang-parser.cc" // lalr1.cc:859
+#line 3906 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 302:
-#line 2296 "seclang-parser.yy" // lalr1.cc:859
+#line 2301 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 3909 "seclang-parser.cc" // lalr1.cc:859
+#line 3914 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 303:
-#line 2300 "seclang-parser.yy" // lalr1.cc:859
+#line 2305 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 3917 "seclang-parser.cc" // lalr1.cc:859
+#line 3922 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 304:
-#line 2304 "seclang-parser.yy" // lalr1.cc:859
+#line 2309 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 3925 "seclang-parser.cc" // lalr1.cc:859
+#line 3930 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 305:
-#line 2308 "seclang-parser.yy" // lalr1.cc:859
+#line 2313 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as< std::string > ()));
       }
-#line 3933 "seclang-parser.cc" // lalr1.cc:859
+#line 3938 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 306:
-#line 2312 "seclang-parser.yy" // lalr1.cc:859
+#line 2317 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as< std::string > ()));
       }
-#line 3941 "seclang-parser.cc" // lalr1.cc:859
+#line 3946 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 307:
-#line 2316 "seclang-parser.yy" // lalr1.cc:859
+#line 2321 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as< std::string > ()));
       }
-#line 3949 "seclang-parser.cc" // lalr1.cc:859
+#line 3954 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 308:
-#line 2320 "seclang-parser.yy" // lalr1.cc:859
+#line 2325 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as< std::string > ()));
       }
-#line 3957 "seclang-parser.cc" // lalr1.cc:859
+#line 3962 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 309:
-#line 2324 "seclang-parser.yy" // lalr1.cc:859
+#line 2329 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 3965 "seclang-parser.cc" // lalr1.cc:859
+#line 3970 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 310:
-#line 2328 "seclang-parser.yy" // lalr1.cc:859
+#line 2333 "seclang-parser.yy" // lalr1.cc:859
     {
         //ACTION_NOT_SUPPORTED("Drop", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[0].value.as< std::string > ()));
       }
-#line 3974 "seclang-parser.cc" // lalr1.cc:859
+#line 3979 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 311:
-#line 2333 "seclang-parser.yy" // lalr1.cc:859
+#line 2338 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as< std::string > ()));
       }
-#line 3982 "seclang-parser.cc" // lalr1.cc:859
+#line 3987 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 312:
-#line 2337 "seclang-parser.yy" // lalr1.cc:859
+#line 2342 "seclang-parser.yy" // lalr1.cc:859
     {
         //ACTION_NOT_SUPPORTED("ExpireVar", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[0].value.as< std::string > ()));
       }
-#line 3991 "seclang-parser.cc" // lalr1.cc:859
+#line 3996 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 313:
-#line 2342 "seclang-parser.yy" // lalr1.cc:859
+#line 2347 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as< std::string > ()));
       }
-#line 3999 "seclang-parser.cc" // lalr1.cc:859
+#line 4004 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 314:
-#line 2346 "seclang-parser.yy" // lalr1.cc:859
+#line 2351 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[0].value.as< std::string > ()));
       }
-#line 4007 "seclang-parser.cc" // lalr1.cc:859
+#line 4012 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 315:
-#line 2350 "seclang-parser.yy" // lalr1.cc:859
+#line 2355 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::LogData(yystack_[0].value.as< std::string > ()));
       }
-#line 4015 "seclang-parser.cc" // lalr1.cc:859
+#line 4020 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 316:
-#line 2354 "seclang-parser.yy" // lalr1.cc:859
+#line 2359 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as< std::string > ()));
       }
-#line 4023 "seclang-parser.cc" // lalr1.cc:859
+#line 4028 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 317:
-#line 2358 "seclang-parser.yy" // lalr1.cc:859
+#line 2363 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as< std::string > ()));
       }
-#line 4031 "seclang-parser.cc" // lalr1.cc:859
+#line 4036 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 318:
-#line 2362 "seclang-parser.yy" // lalr1.cc:859
+#line 2367 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Msg(yystack_[0].value.as< std::string > ()));
       }
-#line 4039 "seclang-parser.cc" // lalr1.cc:859
+#line 4044 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 319:
-#line 2366 "seclang-parser.yy" // lalr1.cc:859
+#line 2371 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as< std::string > ()));
       }
-#line 4047 "seclang-parser.cc" // lalr1.cc:859
+#line 4052 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 320:
-#line 2370 "seclang-parser.yy" // lalr1.cc:859
+#line 2375 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as< std::string > ()));
       }
-#line 4055 "seclang-parser.cc" // lalr1.cc:859
+#line 4060 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 321:
-#line 2374 "seclang-parser.yy" // lalr1.cc:859
+#line 2379 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as< std::string > ()));
       }
-#line 4063 "seclang-parser.cc" // lalr1.cc:859
+#line 4068 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 322:
-#line 2378 "seclang-parser.yy" // lalr1.cc:859
+#line 2383 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as< std::string > ()));
       }
-#line 4071 "seclang-parser.cc" // lalr1.cc:859
+#line 4076 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 323:
-#line 2382 "seclang-parser.yy" // lalr1.cc:859
+#line 2387 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 4079 "seclang-parser.cc" // lalr1.cc:859
+#line 4084 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 324:
-#line 2386 "seclang-parser.yy" // lalr1.cc:859
+#line 2391 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as< std::string > ()));
       }
-#line 4087 "seclang-parser.cc" // lalr1.cc:859
+#line 4092 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 325:
-#line 2390 "seclang-parser.yy" // lalr1.cc:859
+#line 2395 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 4095 "seclang-parser.cc" // lalr1.cc:859
+#line 4100 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 326:
-#line 2394 "seclang-parser.yy" // lalr1.cc:859
+#line 2399 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 4103 "seclang-parser.cc" // lalr1.cc:859
+#line 4108 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 327:
-#line 2398 "seclang-parser.yy" // lalr1.cc:859
+#line 2403 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(yystack_[0].value.as< std::string > ()));
       }
-#line 4111 "seclang-parser.cc" // lalr1.cc:859
+#line 4116 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 328:
-#line 2402 "seclang-parser.yy" // lalr1.cc:859
+#line 2407 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as< std::string > ()));
       }
-#line 4119 "seclang-parser.cc" // lalr1.cc:859
+#line 4124 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 329:
-#line 2406 "seclang-parser.yy" // lalr1.cc:859
+#line 2411 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("SanatiseArg", yystack_[1].location);
       }
-#line 4127 "seclang-parser.cc" // lalr1.cc:859
+#line 4132 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 330:
-#line 2410 "seclang-parser.yy" // lalr1.cc:859
+#line 2415 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("SanatiseMatched", yystack_[1].location);
       }
-#line 4135 "seclang-parser.cc" // lalr1.cc:859
+#line 4140 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 331:
-#line 2414 "seclang-parser.yy" // lalr1.cc:859
+#line 2419 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("SanatiseMatchedBytes", yystack_[1].location);
       }
-#line 4143 "seclang-parser.cc" // lalr1.cc:859
+#line 4148 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 332:
-#line 2418 "seclang-parser.yy" // lalr1.cc:859
+#line 2423 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("SanatiseRequestHeader", yystack_[1].location);
       }
-#line 4151 "seclang-parser.cc" // lalr1.cc:859
+#line 4156 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 333:
-#line 2422 "seclang-parser.yy" // lalr1.cc:859
+#line 2427 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("SanatiseResponseHeader", yystack_[1].location);
       }
-#line 4159 "seclang-parser.cc" // lalr1.cc:859
+#line 4164 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 334:
-#line 2426 "seclang-parser.yy" // lalr1.cc:859
+#line 2431 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_NOT_SUPPORTED("SetEnv", yystack_[1].location);
       }
-#line 4167 "seclang-parser.cc" // lalr1.cc:859
+#line 4172 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 335:
-#line 2430 "seclang-parser.yy" // lalr1.cc:859
+#line 2435 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetRSC(yystack_[0].value.as< std::string > ()));
       }
-#line 4175 "seclang-parser.cc" // lalr1.cc:859
+#line 4180 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 336:
-#line 2434 "seclang-parser.yy" // lalr1.cc:859
+#line 2439 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetSID(yystack_[0].value.as< std::string > ()));
       }
-#line 4183 "seclang-parser.cc" // lalr1.cc:859
+#line 4188 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 337:
-#line 2438 "seclang-parser.yy" // lalr1.cc:859
+#line 2443 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetUID(yystack_[0].value.as< std::string > ()));
       }
-#line 4191 "seclang-parser.cc" // lalr1.cc:859
+#line 4196 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 338:
-#line 2442 "seclang-parser.yy" // lalr1.cc:859
+#line 2447 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as< std::unique_ptr<actions::Action> > ());
       }
-#line 4199 "seclang-parser.cc" // lalr1.cc:859
+#line 4204 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 339:
-#line 2446 "seclang-parser.yy" // lalr1.cc:859
+#line 2451 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as< std::string > ()));
       }
-#line 4207 "seclang-parser.cc" // lalr1.cc:859
+#line 4212 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 340:
-#line 2450 "seclang-parser.yy" // lalr1.cc:859
+#line 2455 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as< std::string > ()));
       }
-#line 4215 "seclang-parser.cc" // lalr1.cc:859
+#line 4220 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 341:
-#line 2454 "seclang-parser.yy" // lalr1.cc:859
+#line 2459 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as< std::string > ()));
       }
-#line 4223 "seclang-parser.cc" // lalr1.cc:859
+#line 4228 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 342:
-#line 2458 "seclang-parser.yy" // lalr1.cc:859
+#line 2463 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as< std::string > ()));
       }
-#line 4231 "seclang-parser.cc" // lalr1.cc:859
+#line 4236 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 343:
-#line 2462 "seclang-parser.yy" // lalr1.cc:859
+#line 2467 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Tag(yystack_[0].value.as< std::string > ()));
       }
-#line 4239 "seclang-parser.cc" // lalr1.cc:859
+#line 4244 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 344:
-#line 2466 "seclang-parser.yy" // lalr1.cc:859
+#line 2471 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as< std::string > ()));
       }
-#line 4247 "seclang-parser.cc" // lalr1.cc:859
+#line 4252 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 345:
-#line 2470 "seclang-parser.yy" // lalr1.cc:859
+#line 2475 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as< std::string > ()));
       }
-#line 4255 "seclang-parser.cc" // lalr1.cc:859
+#line 4260 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 346:
-#line 2474 "seclang-parser.yy" // lalr1.cc:859
+#line 2479 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as< std::string > ()));
       }
-#line 4263 "seclang-parser.cc" // lalr1.cc:859
+#line 4268 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 347:
-#line 2478 "seclang-parser.yy" // lalr1.cc:859
+#line 2483 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as< std::string > ()));
       }
-#line 4271 "seclang-parser.cc" // lalr1.cc:859
+#line 4276 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 348:
-#line 2482 "seclang-parser.yy" // lalr1.cc:859
+#line 2487 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as< std::string > ()));
       }
-#line 4279 "seclang-parser.cc" // lalr1.cc:859
+#line 4284 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 349:
-#line 2486 "seclang-parser.yy" // lalr1.cc:859
+#line 2491 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4287 "seclang-parser.cc" // lalr1.cc:859
+#line 4292 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 350:
-#line 2490 "seclang-parser.yy" // lalr1.cc:859
+#line 2495 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as< std::string > ()));
       }
-#line 4295 "seclang-parser.cc" // lalr1.cc:859
+#line 4300 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 351:
-#line 2494 "seclang-parser.yy" // lalr1.cc:859
+#line 2499 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as< std::string > ()));
       }
-#line 4303 "seclang-parser.cc" // lalr1.cc:859
+#line 4308 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 352:
-#line 2498 "seclang-parser.yy" // lalr1.cc:859
+#line 2503 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as< std::string > ()));
       }
-#line 4311 "seclang-parser.cc" // lalr1.cc:859
+#line 4316 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 353:
-#line 2502 "seclang-parser.yy" // lalr1.cc:859
+#line 2507 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as< std::string > ()));
       }
-#line 4319 "seclang-parser.cc" // lalr1.cc:859
+#line 4324 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 354:
-#line 2506 "seclang-parser.yy" // lalr1.cc:859
+#line 2511 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4327 "seclang-parser.cc" // lalr1.cc:859
+#line 4332 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 355:
-#line 2510 "seclang-parser.yy" // lalr1.cc:859
+#line 2515 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as< std::string > ()));
       }
-#line 4335 "seclang-parser.cc" // lalr1.cc:859
+#line 4340 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 356:
-#line 2514 "seclang-parser.yy" // lalr1.cc:859
+#line 2519 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as< std::string > ()));
       }
-#line 4343 "seclang-parser.cc" // lalr1.cc:859
+#line 4348 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 357:
-#line 2518 "seclang-parser.yy" // lalr1.cc:859
+#line 2523 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as< std::string > ()));
       }
-#line 4351 "seclang-parser.cc" // lalr1.cc:859
+#line 4356 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 358:
-#line 2522 "seclang-parser.yy" // lalr1.cc:859
+#line 2527 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4359 "seclang-parser.cc" // lalr1.cc:859
+#line 4364 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 359:
-#line 2526 "seclang-parser.yy" // lalr1.cc:859
+#line 2531 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as< std::string > ()));
       }
-#line 4367 "seclang-parser.cc" // lalr1.cc:859
+#line 4372 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 360:
-#line 2530 "seclang-parser.yy" // lalr1.cc:859
+#line 2535 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as< std::string > ()));
       }
-#line 4375 "seclang-parser.cc" // lalr1.cc:859
+#line 4380 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 361:
-#line 2534 "seclang-parser.yy" // lalr1.cc:859
+#line 2539 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as< std::string > ()));
       }
-#line 4383 "seclang-parser.cc" // lalr1.cc:859
+#line 4388 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 362:
-#line 2538 "seclang-parser.yy" // lalr1.cc:859
+#line 2543 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as< std::string > ()));
       }
-#line 4391 "seclang-parser.cc" // lalr1.cc:859
+#line 4396 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 363:
-#line 2542 "seclang-parser.yy" // lalr1.cc:859
+#line 2547 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as< std::string > ()));
       }
-#line 4399 "seclang-parser.cc" // lalr1.cc:859
+#line 4404 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 364:
-#line 2546 "seclang-parser.yy" // lalr1.cc:859
+#line 2551 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4407 "seclang-parser.cc" // lalr1.cc:859
+#line 4412 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 365:
-#line 2550 "seclang-parser.yy" // lalr1.cc:859
+#line 2555 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4415 "seclang-parser.cc" // lalr1.cc:859
+#line 4420 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 366:
-#line 2554 "seclang-parser.yy" // lalr1.cc:859
+#line 2559 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4423 "seclang-parser.cc" // lalr1.cc:859
+#line 4428 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 367:
-#line 2558 "seclang-parser.yy" // lalr1.cc:859
+#line 2563 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as< std::string > ()));
       }
-#line 4431 "seclang-parser.cc" // lalr1.cc:859
+#line 4436 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 368:
-#line 2562 "seclang-parser.yy" // lalr1.cc:859
+#line 2567 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as< std::string > ()));
       }
-#line 4439 "seclang-parser.cc" // lalr1.cc:859
+#line 4444 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 369:
-#line 2566 "seclang-parser.yy" // lalr1.cc:859
+#line 2571 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as< std::string > ()));
       }
-#line 4447 "seclang-parser.cc" // lalr1.cc:859
+#line 4452 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 370:
-#line 2570 "seclang-parser.yy" // lalr1.cc:859
+#line 2575 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as< std::string > ()));
       }
-#line 4455 "seclang-parser.cc" // lalr1.cc:859
+#line 4460 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 371:
-#line 2574 "seclang-parser.yy" // lalr1.cc:859
+#line 2579 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as< std::string > ()));
       }
-#line 4463 "seclang-parser.cc" // lalr1.cc:859
+#line 4468 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 372:
-#line 2578 "seclang-parser.yy" // lalr1.cc:859
+#line 2583 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as< std::string > ()));
       }
-#line 4471 "seclang-parser.cc" // lalr1.cc:859
+#line 4476 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 373:
-#line 2582 "seclang-parser.yy" // lalr1.cc:859
+#line 2587 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as< std::string > ()));
       }
-#line 4479 "seclang-parser.cc" // lalr1.cc:859
+#line 4484 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 374:
-#line 2586 "seclang-parser.yy" // lalr1.cc:859
+#line 2591 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as< std::string > ()));
       }
-#line 4487 "seclang-parser.cc" // lalr1.cc:859
+#line 4492 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 375:
-#line 2593 "seclang-parser.yy" // lalr1.cc:859
+#line 2598 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, yystack_[0].value.as< std::string > ()));
       }
-#line 4495 "seclang-parser.cc" // lalr1.cc:859
+#line 4500 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 376:
-#line 2597 "seclang-parser.yy" // lalr1.cc:859
+#line 2602 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, yystack_[0].value.as< std::string > ()));
       }
-#line 4503 "seclang-parser.cc" // lalr1.cc:859
+#line 4508 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 377:
-#line 2601 "seclang-parser.yy" // lalr1.cc:859
+#line 2606 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, yystack_[2].value.as< std::string > (), yystack_[0].value.as< std::string > ()));
       }
-#line 4511 "seclang-parser.cc" // lalr1.cc:859
+#line 4516 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 378:
-#line 2605 "seclang-parser.yy" // lalr1.cc:859
+#line 2610 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, yystack_[2].value.as< std::string > (), yystack_[0].value.as< std::string > ()));
       }
-#line 4519 "seclang-parser.cc" // lalr1.cc:859
+#line 4524 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 379:
-#line 2609 "seclang-parser.yy" // lalr1.cc:859
+#line 2614 "seclang-parser.yy" // lalr1.cc:859
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, yystack_[2].value.as< std::string > (), yystack_[0].value.as< std::string > ()));
       }
-#line 4527 "seclang-parser.cc" // lalr1.cc:859
+#line 4532 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 380:
-#line 2616 "seclang-parser.yy" // lalr1.cc:859
+#line 2621 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::string > () = yystack_[0].value.as< std::string > ();
       }
-#line 4535 "seclang-parser.cc" // lalr1.cc:859
+#line 4540 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 381:
-#line 2621 "seclang-parser.yy" // lalr1.cc:859
+#line 2626 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::string > () = yystack_[1].value.as< std::string > () + yystack_[0].value.as< std::string > ();
       }
-#line 4543 "seclang-parser.cc" // lalr1.cc:859
+#line 4548 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 382:
-#line 2628 "seclang-parser.yy" // lalr1.cc:859
+#line 2633 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::string > () = yystack_[0].value.as< std::string > ();
       }
-#line 4551 "seclang-parser.cc" // lalr1.cc:859
+#line 4556 "seclang-parser.cc" // lalr1.cc:859
     break;
 
   case 383:
-#line 2633 "seclang-parser.yy" // lalr1.cc:859
+#line 2638 "seclang-parser.yy" // lalr1.cc:859
     {
         yylhs.value.as< std::string > () = yystack_[1].value.as< std::string > () + yystack_[0].value.as< std::string > ();
       }
-#line 4559 "seclang-parser.cc" // lalr1.cc:859
+#line 4564 "seclang-parser.cc" // lalr1.cc:859
     break;
 
 
-#line 4563 "seclang-parser.cc" // lalr1.cc:859
+#line 4568 "seclang-parser.cc" // lalr1.cc:859
             default:
               break;
             }
@@ -5469,38 +5474,38 @@ namespace yy {
      905,   909,   918,   927,   931,   935,   940,   944,   948,   953,
      958,   963,   968,   972,   976,   980,   984,   988,   992,   996,
     1000,  1004,  1008,  1012,  1016,  1020,  1024,  1028,  1032,  1036,
-    1040,  1054,  1055,  1079,  1098,  1113,  1137,  1184,  1188,  1192,
-    1196,  1200,  1204,  1208,  1212,  1216,  1225,  1229,  1234,  1239,
-    1244,  1249,  1254,  1267,  1280,  1293,  1306,  1332,  1358,  1370,
-    1390,  1418,  1423,  1428,  1437,  1442,  1446,  1450,  1454,  1458,
-    1462,  1466,  1467,  1468,  1480,  1486,  1490,  1494,  1495,  1496,
-    1497,  1498,  1499,  1500,  1503,  1511,  1515,  1522,  1527,  1533,
-    1539,  1545,  1552,  1562,  1566,  1570,  1574,  1578,  1582,  1586,
-    1590,  1594,  1598,  1602,  1606,  1610,  1614,  1618,  1622,  1626,
-    1630,  1634,  1638,  1642,  1646,  1650,  1654,  1658,  1662,  1666,
-    1670,  1674,  1678,  1682,  1686,  1690,  1694,  1698,  1702,  1706,
-    1710,  1714,  1718,  1722,  1726,  1730,  1734,  1738,  1742,  1746,
-    1750,  1754,  1758,  1762,  1766,  1770,  1774,  1778,  1782,  1786,
-    1790,  1794,  1798,  1802,  1806,  1810,  1815,  1819,  1823,  1828,
-    1832,  1836,  1841,  1845,  1849,  1854,  1858,  1862,  1867,  1871,
-    1875,  1879,  1883,  1887,  1892,  1896,  1900,  1905,  1909,  1913,
-    1918,  1923,  1927,  1931,  1935,  1939,  1943,  1947,  1951,  1955,
-    1959,  1963,  1967,  1971,  1975,  1979,  1983,  1987,  1991,  1995,
-    1999,  2003,  2007,  2011,  2015,  2019,  2023,  2027,  2031,  2035,
-    2039,  2043,  2047,  2051,  2055,  2059,  2063,  2067,  2071,  2075,
-    2079,  2083,  2087,  2091,  2095,  2099,  2103,  2107,  2111,  2115,
-    2119,  2123,  2127,  2135,  2142,  2149,  2156,  2163,  2170,  2177,
-    2184,  2191,  2198,  2205,  2212,  2222,  2226,  2230,  2234,  2238,
-    2242,  2246,  2250,  2255,  2260,  2265,  2269,  2273,  2277,  2282,
-    2287,  2291,  2295,  2299,  2303,  2307,  2311,  2315,  2319,  2323,
-    2327,  2332,  2336,  2341,  2345,  2349,  2353,  2357,  2361,  2365,
-    2369,  2373,  2377,  2381,  2385,  2389,  2393,  2397,  2401,  2405,
-    2409,  2413,  2417,  2421,  2425,  2429,  2433,  2437,  2441,  2445,
-    2449,  2453,  2457,  2461,  2465,  2469,  2473,  2477,  2481,  2485,
-    2489,  2493,  2497,  2501,  2505,  2509,  2513,  2517,  2521,  2525,
-    2529,  2533,  2537,  2541,  2545,  2549,  2553,  2557,  2561,  2565,
-    2569,  2573,  2577,  2581,  2585,  2592,  2596,  2600,  2604,  2608,
-    2615,  2620,  2627,  2632
+    1040,  1054,  1055,  1079,  1098,  1113,  1137,  1189,  1193,  1197,
+    1201,  1205,  1209,  1213,  1217,  1221,  1230,  1234,  1239,  1244,
+    1249,  1254,  1259,  1272,  1285,  1298,  1311,  1337,  1363,  1375,
+    1395,  1423,  1428,  1433,  1442,  1447,  1451,  1455,  1459,  1463,
+    1467,  1471,  1472,  1473,  1485,  1491,  1495,  1499,  1500,  1501,
+    1502,  1503,  1504,  1505,  1508,  1516,  1520,  1527,  1532,  1538,
+    1544,  1550,  1557,  1567,  1571,  1575,  1579,  1583,  1587,  1591,
+    1595,  1599,  1603,  1607,  1611,  1615,  1619,  1623,  1627,  1631,
+    1635,  1639,  1643,  1647,  1651,  1655,  1659,  1663,  1667,  1671,
+    1675,  1679,  1683,  1687,  1691,  1695,  1699,  1703,  1707,  1711,
+    1715,  1719,  1723,  1727,  1731,  1735,  1739,  1743,  1747,  1751,
+    1755,  1759,  1763,  1767,  1771,  1775,  1779,  1783,  1787,  1791,
+    1795,  1799,  1803,  1807,  1811,  1815,  1820,  1824,  1828,  1833,
+    1837,  1841,  1846,  1850,  1854,  1859,  1863,  1867,  1872,  1876,
+    1880,  1884,  1888,  1892,  1897,  1901,  1905,  1910,  1914,  1918,
+    1923,  1928,  1932,  1936,  1940,  1944,  1948,  1952,  1956,  1960,
+    1964,  1968,  1972,  1976,  1980,  1984,  1988,  1992,  1996,  2000,
+    2004,  2008,  2012,  2016,  2020,  2024,  2028,  2032,  2036,  2040,
+    2044,  2048,  2052,  2056,  2060,  2064,  2068,  2072,  2076,  2080,
+    2084,  2088,  2092,  2096,  2100,  2104,  2108,  2112,  2116,  2120,
+    2124,  2128,  2132,  2140,  2147,  2154,  2161,  2168,  2175,  2182,
+    2189,  2196,  2203,  2210,  2217,  2227,  2231,  2235,  2239,  2243,
+    2247,  2251,  2255,  2260,  2265,  2270,  2274,  2278,  2282,  2287,
+    2292,  2296,  2300,  2304,  2308,  2312,  2316,  2320,  2324,  2328,
+    2332,  2337,  2341,  2346,  2350,  2354,  2358,  2362,  2366,  2370,
+    2374,  2378,  2382,  2386,  2390,  2394,  2398,  2402,  2406,  2410,
+    2414,  2418,  2422,  2426,  2430,  2434,  2438,  2442,  2446,  2450,
+    2454,  2458,  2462,  2466,  2470,  2474,  2478,  2482,  2486,  2490,
+    2494,  2498,  2502,  2506,  2510,  2514,  2518,  2522,  2526,  2530,
+    2534,  2538,  2542,  2546,  2550,  2554,  2558,  2562,  2566,  2570,
+    2574,  2578,  2582,  2586,  2590,  2597,  2601,  2605,  2609,  2613,
+    2620,  2625,  2632,  2637
   };
 
   // Print the state stack on the debug stream.
@@ -5535,8 +5540,8 @@ namespace yy {
 
 
 } // yy
-#line 5539 "seclang-parser.cc" // lalr1.cc:1167
-#line 2638 "seclang-parser.yy" // lalr1.cc:1168
+#line 5544 "seclang-parser.cc" // lalr1.cc:1167
+#line 2643 "seclang-parser.yy" // lalr1.cc:1168
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1156,6 +1156,11 @@ expression:
                     driver.error(@0, "The transformation none is not suitable to be part of the SecDefaultActions");
                     YYERROR;
                 }
+                actions::disruptive::Block *block = dynamic_cast<actions::disruptive::Block *>(a);
+                if (block != NULL) {
+                    driver.error(@0, "The 'block' action cannot be used as a default action");
+                    YYERROR;
+                }
                 checkedActions.push_back(a);
             } else {
                 driver.error(@0, "The action '" + a->m_name + "' is not suitable to be part of the SecDefaultActions");

--- a/test/test-cases/regression/action-block.json
+++ b/test/test-cases/regression/action-block.json
@@ -1,0 +1,34 @@
+[
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing 'block' action as default action is rejected by the parser",
+    "expected":{
+      "parser_error": "The 'block' action cannot be used as a default action"
+    },
+    "client":{
+      "ip":"200.249.12.31",
+      "port":12300
+    },
+    "request":{
+      "headers":{
+        "Host":"a.b.com",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "User-Agent":"My sweet little browser",
+        "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120"
+      },
+      "uri":"/path1",
+      "method":"GET"
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:1,log,block\"",
+      "SecRule REQUEST_URI \"@contains path1\" \"phase:1,block,msg:'block',id:500065\""
+    ]
+  }
+]


### PR DESCRIPTION
Currently, it is possible to specify 'block' as the default disruptive
action for any phase. If there is a rule for a phase with default
action 'block' which in turn uses 'block' as its disruptive action,
i.e., wants to use the default disruptive action, and the rule gets
triggered, libmodsecurity enters an infinite recursion with subsequent
segmentation violation.

Include a regression test for this scenario.