### PR TITLE
Configure: actually disable Lua on systems with liblua5.1

### DIFF
--- a/build/lua.m4
+++ b/build/lua.m4
@@ -116,6 +116,10 @@ fi
 if test "${lua_5_1}" = 1 ; then
    AC_MSG_NOTICE([LUA 5.1 was found and it is not currently supported on libModSecurity. LUA_VERSION: ${LUA_VERSION}. LUA build disabled.])
    LUA_FOUND=2
+   LUA_CFLAGS=
+   LUA_DISPLAY=
+   LUA_LDADD=
+   LUA_LDFLAGS=
 fi
 
 AC_SUBST(LUA_FOUND)


### PR DESCRIPTION
In particular, on CentOS 7.3.1611 building libmodsecurity with default configure options ends up with failure while compiling `src/engine/lua.cc`, while config.log states that Lua was disabled:

```
$ ./configure
[..]
configure: LUA library found at: /usr/lib64//liblua.so
configure: LUA headers found at: /usr/include
configure: LUA version from includes: 501
configure: using LUA -llua
configure: LUA 5.1 was found and it is not currently supported on libModSecurity. LUA_VERSION: 501. LUA build disabled.
[..]
   + LUA                                           ....disabled
[..]

$ grep "^LUA_" Makefile
LUA_CFLAGS = -DWITH_LUA -DWITH_LUA_5_1 -I/usr/include
LUA_DISPLAY = -llua -L/usr/lib64/, -DWITH_LUA -DWITH_LUA_5_1 -I/usr/include
LUA_FOUND = 2
LUA_LDADD = -llua
LUA_LDFLAGS = -L/usr/lib64/
```