### PR TITLE
Fix "make dist" target to include necessary headers for Lua

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ noinst_HEADERS = \
 	request_body_processor/*.h \
 	utils/*.h \
 	variables/*.h \
+	engine/*.h \
 	*.h
 
 


### PR DESCRIPTION
Currently the `src/engines/lua.h` header is not being packed into archive made by `make dist`, and building fails with the following:

```
make[3]: Entering directory '/tmp/modsecurity-3.0/src'
/bin/bash ../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I.  -std=c++11 -I.. -g -I../others -fPIC -O3 -I../headers -DWITH_GEOIP -I/usr/include/    -DWITH_YAJL -I/usr/include/yajl  -DPCRE_HAVE_JIT   -I/usr/include/libxml2 -DWITH_LIBXML2   -g -O2 -MT parser/libmodsecurity_la-seclang-parser.lo -MD -MP -MF parser/.deps/libmodsecurity_la-seclang-parser.Tpo -c -o parser/libmodsecurity_la-seclang-parser.lo `test -f 'parser/seclang-parser.cc' || echo './'`parser/seclang-parser.cc
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -std=c++11 -I.. -g -I../others -fPIC -O3 -I../headers -DWITH_GEOIP -I/usr/include/ -DWITH_YAJL -I/usr/include/yajl -DPCRE_HAVE_JIT -I/usr/include/libxml2 -DWITH_LIBXML2 -g -O2 -MT parser/libmodsecurity_la-seclang-parser.lo -MD -MP -MF parser/.deps/libmodsecurity_la-seclang-parser.Tpo -c parser/seclang-parser.cc  -fPIC -DPIC -o parser/.libs/libmodsecurity_la-seclang-parser.o
In file included from seclang-parser.yy:20:0,
                 from seclang-parser.cc:46:
../src/rule_script.h:22:28: fatal error: src/engine/lua.h: No such file or directory
compilation terminated.
Makefile:1795: recipe for target 'parser/libmodsecurity_la-seclang-parser.lo' failed
make[3]: *** [parser/libmodsecurity_la-seclang-parser.lo] Error 1
make[3]: Leaving directory '/tmp/modsecurity-3.0/src'
Makefile:3118: recipe for target 'all-recursive' failed
```