### PR TITLE
Fix "include /foo/*.conf" for single matched object in directory

### DIFF
--- a/src/utils/system.cc
+++ b/src/utils/system.cc
@@ -75,7 +75,7 @@ std::string find_resource(const std::string& resource,
     delete iss;
 
     // What about `*' ?
-    if (utils::expandEnv(resource, 0).size() > 1) {
+    if (utils::expandEnv(resource, 0).size() > 0) {
         return resource;
     } else {
         err->append("'" + resource + "', ");
@@ -94,7 +94,7 @@ std::string find_resource(const std::string& resource,
     delete iss;
 
     // What about `*' ?
-    if (utils::expandEnv(f, 0).size() > 1) {
+    if (utils::expandEnv(f, 0).size() > 0) {
         return f;
     } else {
         err->append("'" + f + "'.");


### PR DESCRIPTION
This allows to use configurations like the following:

```
include /etc/nginx/modsec/custom-rules/*.conf
```

when there's just one .conf file in `/etc/nginx/modsec/custom-rules/`.

Currently it fails with the following error message:

```
root@vagrant:/etc/nginx/modsec# nginx -t
nginx: [emerg] "modsecurity_rules_file" directive Rules error. File: /etc/nginx/modsec/main.conf. Line: 1. Column: 45. /etc/nginx/modsec/custom-rules/*.conf: Not able to open file. Looking at: '/etc/nginx/modsec/custom-rules/*.conf', '/etc/nginx/modsec/custom-rules/*.conf', '/etc/nginx/modsec//etc/nginx/modsec/custom-rules/*.conf', '/etc/nginx/modsec//etc/nginx/modsec/custom-rules/*.conf'. in /etc/nginx/nginx.conf:75
nginx: configuration file /etc/nginx/nginx.conf test failed
root@vagrant:/etc/nginx/modsec# find custom-rules/ -type f
custom-rules/foo.conf
```

And works fine when there're more than 1 matched files:

```
root@vagrant:/etc/nginx/modsec# touch custom-rules/bar.conf
root@vagrant:/etc/nginx/modsec# nginx -t
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
root@vagrant:/etc/nginx/modsec# find custom-rules/ -type f
custom-rules/foo.conf
custom-rules/bar.conf
```