### PR TITLE
Add missing verify*** operator statements to parser

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.x - YYYY-MMM-DD (To be released)
 -------------------------------------
 
+ - Add missing verify*** transformation statements to parser
+  [Issue #1006 and #1007 - @victorhora, @zimmerle]
  - Fix a set of compilation warnings
    [Issue #1650 - @zimmerle, @JayCase]
  - Check for disruptive action on SecDefaultAction.

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.4.
+// A Bison parser, made by GNU Bison 3.0.2.
 
 // Skeleton implementation for Bison LALR(1) parsers in C++
 
-// Copyright (C) 2002-2015 Free Software Foundation, Inc.
+// Copyright (C) 2002-2013 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@
 
 // First part of user declarations.
 
-#line 37 "seclang-parser.cc" // lalr1.cc:404
+#line 37 "seclang-parser.cc" // lalr1.cc:399
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -47,13 +47,13 @@
 
 // User implementation prologue.
 
-#line 51 "seclang-parser.cc" // lalr1.cc:412
+#line 51 "seclang-parser.cc" // lalr1.cc:407
 // Unqualified %code blocks.
-#line 358 "seclang-parser.yy" // lalr1.cc:413
+#line 358 "seclang-parser.yy" // lalr1.cc:408
 
 #include "src/parser/driver.h"
 
-#line 57 "seclang-parser.cc" // lalr1.cc:413
+#line 57 "seclang-parser.cc" // lalr1.cc:408
 
 
 #ifndef YY_
@@ -130,7 +130,7 @@
 #endif // !YYDEBUG
 
 #define yyerrok         (yyerrstatus_ = 0)
-#define yyclearin       (yyla.clear ())
+#define yyclearin       (yyempty = true)
 
 #define YYACCEPT        goto yyacceptlab
 #define YYABORT         goto yyabortlab
@@ -139,7 +139,7 @@
 
 
 namespace yy {
-#line 143 "seclang-parser.cc" // lalr1.cc:479
+#line 143 "seclang-parser.cc" // lalr1.cc:474
 
   /* Return YYSTR after stripping away unnecessary quotes and
      backslashes, so that it's suitable for yyerror.  The heuristic is
@@ -202,7 +202,7 @@ namespace yy {
   // by_state.
   inline
   seclang_parser::by_state::by_state ()
-    : state (empty_state)
+    : state (empty)
   {}
 
   inline
@@ -212,17 +212,10 @@ namespace yy {
 
   inline
   void
-  seclang_parser::by_state::clear ()
-  {
-    state = empty_state;
-  }
-
-  inline
-  void
   seclang_parser::by_state::move (by_state& that)
   {
     state = that.state;
-    that.clear ();
+    that.state = empty;
   }
 
   inline
@@ -234,10 +227,7 @@ namespace yy {
   seclang_parser::symbol_number_type
   seclang_parser::by_state::type_get () const
   {
-    if (state == empty_state)
-      return empty_symbol;
-    else
-      return yystos_[state];
+    return state == empty ? 0 : yystos_[state];
   }
 
   inline
@@ -457,7 +447,7 @@ namespace yy {
     }
 
     // that is emptied.
-    that.type = empty_symbol;
+    that.type = empty;
   }
 
   inline
@@ -695,10 +685,6 @@ namespace yy {
     std::ostream& yyoutput = yyo;
     YYUSE (yyoutput);
     symbol_number_type yytype = yysym.type_get ();
-    // Avoid a (spurious) G++ 4.8 warning about "array subscript is
-    // below array bounds".
-    if (yysym.empty ())
-      std::abort ();
     yyo << (yytype < yyntokens_ ? "token" : "nterm")
         << ' ' << yytname_[yytype] << " ("
         << yysym.location << ": ";
@@ -783,6 +769,9 @@ namespace yy {
   int
   seclang_parser::parse ()
   {
+    /// Whether yyla contains a lookahead.
+    bool yyempty = true;
+
     // State.
     int yyn;
     /// Length of the RHS of the rule being reduced.
@@ -809,13 +798,13 @@ namespace yy {
 
 
     // User initialization code.
-    #line 351 "/home/zimmerle/core-trustwave/ModSecurity/src/parser/seclang-parser.yy" // lalr1.cc:741
+    #line 351 "/root/ModSecurity-v3-Mar/src/parser/seclang-parser.yy" // lalr1.cc:725
 {
   // Initialize the initial location.
   yyla.location.begin.filename = yyla.location.end.filename = &driver.file;
 }
 
-#line 819 "seclang-parser.cc" // lalr1.cc:741
+#line 808 "seclang-parser.cc" // lalr1.cc:725
 
     /* Initialize the stack.  The initial state will be set in
        yynewstate, since the latter expects the semantical and the
@@ -843,7 +832,7 @@ namespace yy {
       goto yydefault;
 
     // Read a lookahead token.
-    if (yyla.empty ())
+    if (yyempty)
       {
         YYCDEBUG << "Reading a token: ";
         try
@@ -856,6 +845,7 @@ namespace yy {
             error (yyexc);
             goto yyerrlab1;
           }
+        yyempty = false;
       }
     YY_SYMBOL_PRINT ("Next token is", yyla);
 
@@ -874,6 +864,9 @@ namespace yy {
         yyn = -yyn;
         goto yyreduce;
       }
+
+    // Discard the token being shifted.
+    yyempty = true;
 
     // Count tokens shifted since error; after three, turn off error status.
     if (yyerrstatus_)
@@ -1124,232 +1117,232 @@ namespace yy {
           switch (yyn)
             {
   case 2:
-#line 713 "seclang-parser.yy" // lalr1.cc:859
+#line 713 "seclang-parser.yy" // lalr1.cc:847
     {
         return 0;
       }
-#line 1132 "seclang-parser.cc" // lalr1.cc:859
+#line 1125 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 6:
-#line 726 "seclang-parser.yy" // lalr1.cc:859
+#line 726 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setStorageDirMode(strtol(yystack_[0].value.as< std::string > ().c_str(), NULL, 8));
       }
-#line 1140 "seclang-parser.cc" // lalr1.cc:859
+#line 1133 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 7:
-#line 732 "seclang-parser.yy" // lalr1.cc:859
+#line 732 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setStorageDir(yystack_[0].value.as< std::string > ());
       }
-#line 1148 "seclang-parser.cc" // lalr1.cc:859
+#line 1141 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 8:
-#line 738 "seclang-parser.yy" // lalr1.cc:859
+#line 738 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::RelevantOnlyAuditLogStatus);
       }
-#line 1156 "seclang-parser.cc" // lalr1.cc:859
+#line 1149 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 9:
-#line 742 "seclang-parser.yy" // lalr1.cc:859
+#line 742 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::OffAuditLogStatus);
       }
-#line 1164 "seclang-parser.cc" // lalr1.cc:859
+#line 1157 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 10:
-#line 746 "seclang-parser.yy" // lalr1.cc:859
+#line 746 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::OnAuditLogStatus);
       }
-#line 1172 "seclang-parser.cc" // lalr1.cc:859
+#line 1165 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 11:
-#line 752 "seclang-parser.yy" // lalr1.cc:859
+#line 752 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setFileMode(strtol(yystack_[0].value.as< std::string > ().c_str(), NULL, 8));
       }
-#line 1180 "seclang-parser.cc" // lalr1.cc:859
+#line 1173 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 12:
-#line 758 "seclang-parser.yy" // lalr1.cc:859
+#line 758 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setFilePath2(yystack_[0].value.as< std::string > ());
       }
-#line 1188 "seclang-parser.cc" // lalr1.cc:859
+#line 1181 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 13:
-#line 764 "seclang-parser.yy" // lalr1.cc:859
+#line 764 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setParts(yystack_[0].value.as< std::string > ());
       }
-#line 1196 "seclang-parser.cc" // lalr1.cc:859
+#line 1189 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 14:
-#line 770 "seclang-parser.yy" // lalr1.cc:859
+#line 770 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setFilePath1(yystack_[0].value.as< std::string > ());
       }
-#line 1204 "seclang-parser.cc" // lalr1.cc:859
+#line 1197 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 15:
-#line 775 "seclang-parser.yy" // lalr1.cc:859
+#line 775 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setFormat(modsecurity::audit_log::AuditLog::JSONAuditLogFormat);
       }
-#line 1212 "seclang-parser.cc" // lalr1.cc:859
+#line 1205 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 16:
-#line 780 "seclang-parser.yy" // lalr1.cc:859
+#line 780 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setFormat(modsecurity::audit_log::AuditLog::NativeAuditLogFormat);
       }
-#line 1220 "seclang-parser.cc" // lalr1.cc:859
+#line 1213 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 17:
-#line 786 "seclang-parser.yy" // lalr1.cc:859
+#line 786 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string relevant_status(yystack_[0].value.as< std::string > ());
         driver.m_auditLog->setRelevantStatus(relevant_status);
       }
-#line 1229 "seclang-parser.cc" // lalr1.cc:859
+#line 1222 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 18:
-#line 793 "seclang-parser.yy" // lalr1.cc:859
+#line 793 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::SerialAuditLogType);
       }
-#line 1237 "seclang-parser.cc" // lalr1.cc:859
+#line 1230 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 19:
-#line 797 "seclang-parser.yy" // lalr1.cc:859
+#line 797 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::ParallelAuditLogType);
       }
-#line 1245 "seclang-parser.cc" // lalr1.cc:859
+#line 1238 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 20:
-#line 801 "seclang-parser.yy" // lalr1.cc:859
+#line 801 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::HttpsAuditLogType);
       }
-#line 1253 "seclang-parser.cc" // lalr1.cc:859
+#line 1246 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 21:
-#line 807 "seclang-parser.yy" // lalr1.cc:859
+#line 807 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_uploadKeepFiles = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 1261 "seclang-parser.cc" // lalr1.cc:859
+#line 1254 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 22:
-#line 811 "seclang-parser.yy" // lalr1.cc:859
+#line 811 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_uploadKeepFiles = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 1269 "seclang-parser.cc" // lalr1.cc:859
+#line 1262 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 23:
-#line 815 "seclang-parser.yy" // lalr1.cc:859
+#line 815 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_uploadFileLimit.m_set = true;
         driver.m_uploadFileLimit.m_value = strtol(yystack_[0].value.as< std::string > ().c_str(), NULL, 10);
       }
-#line 1278 "seclang-parser.cc" // lalr1.cc:859
+#line 1271 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 24:
-#line 820 "seclang-parser.yy" // lalr1.cc:859
+#line 820 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_uploadFileMode.m_set = true;
         driver.m_uploadFileMode.m_value = strtol(yystack_[0].value.as< std::string > ().c_str(), NULL, 8);
       }
-#line 1287 "seclang-parser.cc" // lalr1.cc:859
+#line 1280 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 25:
-#line 825 "seclang-parser.yy" // lalr1.cc:859
+#line 825 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_uploadDirectory.m_set = true;
         driver.m_uploadDirectory.m_value = yystack_[0].value.as< std::string > ();
       }
-#line 1296 "seclang-parser.cc" // lalr1.cc:859
+#line 1289 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 26:
-#line 830 "seclang-parser.yy" // lalr1.cc:859
+#line 830 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 1304 "seclang-parser.cc" // lalr1.cc:859
+#line 1297 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 27:
-#line 834 "seclang-parser.yy" // lalr1.cc:859
+#line 834 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 1312 "seclang-parser.cc" // lalr1.cc:859
+#line 1305 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 28:
-#line 841 "seclang-parser.yy" // lalr1.cc:859
+#line 841 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[1].value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1320 "seclang-parser.cc" // lalr1.cc:859
+#line 1313 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 29:
-#line 845 "seclang-parser.yy" // lalr1.cc:859
+#line 845 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1328 "seclang-parser.cc" // lalr1.cc:859
+#line 1321 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 30:
-#line 852 "seclang-parser.yy" // lalr1.cc:859
+#line 852 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_INIT(yystack_[0].value.as< std::unique_ptr<actions::Action> > (), yystack_[3].location)
         yystack_[2].value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ()->push_back(std::move(yystack_[0].value.as< std::unique_ptr<actions::Action> > ()));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[2].value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1338 "seclang-parser.cc" // lalr1.cc:859
+#line 1331 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 31:
-#line 858 "seclang-parser.yy" // lalr1.cc:859
+#line 858 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<std::vector<std::unique_ptr<actions::Action>>> b(new std::vector<std::unique_ptr<actions::Action>>());
         ACTION_INIT(yystack_[0].value.as< std::unique_ptr<actions::Action> > (), yystack_[1].location)
         b->push_back(std::move(yystack_[0].value.as< std::unique_ptr<actions::Action> > ()));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(b);
       }
-#line 1349 "seclang-parser.cc" // lalr1.cc:859
+#line 1342 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 32:
-#line 868 "seclang-parser.yy" // lalr1.cc:859
+#line 868 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as< std::unique_ptr<Operator> > ());
         std::string error;
@@ -1358,11 +1351,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1362 "seclang-parser.cc" // lalr1.cc:859
+#line 1355 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 33:
-#line 877 "seclang-parser.yy" // lalr1.cc:859
+#line 877 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as< std::unique_ptr<Operator> > ());
         yylhs.value.as< std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1372,11 +1365,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1376 "seclang-parser.cc" // lalr1.cc:859
+#line 1369 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 34:
-#line 887 "seclang-parser.yy" // lalr1.cc:859
+#line 887 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
         std::string error;
@@ -1385,11 +1378,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1389 "seclang-parser.cc" // lalr1.cc:859
+#line 1382 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 35:
-#line 896 "seclang-parser.yy" // lalr1.cc:859
+#line 896 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
         yylhs.value.as< std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1399,288 +1392,286 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1403 "seclang-parser.cc" // lalr1.cc:859
+#line 1396 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 36:
-#line 909 "seclang-parser.yy" // lalr1.cc:859
+#line 909 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::UnconditionalMatch());
       }
-#line 1411 "seclang-parser.cc" // lalr1.cc:859
+#line 1404 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 37:
-#line 913 "seclang-parser.yy" // lalr1.cc:859
+#line 913 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::DetectSQLi());
       }
-#line 1419 "seclang-parser.cc" // lalr1.cc:859
+#line 1412 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 38:
-#line 917 "seclang-parser.yy" // lalr1.cc:859
+#line 917 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::DetectXSS());
       }
-#line 1427 "seclang-parser.cc" // lalr1.cc:859
+#line 1420 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 39:
-#line 921 "seclang-parser.yy" // lalr1.cc:859
+#line 921 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::ValidateUrlEncoding());
       }
-#line 1435 "seclang-parser.cc" // lalr1.cc:859
+#line 1428 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 40:
-#line 925 "seclang-parser.yy" // lalr1.cc:859
+#line 925 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::ValidateUtf8Encoding());
       }
-#line 1443 "seclang-parser.cc" // lalr1.cc:859
+#line 1436 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 41:
-#line 929 "seclang-parser.yy" // lalr1.cc:859
+#line 929 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::InspectFile(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1451 "seclang-parser.cc" // lalr1.cc:859
+#line 1444 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 42:
-#line 933 "seclang-parser.yy" // lalr1.cc:859
+#line 933 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::FuzzyHash(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1459 "seclang-parser.cc" // lalr1.cc:859
+#line 1452 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 43:
-#line 937 "seclang-parser.yy" // lalr1.cc:859
+#line 937 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::ValidateByteRange(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1467 "seclang-parser.cc" // lalr1.cc:859
+#line 1460 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 44:
-#line 941 "seclang-parser.yy" // lalr1.cc:859
+#line 941 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::ValidateDTD(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1475 "seclang-parser.cc" // lalr1.cc:859
+#line 1468 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 45:
-#line 945 "seclang-parser.yy" // lalr1.cc:859
+#line 945 "seclang-parser.yy" // lalr1.cc:847
     {
         /* $$ = new operators::ValidateHash($1); */
         OPERATOR_NOT_SUPPORTED("ValidateHash", yystack_[2].location);
       }
-#line 1484 "seclang-parser.cc" // lalr1.cc:859
+#line 1477 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 46:
-#line 950 "seclang-parser.yy" // lalr1.cc:859
+#line 950 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::ValidateSchema(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1492 "seclang-parser.cc" // lalr1.cc:859
+#line 1485 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 47:
-#line 954 "seclang-parser.yy" // lalr1.cc:859
+#line 954 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::VerifyCC(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1500 "seclang-parser.cc" // lalr1.cc:859
+#line 1493 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 48:
-#line 958 "seclang-parser.yy" // lalr1.cc:859
+#line 958 "seclang-parser.yy" // lalr1.cc:847
     {
-        /* $$ = new operators::VerifyCPF($1); */
-        OPERATOR_NOT_SUPPORTED("VerifyCPF", yystack_[2].location);
+        OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::VerifyCPF(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1509 "seclang-parser.cc" // lalr1.cc:859
+#line 1501 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 49:
-#line 963 "seclang-parser.yy" // lalr1.cc:859
+#line 962 "seclang-parser.yy" // lalr1.cc:847
     {
-        /* $$ = new operators::VerifySSN($1); */
-        OPERATOR_NOT_SUPPORTED("VerifySSN", yystack_[2].location);
+        OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::VerifySSN(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1518 "seclang-parser.cc" // lalr1.cc:859
+#line 1509 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 50:
-#line 968 "seclang-parser.yy" // lalr1.cc:859
+#line 966 "seclang-parser.yy" // lalr1.cc:847
     {
         /* $$ = new operators::GsbLookup($1); */
         OPERATOR_NOT_SUPPORTED("GsbLookup", yystack_[2].location);
       }
-#line 1527 "seclang-parser.cc" // lalr1.cc:859
+#line 1518 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 51:
-#line 973 "seclang-parser.yy" // lalr1.cc:859
+#line 971 "seclang-parser.yy" // lalr1.cc:847
     {
         /* $$ = new operators::Rsub($1); */
         OPERATOR_NOT_SUPPORTED("Rsub", yystack_[2].location);
       }
-#line 1536 "seclang-parser.cc" // lalr1.cc:859
+#line 1527 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 52:
-#line 978 "seclang-parser.yy" // lalr1.cc:859
+#line 976 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Within(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1544 "seclang-parser.cc" // lalr1.cc:859
+#line 1535 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 53:
-#line 982 "seclang-parser.yy" // lalr1.cc:859
+#line 980 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::ContainsWord(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1552 "seclang-parser.cc" // lalr1.cc:859
+#line 1543 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 54:
-#line 986 "seclang-parser.yy" // lalr1.cc:859
+#line 984 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Contains(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1560 "seclang-parser.cc" // lalr1.cc:859
+#line 1551 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 55:
-#line 990 "seclang-parser.yy" // lalr1.cc:859
+#line 988 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::EndsWith(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1568 "seclang-parser.cc" // lalr1.cc:859
+#line 1559 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 56:
-#line 994 "seclang-parser.yy" // lalr1.cc:859
+#line 992 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Eq(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1576 "seclang-parser.cc" // lalr1.cc:859
+#line 1567 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 57:
-#line 998 "seclang-parser.yy" // lalr1.cc:859
+#line 996 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Ge(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1584 "seclang-parser.cc" // lalr1.cc:859
+#line 1575 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 58:
-#line 1002 "seclang-parser.yy" // lalr1.cc:859
+#line 1000 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Gt(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1592 "seclang-parser.cc" // lalr1.cc:859
+#line 1583 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 59:
-#line 1006 "seclang-parser.yy" // lalr1.cc:859
+#line 1004 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::IpMatchF(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1600 "seclang-parser.cc" // lalr1.cc:859
+#line 1591 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 60:
-#line 1010 "seclang-parser.yy" // lalr1.cc:859
+#line 1008 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::IpMatch(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1608 "seclang-parser.cc" // lalr1.cc:859
+#line 1599 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 61:
-#line 1014 "seclang-parser.yy" // lalr1.cc:859
+#line 1012 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Le(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1616 "seclang-parser.cc" // lalr1.cc:859
+#line 1607 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 62:
-#line 1018 "seclang-parser.yy" // lalr1.cc:859
+#line 1016 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Lt(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1624 "seclang-parser.cc" // lalr1.cc:859
+#line 1615 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 63:
-#line 1022 "seclang-parser.yy" // lalr1.cc:859
+#line 1020 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::PmFromFile(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1632 "seclang-parser.cc" // lalr1.cc:859
+#line 1623 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 64:
-#line 1026 "seclang-parser.yy" // lalr1.cc:859
+#line 1024 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Pm(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1640 "seclang-parser.cc" // lalr1.cc:859
+#line 1631 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 65:
-#line 1030 "seclang-parser.yy" // lalr1.cc:859
+#line 1028 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Rbl(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1648 "seclang-parser.cc" // lalr1.cc:859
+#line 1639 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 66:
-#line 1034 "seclang-parser.yy" // lalr1.cc:859
+#line 1032 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1656 "seclang-parser.cc" // lalr1.cc:859
+#line 1647 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 67:
-#line 1038 "seclang-parser.yy" // lalr1.cc:859
+#line 1036 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::StrEq(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1664 "seclang-parser.cc" // lalr1.cc:859
+#line 1655 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 68:
-#line 1042 "seclang-parser.yy" // lalr1.cc:859
+#line 1040 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::StrMatch(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1672 "seclang-parser.cc" // lalr1.cc:859
+#line 1663 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 69:
-#line 1046 "seclang-parser.yy" // lalr1.cc:859
+#line 1044 "seclang-parser.yy" // lalr1.cc:847
     {
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::BeginsWith(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 1680 "seclang-parser.cc" // lalr1.cc:859
+#line 1671 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 70:
-#line 1050 "seclang-parser.yy" // lalr1.cc:859
+#line 1048 "seclang-parser.yy" // lalr1.cc:847
     {
 #ifdef WITH_GEOIP
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::GeoLookup());
@@ -1691,11 +1682,11 @@ namespace yy {
             YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 1695 "seclang-parser.cc" // lalr1.cc:859
+#line 1686 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 72:
-#line 1065 "seclang-parser.yy" // lalr1.cc:859
+#line 1063 "seclang-parser.yy" // lalr1.cc:847
     {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         for (auto &i : *yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ().get()) {
@@ -1719,11 +1710,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1723 "seclang-parser.cc" // lalr1.cc:859
+#line 1714 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 73:
-#line 1089 "seclang-parser.yy" // lalr1.cc:859
+#line 1087 "seclang-parser.yy" // lalr1.cc:847
     {
         std::vector<Variable *> *v = new std::vector<Variable *>();
         for (auto &i : *yystack_[1].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ().get()) {
@@ -1742,11 +1733,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1746 "seclang-parser.cc" // lalr1.cc:859
+#line 1737 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 74:
-#line 1108 "seclang-parser.yy" // lalr1.cc:859
+#line 1106 "seclang-parser.yy" // lalr1.cc:847
     {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         for (auto &i : *yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ().get()) {
@@ -1761,11 +1752,11 @@ namespace yy {
             );
         driver.addSecAction(rule);
       }
-#line 1765 "seclang-parser.cc" // lalr1.cc:859
+#line 1756 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 75:
-#line 1123 "seclang-parser.yy" // lalr1.cc:859
+#line 1121 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string err;
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
@@ -1789,11 +1780,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1793 "seclang-parser.cc" // lalr1.cc:859
+#line 1784 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 76:
-#line 1147 "seclang-parser.yy" // lalr1.cc:859
+#line 1145 "seclang-parser.yy" // lalr1.cc:847
     {
         bool hasDisruptive = false;
         std::vector<actions::Action *> *actions = new std::vector<actions::Action *>();
@@ -1849,75 +1840,75 @@ namespace yy {
 
         delete actions;
       }
-#line 1853 "seclang-parser.cc" // lalr1.cc:859
+#line 1844 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 77:
-#line 1203 "seclang-parser.yy" // lalr1.cc:859
+#line 1201 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as< std::string > ()));
       }
-#line 1861 "seclang-parser.cc" // lalr1.cc:859
+#line 1852 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 78:
-#line 1207 "seclang-parser.yy" // lalr1.cc:859
+#line 1205 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secRuleEngine = modsecurity::Rules::DisabledRuleEngine;
       }
-#line 1869 "seclang-parser.cc" // lalr1.cc:859
+#line 1860 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 79:
-#line 1211 "seclang-parser.yy" // lalr1.cc:859
+#line 1209 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secRuleEngine = modsecurity::Rules::EnabledRuleEngine;
       }
-#line 1877 "seclang-parser.cc" // lalr1.cc:859
+#line 1868 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 80:
-#line 1215 "seclang-parser.yy" // lalr1.cc:859
+#line 1213 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secRuleEngine = modsecurity::Rules::DetectionOnlyRuleEngine;
       }
-#line 1885 "seclang-parser.cc" // lalr1.cc:859
+#line 1876 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 81:
-#line 1219 "seclang-parser.yy" // lalr1.cc:859
+#line 1217 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secRequestBodyAccess = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 1893 "seclang-parser.cc" // lalr1.cc:859
+#line 1884 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 82:
-#line 1223 "seclang-parser.yy" // lalr1.cc:859
+#line 1221 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secRequestBodyAccess = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 1901 "seclang-parser.cc" // lalr1.cc:859
+#line 1892 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 83:
-#line 1227 "seclang-parser.yy" // lalr1.cc:859
+#line 1225 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secResponseBodyAccess = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 1909 "seclang-parser.cc" // lalr1.cc:859
+#line 1900 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 84:
-#line 1231 "seclang-parser.yy" // lalr1.cc:859
+#line 1229 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secResponseBodyAccess = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 1917 "seclang-parser.cc" // lalr1.cc:859
+#line 1908 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 85:
-#line 1235 "seclang-parser.yy" // lalr1.cc:859
+#line 1233 "seclang-parser.yy" // lalr1.cc:847
     {
         if (yystack_[0].value.as< std::string > ().length() != 1) {
           driver.error(yystack_[1].location, "Argument separator should be set to a single character.");
@@ -1926,64 +1917,64 @@ namespace yy {
         driver.m_secArgumentSeparator.m_value = yystack_[0].value.as< std::string > ();
         driver.m_secArgumentSeparator.m_set = true;
       }
-#line 1930 "seclang-parser.cc" // lalr1.cc:859
+#line 1921 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 86:
-#line 1244 "seclang-parser.yy" // lalr1.cc:859
+#line 1242 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_components.push_back(yystack_[0].value.as< std::string > ());
       }
-#line 1938 "seclang-parser.cc" // lalr1.cc:859
+#line 1929 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 87:
-#line 1248 "seclang-parser.yy" // lalr1.cc:859
+#line 1246 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secWebAppId.m_value = yystack_[0].value.as< std::string > ();
         driver.m_secWebAppId.m_set = true;
       }
-#line 1947 "seclang-parser.cc" // lalr1.cc:859
+#line 1938 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 88:
-#line 1253 "seclang-parser.yy" // lalr1.cc:859
+#line 1251 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.error(yystack_[1].location, "SecServerSignature is not supported.");
         YYERROR;
       }
-#line 1956 "seclang-parser.cc" // lalr1.cc:859
+#line 1947 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 89:
-#line 1258 "seclang-parser.yy" // lalr1.cc:859
+#line 1256 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.error(yystack_[2].location, "ContentInjection is not yet supported.");
         YYERROR;
       }
-#line 1965 "seclang-parser.cc" // lalr1.cc:859
+#line 1956 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 90:
-#line 1263 "seclang-parser.yy" // lalr1.cc:859
+#line 1261 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.error(yystack_[1].location, "SecCacheTransformations is not supported.");
         YYERROR;
       }
-#line 1974 "seclang-parser.cc" // lalr1.cc:859
+#line 1965 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 91:
-#line 1268 "seclang-parser.yy" // lalr1.cc:859
+#line 1266 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.error(yystack_[2].location, "ContentInjection is not yet supported.");
         YYERROR;
       }
-#line 1983 "seclang-parser.cc" // lalr1.cc:859
+#line 1974 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 92:
-#line 1273 "seclang-parser.yy" // lalr1.cc:859
+#line 1271 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         if (driver.m_exceptions.load(yystack_[0].value.as< std::string > (), &error) == false) {
@@ -1996,11 +1987,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2000 "seclang-parser.cc" // lalr1.cc:859
+#line 1991 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 93:
-#line 1286 "seclang-parser.yy" // lalr1.cc:859
+#line 1284 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByTag(yystack_[0].value.as< std::string > (), &error) == false) {
@@ -2013,11 +2004,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2017 "seclang-parser.cc" // lalr1.cc:859
+#line 2008 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 94:
-#line 1299 "seclang-parser.yy" // lalr1.cc:859
+#line 1297 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByMsg(yystack_[0].value.as< std::string > (), &error) == false) {
@@ -2030,11 +2021,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2034 "seclang-parser.cc" // lalr1.cc:859
+#line 2025 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 95:
-#line 1312 "seclang-parser.yy" // lalr1.cc:859
+#line 1310 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByTag(yystack_[1].value.as< std::string > (), std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2047,11 +2038,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2051 "seclang-parser.cc" // lalr1.cc:859
+#line 2042 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 96:
-#line 1325 "seclang-parser.yy" // lalr1.cc:859
+#line 1323 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByMsg(yystack_[1].value.as< std::string > (), std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2064,11 +2055,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2068 "seclang-parser.cc" // lalr1.cc:859
+#line 2059 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 97:
-#line 1338 "seclang-parser.yy" // lalr1.cc:859
+#line 1336 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         double ruleId;
@@ -2094,11 +2085,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2098 "seclang-parser.cc" // lalr1.cc:859
+#line 2089 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 98:
-#line 1364 "seclang-parser.yy" // lalr1.cc:859
+#line 1362 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string error;
         double ruleId;
@@ -2123,11 +2114,11 @@ namespace yy {
         driver.error(yystack_[2].location, "SecRuleUpdateActionById is not yet supported");
         YYERROR;
       }
-#line 2127 "seclang-parser.cc" // lalr1.cc:859
+#line 2118 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 99:
-#line 1390 "seclang-parser.yy" // lalr1.cc:859
+#line 1388 "seclang-parser.yy" // lalr1.cc:847
     {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as< std::string > ().c_str()));
@@ -2139,11 +2130,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2143 "seclang-parser.cc" // lalr1.cc:859
+#line 2134 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 100:
-#line 1402 "seclang-parser.yy" // lalr1.cc:859
+#line 1400 "seclang-parser.yy" // lalr1.cc:847
     {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -2162,11 +2153,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2166 "seclang-parser.cc" // lalr1.cc:859
+#line 2157 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 101:
-#line 1422 "seclang-parser.yy" // lalr1.cc:859
+#line 1420 "seclang-parser.yy" // lalr1.cc:847
     {
 #ifdef WITH_GEOIP
         std::string err;
@@ -2193,29 +2184,29 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 2197 "seclang-parser.cc" // lalr1.cc:859
+#line 2188 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 102:
-#line 1450 "seclang-parser.yy" // lalr1.cc:859
+#line 1448 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_requestBodyLimit.m_set = true;
         driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as< std::string > ().c_str());
       }
-#line 2206 "seclang-parser.cc" // lalr1.cc:859
+#line 2197 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 103:
-#line 1455 "seclang-parser.yy" // lalr1.cc:859
+#line 1453 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_requestBodyNoFilesLimit.m_set = true;
         driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as< std::string > ().c_str());
       }
-#line 2215 "seclang-parser.cc" // lalr1.cc:859
+#line 2206 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 104:
-#line 1460 "seclang-parser.yy" // lalr1.cc:859
+#line 1458 "seclang-parser.yy" // lalr1.cc:847
     {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -2224,68 +2215,68 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 2228 "seclang-parser.cc" // lalr1.cc:859
+#line 2219 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 105:
-#line 1469 "seclang-parser.yy" // lalr1.cc:859
+#line 1467 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_responseBodyLimit.m_set = true;
         driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as< std::string > ().c_str());
       }
-#line 2237 "seclang-parser.cc" // lalr1.cc:859
+#line 2228 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 106:
-#line 1474 "seclang-parser.yy" // lalr1.cc:859
+#line 1472 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_requestBodyLimitAction = modsecurity::Rules::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 2245 "seclang-parser.cc" // lalr1.cc:859
+#line 2236 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 107:
-#line 1478 "seclang-parser.yy" // lalr1.cc:859
+#line 1476 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_requestBodyLimitAction = modsecurity::Rules::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 2253 "seclang-parser.cc" // lalr1.cc:859
+#line 2244 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 108:
-#line 1482 "seclang-parser.yy" // lalr1.cc:859
+#line 1480 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_responseBodyLimitAction = modsecurity::Rules::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 2261 "seclang-parser.cc" // lalr1.cc:859
+#line 2252 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 109:
-#line 1486 "seclang-parser.yy" // lalr1.cc:859
+#line 1484 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_responseBodyLimitAction = modsecurity::Rules::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 2269 "seclang-parser.cc" // lalr1.cc:859
+#line 2260 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 110:
-#line 1490 "seclang-parser.yy" // lalr1.cc:859
+#line 1488 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_remoteRulesActionOnFailed = Rules::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 2277 "seclang-parser.cc" // lalr1.cc:859
+#line 2268 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 111:
-#line 1494 "seclang-parser.yy" // lalr1.cc:859
+#line 1492 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_remoteRulesActionOnFailed = Rules::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 2285 "seclang-parser.cc" // lalr1.cc:859
+#line 2276 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 114:
-#line 1500 "seclang-parser.yy" // lalr1.cc:859
+#line 1498 "seclang-parser.yy" // lalr1.cc:847
     {
         std::istringstream buf(yystack_[0].value.as< std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -2297,2342 +2288,2342 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 2301 "seclang-parser.cc" // lalr1.cc:859
+#line 2292 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 115:
-#line 1512 "seclang-parser.yy" // lalr1.cc:859
+#line 1510 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 2311 "seclang-parser.cc" // lalr1.cc:859
+#line 2302 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 116:
-#line 1518 "seclang-parser.yy" // lalr1.cc:859
+#line 1516 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secXMLExternalEntity = modsecurity::RulesProperties::FalseConfigBoolean;
       }
-#line 2319 "seclang-parser.cc" // lalr1.cc:859
+#line 2310 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 117:
-#line 1522 "seclang-parser.yy" // lalr1.cc:859
+#line 1520 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_secXMLExternalEntity = modsecurity::RulesProperties::TrueConfigBoolean;
       }
-#line 2327 "seclang-parser.cc" // lalr1.cc:859
+#line 2318 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 124:
-#line 1532 "seclang-parser.yy" // lalr1.cc:859
+#line 1530 "seclang-parser.yy" // lalr1.cc:847
     {
       }
-#line 2334 "seclang-parser.cc" // lalr1.cc:859
+#line 2325 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 125:
-#line 1535 "seclang-parser.yy" // lalr1.cc:859
+#line 1533 "seclang-parser.yy" // lalr1.cc:847
     {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as< std::string > ();
       }
-#line 2343 "seclang-parser.cc" // lalr1.cc:859
+#line 2334 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 126:
-#line 1543 "seclang-parser.yy" // lalr1.cc:859
+#line 1541 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2351 "seclang-parser.cc" // lalr1.cc:859
+#line 2342 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 127:
-#line 1547 "seclang-parser.yy" // lalr1.cc:859
+#line 1545 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2359 "seclang-parser.cc" // lalr1.cc:859
+#line 2350 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 128:
-#line 1554 "seclang-parser.yy" // lalr1.cc:859
+#line 1552 "seclang-parser.yy" // lalr1.cc:847
     {
         yystack_[2].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ()));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2368 "seclang-parser.cc" // lalr1.cc:859
+#line 2359 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 129:
-#line 1559 "seclang-parser.yy" // lalr1.cc:859
+#line 1557 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2378 "seclang-parser.cc" // lalr1.cc:859
+#line 2369 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 130:
-#line 1565 "seclang-parser.yy" // lalr1.cc:859
+#line 1563 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 2388 "seclang-parser.cc" // lalr1.cc:859
+#line 2379 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 131:
-#line 1571 "seclang-parser.yy" // lalr1.cc:859
+#line 1569 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ()));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 2398 "seclang-parser.cc" // lalr1.cc:859
+#line 2389 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 132:
-#line 1577 "seclang-parser.yy" // lalr1.cc:859
+#line 1575 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 2409 "seclang-parser.cc" // lalr1.cc:859
+#line 2400 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 133:
-#line 1584 "seclang-parser.yy" // lalr1.cc:859
+#line 1582 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as< std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 2420 "seclang-parser.cc" // lalr1.cc:859
+#line 2411 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 134:
-#line 1594 "seclang-parser.yy" // lalr1.cc:859
+#line 1592 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Args_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2428 "seclang-parser.cc" // lalr1.cc:859
+#line 2419 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 135:
-#line 1598 "seclang-parser.yy" // lalr1.cc:859
+#line 1596 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Args_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2436 "seclang-parser.cc" // lalr1.cc:859
+#line 2427 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 136:
-#line 1602 "seclang-parser.yy" // lalr1.cc:859
+#line 1600 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Args_NoDictElement());
       }
-#line 2444 "seclang-parser.cc" // lalr1.cc:859
+#line 2435 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 137:
-#line 1606 "seclang-parser.yy" // lalr1.cc:859
+#line 1604 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPost_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2452 "seclang-parser.cc" // lalr1.cc:859
+#line 2443 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 138:
-#line 1610 "seclang-parser.yy" // lalr1.cc:859
+#line 1608 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPost_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2460 "seclang-parser.cc" // lalr1.cc:859
+#line 2451 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 139:
-#line 1614 "seclang-parser.yy" // lalr1.cc:859
+#line 1612 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPost_NoDictElement());
       }
-#line 2468 "seclang-parser.cc" // lalr1.cc:859
+#line 2459 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 140:
-#line 1618 "seclang-parser.yy" // lalr1.cc:859
+#line 1616 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGet_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2476 "seclang-parser.cc" // lalr1.cc:859
+#line 2467 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 141:
-#line 1622 "seclang-parser.yy" // lalr1.cc:859
+#line 1620 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGet_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2484 "seclang-parser.cc" // lalr1.cc:859
+#line 2475 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 142:
-#line 1626 "seclang-parser.yy" // lalr1.cc:859
+#line 1624 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGet_NoDictElement());
       }
-#line 2492 "seclang-parser.cc" // lalr1.cc:859
+#line 2483 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 143:
-#line 1630 "seclang-parser.yy" // lalr1.cc:859
+#line 1628 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesSizes_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2500 "seclang-parser.cc" // lalr1.cc:859
+#line 2491 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 144:
-#line 1634 "seclang-parser.yy" // lalr1.cc:859
+#line 1632 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesSizes_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2508 "seclang-parser.cc" // lalr1.cc:859
+#line 2499 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 145:
-#line 1638 "seclang-parser.yy" // lalr1.cc:859
+#line 1636 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesSizes_NoDictElement());
       }
-#line 2516 "seclang-parser.cc" // lalr1.cc:859
+#line 2507 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 146:
-#line 1642 "seclang-parser.yy" // lalr1.cc:859
+#line 1640 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2524 "seclang-parser.cc" // lalr1.cc:859
+#line 2515 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 147:
-#line 1646 "seclang-parser.yy" // lalr1.cc:859
+#line 1644 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2532 "seclang-parser.cc" // lalr1.cc:859
+#line 2523 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 148:
-#line 1650 "seclang-parser.yy" // lalr1.cc:859
+#line 1648 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesNames_NoDictElement());
       }
-#line 2540 "seclang-parser.cc" // lalr1.cc:859
+#line 2531 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 149:
-#line 1654 "seclang-parser.yy" // lalr1.cc:859
+#line 1652 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpContent_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2548 "seclang-parser.cc" // lalr1.cc:859
+#line 2539 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 150:
-#line 1658 "seclang-parser.yy" // lalr1.cc:859
+#line 1656 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2556 "seclang-parser.cc" // lalr1.cc:859
+#line 2547 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 151:
-#line 1662 "seclang-parser.yy" // lalr1.cc:859
+#line 1660 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpContent_NoDictElement());
       }
-#line 2564 "seclang-parser.cc" // lalr1.cc:859
+#line 2555 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 152:
-#line 1666 "seclang-parser.yy" // lalr1.cc:859
+#line 1664 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartFileName_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2572 "seclang-parser.cc" // lalr1.cc:859
+#line 2563 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 153:
-#line 1670 "seclang-parser.yy" // lalr1.cc:859
+#line 1668 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2580 "seclang-parser.cc" // lalr1.cc:859
+#line 2571 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 154:
-#line 1674 "seclang-parser.yy" // lalr1.cc:859
+#line 1672 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartFileName_NoDictElement());
       }
-#line 2588 "seclang-parser.cc" // lalr1.cc:859
+#line 2579 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 155:
-#line 1678 "seclang-parser.yy" // lalr1.cc:859
+#line 1676 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartName_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2596 "seclang-parser.cc" // lalr1.cc:859
+#line 2587 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 156:
-#line 1682 "seclang-parser.yy" // lalr1.cc:859
+#line 1680 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartName_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2604 "seclang-parser.cc" // lalr1.cc:859
+#line 2595 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 157:
-#line 1686 "seclang-parser.yy" // lalr1.cc:859
+#line 1684 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultiPartName_NoDictElement());
       }
-#line 2612 "seclang-parser.cc" // lalr1.cc:859
+#line 2603 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 158:
-#line 1690 "seclang-parser.yy" // lalr1.cc:859
+#line 1688 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarsNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2620 "seclang-parser.cc" // lalr1.cc:859
+#line 2611 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 159:
-#line 1694 "seclang-parser.yy" // lalr1.cc:859
+#line 1692 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2628 "seclang-parser.cc" // lalr1.cc:859
+#line 2619 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 160:
-#line 1698 "seclang-parser.yy" // lalr1.cc:859
+#line 1696 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarsNames_NoDictElement());
       }
-#line 2636 "seclang-parser.cc" // lalr1.cc:859
+#line 2627 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 161:
-#line 1702 "seclang-parser.yy" // lalr1.cc:859
+#line 1700 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVars_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2644 "seclang-parser.cc" // lalr1.cc:859
+#line 2635 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 162:
-#line 1706 "seclang-parser.yy" // lalr1.cc:859
+#line 1704 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVars_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2652 "seclang-parser.cc" // lalr1.cc:859
+#line 2643 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 163:
-#line 1710 "seclang-parser.yy" // lalr1.cc:859
+#line 1708 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVars_NoDictElement());
       }
-#line 2660 "seclang-parser.cc" // lalr1.cc:859
+#line 2651 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 164:
-#line 1714 "seclang-parser.yy" // lalr1.cc:859
+#line 1712 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Files_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2668 "seclang-parser.cc" // lalr1.cc:859
+#line 2659 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 165:
-#line 1718 "seclang-parser.yy" // lalr1.cc:859
+#line 1716 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Files_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2676 "seclang-parser.cc" // lalr1.cc:859
+#line 2667 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 166:
-#line 1722 "seclang-parser.yy" // lalr1.cc:859
+#line 1720 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Files_NoDictElement());
       }
-#line 2684 "seclang-parser.cc" // lalr1.cc:859
+#line 2675 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 167:
-#line 1726 "seclang-parser.yy" // lalr1.cc:859
+#line 1724 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookies_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2692 "seclang-parser.cc" // lalr1.cc:859
+#line 2683 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 168:
-#line 1730 "seclang-parser.yy" // lalr1.cc:859
+#line 1728 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookies_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2700 "seclang-parser.cc" // lalr1.cc:859
+#line 2691 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 169:
-#line 1734 "seclang-parser.yy" // lalr1.cc:859
+#line 1732 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookies_NoDictElement());
       }
-#line 2708 "seclang-parser.cc" // lalr1.cc:859
+#line 2699 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 170:
-#line 1738 "seclang-parser.yy" // lalr1.cc:859
+#line 1736 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeaders_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2716 "seclang-parser.cc" // lalr1.cc:859
+#line 2707 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 171:
-#line 1742 "seclang-parser.yy" // lalr1.cc:859
+#line 1740 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2724 "seclang-parser.cc" // lalr1.cc:859
+#line 2715 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 172:
-#line 1746 "seclang-parser.yy" // lalr1.cc:859
+#line 1744 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeaders_NoDictElement());
       }
-#line 2732 "seclang-parser.cc" // lalr1.cc:859
+#line 2723 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 173:
-#line 1750 "seclang-parser.yy" // lalr1.cc:859
+#line 1748 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeaders_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2740 "seclang-parser.cc" // lalr1.cc:859
+#line 2731 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 174:
-#line 1754 "seclang-parser.yy" // lalr1.cc:859
+#line 1752 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2748 "seclang-parser.cc" // lalr1.cc:859
+#line 2739 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 175:
-#line 1758 "seclang-parser.yy" // lalr1.cc:859
+#line 1756 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeaders_NoDictElement());
       }
-#line 2756 "seclang-parser.cc" // lalr1.cc:859
+#line 2747 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 176:
-#line 1762 "seclang-parser.yy" // lalr1.cc:859
+#line 1760 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Geo_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2764 "seclang-parser.cc" // lalr1.cc:859
+#line 2755 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 177:
-#line 1766 "seclang-parser.yy" // lalr1.cc:859
+#line 1764 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Geo_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2772 "seclang-parser.cc" // lalr1.cc:859
+#line 2763 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 178:
-#line 1770 "seclang-parser.yy" // lalr1.cc:859
+#line 1768 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Geo_NoDictElement());
       }
-#line 2780 "seclang-parser.cc" // lalr1.cc:859
+#line 2771 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 179:
-#line 1774 "seclang-parser.yy" // lalr1.cc:859
+#line 1772 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookiesNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2788 "seclang-parser.cc" // lalr1.cc:859
+#line 2779 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 180:
-#line 1778 "seclang-parser.yy" // lalr1.cc:859
+#line 1776 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2796 "seclang-parser.cc" // lalr1.cc:859
+#line 2787 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 181:
-#line 1782 "seclang-parser.yy" // lalr1.cc:859
+#line 1780 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestCookiesNames_NoDictElement());
       }
-#line 2804 "seclang-parser.cc" // lalr1.cc:859
+#line 2795 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 182:
-#line 1786 "seclang-parser.yy" // lalr1.cc:859
+#line 1784 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Rule_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2812 "seclang-parser.cc" // lalr1.cc:859
+#line 2803 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 183:
-#line 1790 "seclang-parser.yy" // lalr1.cc:859
+#line 1788 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Rule_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2820 "seclang-parser.cc" // lalr1.cc:859
+#line 2811 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 184:
-#line 1794 "seclang-parser.yy" // lalr1.cc:859
+#line 1792 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Rule_NoDictElement());
       }
-#line 2828 "seclang-parser.cc" // lalr1.cc:859
+#line 2819 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 185:
-#line 1798 "seclang-parser.yy" // lalr1.cc:859
+#line 1796 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Env("ENV:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2836 "seclang-parser.cc" // lalr1.cc:859
+#line 2827 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 186:
-#line 1802 "seclang-parser.yy" // lalr1.cc:859
+#line 1800 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Env("ENV:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2844 "seclang-parser.cc" // lalr1.cc:859
+#line 2835 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 187:
-#line 1806 "seclang-parser.yy" // lalr1.cc:859
+#line 1804 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Env("ENV"));
       }
-#line 2852 "seclang-parser.cc" // lalr1.cc:859
+#line 2843 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 188:
-#line 1810 "seclang-parser.yy" // lalr1.cc:859
+#line 1808 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::XML("XML:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2860 "seclang-parser.cc" // lalr1.cc:859
+#line 2851 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 189:
-#line 1814 "seclang-parser.yy" // lalr1.cc:859
+#line 1812 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::XML("XML:" + yystack_[0].value.as< std::string > ()));
       }
-#line 2868 "seclang-parser.cc" // lalr1.cc:859
+#line 2859 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 190:
-#line 1818 "seclang-parser.yy" // lalr1.cc:859
+#line 1816 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::XML_NoDictElement());
       }
-#line 2876 "seclang-parser.cc" // lalr1.cc:859
+#line 2867 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 191:
-#line 1822 "seclang-parser.yy" // lalr1.cc:859
+#line 1820 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2884 "seclang-parser.cc" // lalr1.cc:859
+#line 2875 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 192:
-#line 1826 "seclang-parser.yy" // lalr1.cc:859
+#line 1824 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2892 "seclang-parser.cc" // lalr1.cc:859
+#line 2883 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 193:
-#line 1830 "seclang-parser.yy" // lalr1.cc:859
+#line 1828 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesTmpNames_NoDictElement());
       }
-#line 2900 "seclang-parser.cc" // lalr1.cc:859
+#line 2891 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 194:
-#line 1834 "seclang-parser.yy" // lalr1.cc:859
+#line 1832 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_DynamicElement(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 2908 "seclang-parser.cc" // lalr1.cc:859
+#line 2899 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 195:
-#line 1838 "seclang-parser.yy" // lalr1.cc:859
+#line 1836 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2916 "seclang-parser.cc" // lalr1.cc:859
+#line 2907 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 196:
-#line 1842 "seclang-parser.yy" // lalr1.cc:859
+#line 1840 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2924 "seclang-parser.cc" // lalr1.cc:859
+#line 2915 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 197:
-#line 1846 "seclang-parser.yy" // lalr1.cc:859
+#line 1844 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Resource_NoDictElement());
       }
-#line 2932 "seclang-parser.cc" // lalr1.cc:859
+#line 2923 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 198:
-#line 1850 "seclang-parser.yy" // lalr1.cc:859
+#line 1848 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_DynamicElement(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 2940 "seclang-parser.cc" // lalr1.cc:859
+#line 2931 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 199:
-#line 1854 "seclang-parser.yy" // lalr1.cc:859
+#line 1852 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2948 "seclang-parser.cc" // lalr1.cc:859
+#line 2939 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 200:
-#line 1858 "seclang-parser.yy" // lalr1.cc:859
+#line 1856 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2956 "seclang-parser.cc" // lalr1.cc:859
+#line 2947 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 201:
-#line 1862 "seclang-parser.yy" // lalr1.cc:859
+#line 1860 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Ip_NoDictElement());
       }
-#line 2964 "seclang-parser.cc" // lalr1.cc:859
+#line 2955 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 202:
-#line 1866 "seclang-parser.yy" // lalr1.cc:859
+#line 1864 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_DynamicElement(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 2972 "seclang-parser.cc" // lalr1.cc:859
+#line 2963 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 203:
-#line 1870 "seclang-parser.yy" // lalr1.cc:859
+#line 1868 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 2980 "seclang-parser.cc" // lalr1.cc:859
+#line 2971 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 204:
-#line 1874 "seclang-parser.yy" // lalr1.cc:859
+#line 1872 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 2988 "seclang-parser.cc" // lalr1.cc:859
+#line 2979 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 205:
-#line 1878 "seclang-parser.yy" // lalr1.cc:859
+#line 1876 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Global_NoDictElement());
       }
-#line 2996 "seclang-parser.cc" // lalr1.cc:859
+#line 2987 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 206:
-#line 1882 "seclang-parser.yy" // lalr1.cc:859
+#line 1880 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::User_DynamicElement(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 3004 "seclang-parser.cc" // lalr1.cc:859
+#line 2995 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 207:
-#line 1886 "seclang-parser.yy" // lalr1.cc:859
+#line 1884 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::User_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3012 "seclang-parser.cc" // lalr1.cc:859
+#line 3003 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 208:
-#line 1890 "seclang-parser.yy" // lalr1.cc:859
+#line 1888 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::User_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3020 "seclang-parser.cc" // lalr1.cc:859
+#line 3011 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 209:
-#line 1894 "seclang-parser.yy" // lalr1.cc:859
+#line 1892 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::User_NoDictElement());
       }
-#line 3028 "seclang-parser.cc" // lalr1.cc:859
+#line 3019 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 210:
-#line 1898 "seclang-parser.yy" // lalr1.cc:859
+#line 1896 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_DynamicElement(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 3036 "seclang-parser.cc" // lalr1.cc:859
+#line 3027 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 211:
-#line 1902 "seclang-parser.yy" // lalr1.cc:859
+#line 1900 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3044 "seclang-parser.cc" // lalr1.cc:859
+#line 3035 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 212:
-#line 1906 "seclang-parser.yy" // lalr1.cc:859
+#line 1904 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3052 "seclang-parser.cc" // lalr1.cc:859
+#line 3043 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 213:
-#line 1910 "seclang-parser.yy" // lalr1.cc:859
+#line 1908 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Tx_NoDictElement());
       }
-#line 3060 "seclang-parser.cc" // lalr1.cc:859
+#line 3051 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 214:
-#line 1914 "seclang-parser.yy" // lalr1.cc:859
+#line 1912 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_DynamicElement(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 3068 "seclang-parser.cc" // lalr1.cc:859
+#line 3059 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 215:
-#line 1918 "seclang-parser.yy" // lalr1.cc:859
+#line 1916 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3076 "seclang-parser.cc" // lalr1.cc:859
+#line 3067 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 216:
-#line 1922 "seclang-parser.yy" // lalr1.cc:859
+#line 1920 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3084 "seclang-parser.cc" // lalr1.cc:859
+#line 3075 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 217:
-#line 1926 "seclang-parser.yy" // lalr1.cc:859
+#line 1924 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Session_NoDictElement());
       }
-#line 3092 "seclang-parser.cc" // lalr1.cc:859
+#line 3083 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 218:
-#line 1930 "seclang-parser.yy" // lalr1.cc:859
+#line 1928 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3100 "seclang-parser.cc" // lalr1.cc:859
+#line 3091 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 219:
-#line 1934 "seclang-parser.yy" // lalr1.cc:859
+#line 1932 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3108 "seclang-parser.cc" // lalr1.cc:859
+#line 3099 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 220:
-#line 1938 "seclang-parser.yy" // lalr1.cc:859
+#line 1936 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsNames_NoDictElement());
       }
-#line 3116 "seclang-parser.cc" // lalr1.cc:859
+#line 3107 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 221:
-#line 1942 "seclang-parser.yy" // lalr1.cc:859
+#line 1940 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGetNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3124 "seclang-parser.cc" // lalr1.cc:859
+#line 3115 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 222:
-#line 1946 "seclang-parser.yy" // lalr1.cc:859
+#line 1944 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3132 "seclang-parser.cc" // lalr1.cc:859
+#line 3123 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 223:
-#line 1950 "seclang-parser.yy" // lalr1.cc:859
+#line 1948 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsGetNames_NoDictElement());
       }
-#line 3140 "seclang-parser.cc" // lalr1.cc:859
+#line 3131 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 224:
-#line 1955 "seclang-parser.yy" // lalr1.cc:859
+#line 1953 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPostNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3148 "seclang-parser.cc" // lalr1.cc:859
+#line 3139 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 225:
-#line 1959 "seclang-parser.yy" // lalr1.cc:859
+#line 1957 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3156 "seclang-parser.cc" // lalr1.cc:859
+#line 3147 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 226:
-#line 1963 "seclang-parser.yy" // lalr1.cc:859
+#line 1961 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsPostNames_NoDictElement());
       }
-#line 3164 "seclang-parser.cc" // lalr1.cc:859
+#line 3155 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 227:
-#line 1968 "seclang-parser.yy" // lalr1.cc:859
+#line 1966 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeadersNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3172 "seclang-parser.cc" // lalr1.cc:859
+#line 3163 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 228:
-#line 1972 "seclang-parser.yy" // lalr1.cc:859
+#line 1970 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3180 "seclang-parser.cc" // lalr1.cc:859
+#line 3171 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 229:
-#line 1976 "seclang-parser.yy" // lalr1.cc:859
+#line 1974 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestHeadersNames_NoDictElement());
       }
-#line 3188 "seclang-parser.cc" // lalr1.cc:859
+#line 3179 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 230:
-#line 1981 "seclang-parser.yy" // lalr1.cc:859
+#line 1979 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseContentType());
       }
-#line 3196 "seclang-parser.cc" // lalr1.cc:859
+#line 3187 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 231:
-#line 1986 "seclang-parser.yy" // lalr1.cc:859
+#line 1984 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeadersNames_DictElement(yystack_[0].value.as< std::string > ()));
       }
-#line 3204 "seclang-parser.cc" // lalr1.cc:859
+#line 3195 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 232:
-#line 1990 "seclang-parser.yy" // lalr1.cc:859
+#line 1988 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as< std::string > ()));
       }
-#line 3212 "seclang-parser.cc" // lalr1.cc:859
+#line 3203 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 233:
-#line 1994 "seclang-parser.yy" // lalr1.cc:859
+#line 1992 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseHeadersNames_NoDictElement());
       }
-#line 3220 "seclang-parser.cc" // lalr1.cc:859
+#line 3211 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 234:
-#line 1998 "seclang-parser.yy" // lalr1.cc:859
+#line 1996 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ArgsCombinedSize());
       }
-#line 3228 "seclang-parser.cc" // lalr1.cc:859
+#line 3219 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 235:
-#line 2002 "seclang-parser.yy" // lalr1.cc:859
+#line 2000 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::AuthType());
       }
-#line 3236 "seclang-parser.cc" // lalr1.cc:859
+#line 3227 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 236:
-#line 2006 "seclang-parser.yy" // lalr1.cc:859
+#line 2004 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FilesCombinedSize());
       }
-#line 3244 "seclang-parser.cc" // lalr1.cc:859
+#line 3235 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 237:
-#line 2010 "seclang-parser.yy" // lalr1.cc:859
+#line 2008 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FullRequest());
       }
-#line 3252 "seclang-parser.cc" // lalr1.cc:859
+#line 3243 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 238:
-#line 2014 "seclang-parser.yy" // lalr1.cc:859
+#line 2012 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::FullRequestLength());
       }
-#line 3260 "seclang-parser.cc" // lalr1.cc:859
+#line 3251 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 239:
-#line 2018 "seclang-parser.yy" // lalr1.cc:859
+#line 2016 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::InboundDataError());
       }
-#line 3268 "seclang-parser.cc" // lalr1.cc:859
+#line 3259 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 240:
-#line 2022 "seclang-parser.yy" // lalr1.cc:859
+#line 2020 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVar());
       }
-#line 3276 "seclang-parser.cc" // lalr1.cc:859
+#line 3267 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 241:
-#line 2026 "seclang-parser.yy" // lalr1.cc:859
+#line 2024 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MatchedVarName());
       }
-#line 3284 "seclang-parser.cc" // lalr1.cc:859
+#line 3275 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 242:
-#line 2030 "seclang-parser.yy" // lalr1.cc:859
+#line 2028 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartBoundaryQuoted());
       }
-#line 3292 "seclang-parser.cc" // lalr1.cc:859
+#line 3283 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 243:
-#line 2034 "seclang-parser.yy" // lalr1.cc:859
+#line 2032 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartBoundaryWhiteSpace());
       }
-#line 3300 "seclang-parser.cc" // lalr1.cc:859
+#line 3291 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 244:
-#line 2038 "seclang-parser.yy" // lalr1.cc:859
+#line 2036 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartCrlfLFLines());
       }
-#line 3308 "seclang-parser.cc" // lalr1.cc:859
+#line 3299 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 245:
-#line 2042 "seclang-parser.yy" // lalr1.cc:859
+#line 2040 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartDateAfter());
       }
-#line 3316 "seclang-parser.cc" // lalr1.cc:859
+#line 3307 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 246:
-#line 2046 "seclang-parser.yy" // lalr1.cc:859
+#line 2044 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartDateBefore());
       }
-#line 3324 "seclang-parser.cc" // lalr1.cc:859
+#line 3315 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 247:
-#line 2050 "seclang-parser.yy" // lalr1.cc:859
+#line 2048 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartFileLimitExceeded());
       }
-#line 3332 "seclang-parser.cc" // lalr1.cc:859
+#line 3323 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 248:
-#line 2054 "seclang-parser.yy" // lalr1.cc:859
+#line 2052 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartHeaderFolding());
       }
-#line 3340 "seclang-parser.cc" // lalr1.cc:859
+#line 3331 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 249:
-#line 2058 "seclang-parser.yy" // lalr1.cc:859
+#line 2056 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartInvalidHeaderFolding());
       }
-#line 3348 "seclang-parser.cc" // lalr1.cc:859
+#line 3339 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 250:
-#line 2062 "seclang-parser.yy" // lalr1.cc:859
+#line 2060 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartInvalidPart());
       }
-#line 3356 "seclang-parser.cc" // lalr1.cc:859
+#line 3347 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 251:
-#line 2066 "seclang-parser.yy" // lalr1.cc:859
+#line 2064 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartInvalidQuoting());
       }
-#line 3364 "seclang-parser.cc" // lalr1.cc:859
+#line 3355 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 252:
-#line 2070 "seclang-parser.yy" // lalr1.cc:859
+#line 2068 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartLFLine());
       }
-#line 3372 "seclang-parser.cc" // lalr1.cc:859
+#line 3363 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 253:
-#line 2074 "seclang-parser.yy" // lalr1.cc:859
+#line 2072 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartMissingSemicolon());
       }
-#line 3380 "seclang-parser.cc" // lalr1.cc:859
+#line 3371 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 254:
-#line 2078 "seclang-parser.yy" // lalr1.cc:859
+#line 2076 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartStrictError());
       }
-#line 3388 "seclang-parser.cc" // lalr1.cc:859
+#line 3379 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 255:
-#line 2082 "seclang-parser.yy" // lalr1.cc:859
+#line 2080 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::MultipartUnmatchedBoundary());
       }
-#line 3396 "seclang-parser.cc" // lalr1.cc:859
+#line 3387 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 256:
-#line 2086 "seclang-parser.yy" // lalr1.cc:859
+#line 2084 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::OutboundDataError());
       }
-#line 3404 "seclang-parser.cc" // lalr1.cc:859
+#line 3395 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 257:
-#line 2090 "seclang-parser.yy" // lalr1.cc:859
+#line 2088 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::PathInfo());
       }
-#line 3412 "seclang-parser.cc" // lalr1.cc:859
+#line 3403 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 258:
-#line 2094 "seclang-parser.yy" // lalr1.cc:859
+#line 2092 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::QueryString());
       }
-#line 3420 "seclang-parser.cc" // lalr1.cc:859
+#line 3411 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 259:
-#line 2098 "seclang-parser.yy" // lalr1.cc:859
+#line 2096 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RemoteAddr());
       }
-#line 3428 "seclang-parser.cc" // lalr1.cc:859
+#line 3419 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 260:
-#line 2102 "seclang-parser.yy" // lalr1.cc:859
+#line 2100 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RemoteHost());
       }
-#line 3436 "seclang-parser.cc" // lalr1.cc:859
+#line 3427 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 261:
-#line 2106 "seclang-parser.yy" // lalr1.cc:859
+#line 2104 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RemotePort());
       }
-#line 3444 "seclang-parser.cc" // lalr1.cc:859
+#line 3435 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 262:
-#line 2110 "seclang-parser.yy" // lalr1.cc:859
+#line 2108 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyError());
       }
-#line 3452 "seclang-parser.cc" // lalr1.cc:859
+#line 3443 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 263:
-#line 2114 "seclang-parser.yy" // lalr1.cc:859
+#line 2112 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyErrorMsg());
       }
-#line 3460 "seclang-parser.cc" // lalr1.cc:859
+#line 3451 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 264:
-#line 2118 "seclang-parser.yy" // lalr1.cc:859
+#line 2116 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyProcessor());
       }
-#line 3468 "seclang-parser.cc" // lalr1.cc:859
+#line 3459 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 265:
-#line 2122 "seclang-parser.yy" // lalr1.cc:859
+#line 2120 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyProcessorError());
       }
-#line 3476 "seclang-parser.cc" // lalr1.cc:859
+#line 3467 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 266:
-#line 2126 "seclang-parser.yy" // lalr1.cc:859
+#line 2124 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ReqbodyProcessorErrorMsg());
       }
-#line 3484 "seclang-parser.cc" // lalr1.cc:859
+#line 3475 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 267:
-#line 2130 "seclang-parser.yy" // lalr1.cc:859
+#line 2128 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestBasename());
       }
-#line 3492 "seclang-parser.cc" // lalr1.cc:859
+#line 3483 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 268:
-#line 2134 "seclang-parser.yy" // lalr1.cc:859
+#line 2132 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestBody());
       }
-#line 3500 "seclang-parser.cc" // lalr1.cc:859
+#line 3491 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 269:
-#line 2138 "seclang-parser.yy" // lalr1.cc:859
+#line 2136 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestBodyLength());
       }
-#line 3508 "seclang-parser.cc" // lalr1.cc:859
+#line 3499 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 270:
-#line 2142 "seclang-parser.yy" // lalr1.cc:859
+#line 2140 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestFilename());
       }
-#line 3516 "seclang-parser.cc" // lalr1.cc:859
+#line 3507 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 271:
-#line 2146 "seclang-parser.yy" // lalr1.cc:859
+#line 2144 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestLine());
       }
-#line 3524 "seclang-parser.cc" // lalr1.cc:859
+#line 3515 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 272:
-#line 2150 "seclang-parser.yy" // lalr1.cc:859
+#line 2148 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestMethod());
       }
-#line 3532 "seclang-parser.cc" // lalr1.cc:859
+#line 3523 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 273:
-#line 2154 "seclang-parser.yy" // lalr1.cc:859
+#line 2152 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestProtocol());
       }
-#line 3540 "seclang-parser.cc" // lalr1.cc:859
+#line 3531 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 274:
-#line 2158 "seclang-parser.yy" // lalr1.cc:859
+#line 2156 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestURI());
       }
-#line 3548 "seclang-parser.cc" // lalr1.cc:859
+#line 3539 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 275:
-#line 2162 "seclang-parser.yy" // lalr1.cc:859
+#line 2160 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::RequestURIRaw());
       }
-#line 3556 "seclang-parser.cc" // lalr1.cc:859
+#line 3547 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 276:
-#line 2166 "seclang-parser.yy" // lalr1.cc:859
+#line 2164 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseBody());
       }
-#line 3564 "seclang-parser.cc" // lalr1.cc:859
+#line 3555 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 277:
-#line 2170 "seclang-parser.yy" // lalr1.cc:859
+#line 2168 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseContentLength());
       }
-#line 3572 "seclang-parser.cc" // lalr1.cc:859
+#line 3563 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 278:
-#line 2174 "seclang-parser.yy" // lalr1.cc:859
+#line 2172 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseProtocol());
       }
-#line 3580 "seclang-parser.cc" // lalr1.cc:859
+#line 3571 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 279:
-#line 2178 "seclang-parser.yy" // lalr1.cc:859
+#line 2176 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ResponseStatus());
       }
-#line 3588 "seclang-parser.cc" // lalr1.cc:859
+#line 3579 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 280:
-#line 2182 "seclang-parser.yy" // lalr1.cc:859
+#line 2180 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ServerAddr());
       }
-#line 3596 "seclang-parser.cc" // lalr1.cc:859
+#line 3587 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 281:
-#line 2186 "seclang-parser.yy" // lalr1.cc:859
+#line 2184 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ServerName());
       }
-#line 3604 "seclang-parser.cc" // lalr1.cc:859
+#line 3595 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 282:
-#line 2190 "seclang-parser.yy" // lalr1.cc:859
+#line 2188 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::ServerPort());
       }
-#line 3612 "seclang-parser.cc" // lalr1.cc:859
+#line 3603 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 283:
-#line 2194 "seclang-parser.yy" // lalr1.cc:859
+#line 2192 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::SessionID());
       }
-#line 3620 "seclang-parser.cc" // lalr1.cc:859
+#line 3611 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 284:
-#line 2198 "seclang-parser.yy" // lalr1.cc:859
+#line 2196 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::UniqueID());
       }
-#line 3628 "seclang-parser.cc" // lalr1.cc:859
+#line 3619 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 285:
-#line 2202 "seclang-parser.yy" // lalr1.cc:859
+#line 2200 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::UrlEncodedError());
       }
-#line 3636 "seclang-parser.cc" // lalr1.cc:859
+#line 3627 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 286:
-#line 2206 "seclang-parser.yy" // lalr1.cc:859
+#line 2204 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::UserID());
       }
-#line 3644 "seclang-parser.cc" // lalr1.cc:859
+#line 3635 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 287:
-#line 2210 "seclang-parser.yy" // lalr1.cc:859
+#line 2208 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::Status());
       }
-#line 3652 "seclang-parser.cc" // lalr1.cc:859
+#line 3643 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 288:
-#line 2214 "seclang-parser.yy" // lalr1.cc:859
+#line 2212 "seclang-parser.yy" // lalr1.cc:847
     {
         VARIABLE_CONTAINER(yylhs.value.as< std::unique_ptr<Variable> > (), new Variables::WebAppId());
       }
-#line 3660 "seclang-parser.cc" // lalr1.cc:859
+#line 3651 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 289:
-#line 2218 "seclang-parser.yy" // lalr1.cc:859
+#line 2216 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3671 "seclang-parser.cc" // lalr1.cc:859
+#line 3662 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 290:
-#line 2226 "seclang-parser.yy" // lalr1.cc:859
+#line 2224 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3682 "seclang-parser.cc" // lalr1.cc:859
+#line 3673 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 291:
-#line 2233 "seclang-parser.yy" // lalr1.cc:859
+#line 2231 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3693 "seclang-parser.cc" // lalr1.cc:859
+#line 3684 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 292:
-#line 2240 "seclang-parser.yy" // lalr1.cc:859
+#line 2238 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3704 "seclang-parser.cc" // lalr1.cc:859
+#line 3695 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 293:
-#line 2247 "seclang-parser.yy" // lalr1.cc:859
+#line 2245 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3715 "seclang-parser.cc" // lalr1.cc:859
+#line 3706 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 294:
-#line 2254 "seclang-parser.yy" // lalr1.cc:859
+#line 2252 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3726 "seclang-parser.cc" // lalr1.cc:859
+#line 3717 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 295:
-#line 2261 "seclang-parser.yy" // lalr1.cc:859
+#line 2259 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3737 "seclang-parser.cc" // lalr1.cc:859
+#line 3728 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 296:
-#line 2268 "seclang-parser.yy" // lalr1.cc:859
+#line 2266 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3748 "seclang-parser.cc" // lalr1.cc:859
+#line 3739 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 297:
-#line 2275 "seclang-parser.yy" // lalr1.cc:859
+#line 2273 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3759 "seclang-parser.cc" // lalr1.cc:859
+#line 3750 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 298:
-#line 2282 "seclang-parser.yy" // lalr1.cc:859
+#line 2280 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3770 "seclang-parser.cc" // lalr1.cc:859
+#line 3761 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 299:
-#line 2289 "seclang-parser.yy" // lalr1.cc:859
+#line 2287 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3781 "seclang-parser.cc" // lalr1.cc:859
+#line 3772 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 300:
-#line 2296 "seclang-parser.yy" // lalr1.cc:859
+#line 2294 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3792 "seclang-parser.cc" // lalr1.cc:859
+#line 3783 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 301:
-#line 2303 "seclang-parser.yy" // lalr1.cc:859
+#line 2301 "seclang-parser.yy" // lalr1.cc:847
     {
         std::string name(yystack_[0].value.as< std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as< std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 3803 "seclang-parser.cc" // lalr1.cc:859
+#line 3794 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 302:
-#line 2313 "seclang-parser.yy" // lalr1.cc:859
+#line 2311 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as< std::string > ()));
       }
-#line 3811 "seclang-parser.cc" // lalr1.cc:859
+#line 3802 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 303:
-#line 2317 "seclang-parser.yy" // lalr1.cc:859
+#line 2315 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as< std::string > ()));
       }
-#line 3819 "seclang-parser.cc" // lalr1.cc:859
+#line 3810 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 304:
-#line 2321 "seclang-parser.yy" // lalr1.cc:859
+#line 2319 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 3827 "seclang-parser.cc" // lalr1.cc:859
+#line 3818 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 305:
-#line 2325 "seclang-parser.yy" // lalr1.cc:859
+#line 2323 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as< std::string > ()));
       }
-#line 3835 "seclang-parser.cc" // lalr1.cc:859
+#line 3826 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 306:
-#line 2329 "seclang-parser.yy" // lalr1.cc:859
+#line 2327 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Block(yystack_[0].value.as< std::string > ()));
       }
-#line 3843 "seclang-parser.cc" // lalr1.cc:859
+#line 3834 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 307:
-#line 2333 "seclang-parser.yy" // lalr1.cc:859
+#line 2331 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as< std::string > ()));
       }
-#line 3851 "seclang-parser.cc" // lalr1.cc:859
+#line 3842 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 308:
-#line 2337 "seclang-parser.yy" // lalr1.cc:859
+#line 2335 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as< std::string > ()));
       }
-#line 3859 "seclang-parser.cc" // lalr1.cc:859
+#line 3850 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 309:
-#line 2341 "seclang-parser.yy" // lalr1.cc:859
+#line 2339 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3868 "seclang-parser.cc" // lalr1.cc:859
+#line 3859 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 310:
-#line 2346 "seclang-parser.yy" // lalr1.cc:859
+#line 2344 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3877 "seclang-parser.cc" // lalr1.cc:859
+#line 3868 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 311:
-#line 2351 "seclang-parser.yy" // lalr1.cc:859
+#line 2349 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("CtlAuditEngine", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3886 "seclang-parser.cc" // lalr1.cc:859
+#line 3877 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 312:
-#line 2356 "seclang-parser.yy" // lalr1.cc:859
+#line 2354 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as< std::string > ()));
       }
-#line 3894 "seclang-parser.cc" // lalr1.cc:859
+#line 3885 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 313:
-#line 2360 "seclang-parser.yy" // lalr1.cc:859
+#line 2358 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as< std::string > ()));
       }
-#line 3902 "seclang-parser.cc" // lalr1.cc:859
+#line 3893 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 314:
-#line 2364 "seclang-parser.yy" // lalr1.cc:859
+#line 2362 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as< std::string > ()));
       }
-#line 3910 "seclang-parser.cc" // lalr1.cc:859
+#line 3901 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 315:
-#line 2368 "seclang-parser.yy" // lalr1.cc:859
+#line 2366 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3919 "seclang-parser.cc" // lalr1.cc:859
+#line 3910 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 316:
-#line 2373 "seclang-parser.yy" // lalr1.cc:859
+#line 2371 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as< std::string > ()));
       }
-#line 3928 "seclang-parser.cc" // lalr1.cc:859
+#line 3919 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 317:
-#line 2378 "seclang-parser.yy" // lalr1.cc:859
+#line 2376 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as< std::string > () + "true"));
       }
-#line 3936 "seclang-parser.cc" // lalr1.cc:859
+#line 3927 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 318:
-#line 2382 "seclang-parser.yy" // lalr1.cc:859
+#line 2380 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as< std::string > () + "false"));
       }
-#line 3944 "seclang-parser.cc" // lalr1.cc:859
+#line 3935 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 319:
-#line 2386 "seclang-parser.yy" // lalr1.cc:859
+#line 2384 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 3952 "seclang-parser.cc" // lalr1.cc:859
+#line 3943 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 320:
-#line 2390 "seclang-parser.yy" // lalr1.cc:859
+#line 2388 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 3960 "seclang-parser.cc" // lalr1.cc:859
+#line 3951 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 321:
-#line 2394 "seclang-parser.yy" // lalr1.cc:859
+#line 2392 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 3968 "seclang-parser.cc" // lalr1.cc:859
+#line 3959 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 322:
-#line 2398 "seclang-parser.yy" // lalr1.cc:859
+#line 2396 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as< std::string > ()));
       }
-#line 3976 "seclang-parser.cc" // lalr1.cc:859
+#line 3967 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 323:
-#line 2402 "seclang-parser.yy" // lalr1.cc:859
+#line 2400 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as< std::string > ()));
       }
-#line 3984 "seclang-parser.cc" // lalr1.cc:859
+#line 3975 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 324:
-#line 2406 "seclang-parser.yy" // lalr1.cc:859
+#line 2404 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as< std::string > ()));
       }
-#line 3992 "seclang-parser.cc" // lalr1.cc:859
+#line 3983 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 325:
-#line 2410 "seclang-parser.yy" // lalr1.cc:859
+#line 2408 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as< std::string > ()));
       }
-#line 4000 "seclang-parser.cc" // lalr1.cc:859
+#line 3991 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 326:
-#line 2414 "seclang-parser.yy" // lalr1.cc:859
+#line 2412 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 4008 "seclang-parser.cc" // lalr1.cc:859
+#line 3999 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 327:
-#line 2418 "seclang-parser.yy" // lalr1.cc:859
+#line 2416 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("Drop", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[0].value.as< std::string > ()));
       }
-#line 4017 "seclang-parser.cc" // lalr1.cc:859
+#line 4008 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 328:
-#line 2423 "seclang-parser.yy" // lalr1.cc:859
+#line 2421 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as< std::string > ()));
       }
-#line 4025 "seclang-parser.cc" // lalr1.cc:859
+#line 4016 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 329:
-#line 2427 "seclang-parser.yy" // lalr1.cc:859
+#line 2425 "seclang-parser.yy" // lalr1.cc:847
     {
         //ACTION_NOT_SUPPORTED("ExpireVar", @0);
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[0].value.as< std::string > ()));
       }
-#line 4034 "seclang-parser.cc" // lalr1.cc:859
+#line 4025 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 330:
-#line 2432 "seclang-parser.yy" // lalr1.cc:859
+#line 2430 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as< std::string > ()));
       }
-#line 4042 "seclang-parser.cc" // lalr1.cc:859
+#line 4033 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 331:
-#line 2436 "seclang-parser.yy" // lalr1.cc:859
+#line 2434 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as< std::string > (), std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4050 "seclang-parser.cc" // lalr1.cc:859
+#line 4041 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 332:
-#line 2440 "seclang-parser.yy" // lalr1.cc:859
+#line 2438 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4058 "seclang-parser.cc" // lalr1.cc:859
+#line 4049 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 333:
-#line 2444 "seclang-parser.yy" // lalr1.cc:859
+#line 2442 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as< std::string > ()));
       }
-#line 4066 "seclang-parser.cc" // lalr1.cc:859
+#line 4057 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 334:
-#line 2448 "seclang-parser.yy" // lalr1.cc:859
+#line 2446 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as< std::string > ()));
       }
-#line 4074 "seclang-parser.cc" // lalr1.cc:859
+#line 4065 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 335:
-#line 2452 "seclang-parser.yy" // lalr1.cc:859
+#line 2450 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4082 "seclang-parser.cc" // lalr1.cc:859
+#line 4073 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 336:
-#line 2456 "seclang-parser.yy" // lalr1.cc:859
+#line 2454 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as< std::string > ()));
       }
-#line 4090 "seclang-parser.cc" // lalr1.cc:859
+#line 4081 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 337:
-#line 2460 "seclang-parser.yy" // lalr1.cc:859
+#line 2458 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as< std::string > ()));
       }
-#line 4098 "seclang-parser.cc" // lalr1.cc:859
+#line 4089 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 338:
-#line 2464 "seclang-parser.yy" // lalr1.cc:859
+#line 2462 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as< std::string > ()));
       }
-#line 4106 "seclang-parser.cc" // lalr1.cc:859
+#line 4097 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 339:
-#line 2468 "seclang-parser.yy" // lalr1.cc:859
+#line 2466 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as< std::string > ()));
       }
-#line 4114 "seclang-parser.cc" // lalr1.cc:859
+#line 4105 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 340:
-#line 2472 "seclang-parser.yy" // lalr1.cc:859
+#line 2470 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 4122 "seclang-parser.cc" // lalr1.cc:859
+#line 4113 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 341:
-#line 2476 "seclang-parser.yy" // lalr1.cc:859
+#line 2474 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as< std::string > ()));
       }
-#line 4130 "seclang-parser.cc" // lalr1.cc:859
+#line 4121 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 342:
-#line 2480 "seclang-parser.yy" // lalr1.cc:859
+#line 2478 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 4138 "seclang-parser.cc" // lalr1.cc:859
+#line 4129 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 343:
-#line 2484 "seclang-parser.yy" // lalr1.cc:859
+#line 2482 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 4146 "seclang-parser.cc" // lalr1.cc:859
+#line 4137 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 344:
-#line 2488 "seclang-parser.yy" // lalr1.cc:859
+#line 2486 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4154 "seclang-parser.cc" // lalr1.cc:859
+#line 4145 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 345:
-#line 2492 "seclang-parser.yy" // lalr1.cc:859
+#line 2490 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as< std::string > ()));
       }
-#line 4162 "seclang-parser.cc" // lalr1.cc:859
+#line 4153 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 346:
-#line 2496 "seclang-parser.yy" // lalr1.cc:859
+#line 2494 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("SanatiseArg", yystack_[1].location);
       }
-#line 4170 "seclang-parser.cc" // lalr1.cc:859
+#line 4161 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 347:
-#line 2500 "seclang-parser.yy" // lalr1.cc:859
+#line 2498 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("SanatiseMatched", yystack_[1].location);
       }
-#line 4178 "seclang-parser.cc" // lalr1.cc:859
+#line 4169 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 348:
-#line 2504 "seclang-parser.yy" // lalr1.cc:859
+#line 2502 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("SanatiseMatchedBytes", yystack_[1].location);
       }
-#line 4186 "seclang-parser.cc" // lalr1.cc:859
+#line 4177 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 349:
-#line 2508 "seclang-parser.yy" // lalr1.cc:859
+#line 2506 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("SanatiseRequestHeader", yystack_[1].location);
       }
-#line 4194 "seclang-parser.cc" // lalr1.cc:859
+#line 4185 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 350:
-#line 2512 "seclang-parser.yy" // lalr1.cc:859
+#line 2510 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("SanatiseResponseHeader", yystack_[1].location);
       }
-#line 4202 "seclang-parser.cc" // lalr1.cc:859
+#line 4193 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 351:
-#line 2516 "seclang-parser.yy" // lalr1.cc:859
+#line 2514 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_NOT_SUPPORTED("SetEnv", yystack_[1].location);
       }
-#line 4210 "seclang-parser.cc" // lalr1.cc:859
+#line 4201 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 352:
-#line 2520 "seclang-parser.yy" // lalr1.cc:859
+#line 2518 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4218 "seclang-parser.cc" // lalr1.cc:859
+#line 4209 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 353:
-#line 2524 "seclang-parser.yy" // lalr1.cc:859
+#line 2522 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4226 "seclang-parser.cc" // lalr1.cc:859
+#line 4217 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 354:
-#line 2528 "seclang-parser.yy" // lalr1.cc:859
+#line 2526 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4234 "seclang-parser.cc" // lalr1.cc:859
+#line 4225 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 355:
-#line 2532 "seclang-parser.yy" // lalr1.cc:859
+#line 2530 "seclang-parser.yy" // lalr1.cc:847
     {
         yylhs.value.as< std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as< std::unique_ptr<actions::Action> > ());
       }
-#line 4242 "seclang-parser.cc" // lalr1.cc:859
+#line 4233 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 356:
-#line 2536 "seclang-parser.yy" // lalr1.cc:859
+#line 2534 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as< std::string > ()));
       }
-#line 4250 "seclang-parser.cc" // lalr1.cc:859
+#line 4241 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 357:
-#line 2540 "seclang-parser.yy" // lalr1.cc:859
+#line 2538 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as< std::string > ()));
       }
-#line 4258 "seclang-parser.cc" // lalr1.cc:859
+#line 4249 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 358:
-#line 2544 "seclang-parser.yy" // lalr1.cc:859
+#line 2542 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as< std::string > ()));
       }
-#line 4266 "seclang-parser.cc" // lalr1.cc:859
+#line 4257 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 359:
-#line 2548 "seclang-parser.yy" // lalr1.cc:859
+#line 2546 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as< std::string > ()));
       }
-#line 4274 "seclang-parser.cc" // lalr1.cc:859
+#line 4265 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 360:
-#line 2552 "seclang-parser.yy" // lalr1.cc:859
+#line 2550 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4282 "seclang-parser.cc" // lalr1.cc:859
+#line 4273 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 361:
-#line 2556 "seclang-parser.yy" // lalr1.cc:859
+#line 2554 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as< std::string > ()));
       }
-#line 4290 "seclang-parser.cc" // lalr1.cc:859
+#line 4281 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 362:
-#line 2560 "seclang-parser.yy" // lalr1.cc:859
+#line 2558 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as< std::string > ()));
       }
-#line 4298 "seclang-parser.cc" // lalr1.cc:859
+#line 4289 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 363:
-#line 2564 "seclang-parser.yy" // lalr1.cc:859
+#line 2562 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as< std::string > ()));
       }
-#line 4306 "seclang-parser.cc" // lalr1.cc:859
+#line 4297 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 364:
-#line 2568 "seclang-parser.yy" // lalr1.cc:859
+#line 2566 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as< std::string > ()));
       }
-#line 4314 "seclang-parser.cc" // lalr1.cc:859
+#line 4305 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 365:
-#line 2572 "seclang-parser.yy" // lalr1.cc:859
+#line 2570 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as< std::string > ()));
       }
-#line 4322 "seclang-parser.cc" // lalr1.cc:859
+#line 4313 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 366:
-#line 2576 "seclang-parser.yy" // lalr1.cc:859
+#line 2574 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4330 "seclang-parser.cc" // lalr1.cc:859
+#line 4321 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 367:
-#line 2580 "seclang-parser.yy" // lalr1.cc:859
+#line 2578 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as< std::string > ()));
       }
-#line 4338 "seclang-parser.cc" // lalr1.cc:859
+#line 4329 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 368:
-#line 2584 "seclang-parser.yy" // lalr1.cc:859
+#line 2582 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as< std::string > ()));
       }
-#line 4346 "seclang-parser.cc" // lalr1.cc:859
+#line 4337 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 369:
-#line 2588 "seclang-parser.yy" // lalr1.cc:859
+#line 2586 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as< std::string > ()));
       }
-#line 4354 "seclang-parser.cc" // lalr1.cc:859
+#line 4345 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 370:
-#line 2592 "seclang-parser.yy" // lalr1.cc:859
+#line 2590 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as< std::string > ()));
       }
-#line 4362 "seclang-parser.cc" // lalr1.cc:859
+#line 4353 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 371:
-#line 2596 "seclang-parser.yy" // lalr1.cc:859
+#line 2594 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as< std::string > ()));
       }
-#line 4370 "seclang-parser.cc" // lalr1.cc:859
+#line 4361 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 372:
-#line 2600 "seclang-parser.yy" // lalr1.cc:859
+#line 2598 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as< std::string > ()));
       }
-#line 4378 "seclang-parser.cc" // lalr1.cc:859
+#line 4369 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 373:
-#line 2604 "seclang-parser.yy" // lalr1.cc:859
+#line 2602 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as< std::string > ()));
       }
-#line 4386 "seclang-parser.cc" // lalr1.cc:859
+#line 4377 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 374:
-#line 2608 "seclang-parser.yy" // lalr1.cc:859
+#line 2606 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4394 "seclang-parser.cc" // lalr1.cc:859
+#line 4385 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 375:
-#line 2612 "seclang-parser.yy" // lalr1.cc:859
+#line 2610 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as< std::string > ()));
       }
-#line 4402 "seclang-parser.cc" // lalr1.cc:859
+#line 4393 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 376:
-#line 2616 "seclang-parser.yy" // lalr1.cc:859
+#line 2614 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as< std::string > ()));
       }
-#line 4410 "seclang-parser.cc" // lalr1.cc:859
+#line 4401 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 377:
-#line 2620 "seclang-parser.yy" // lalr1.cc:859
+#line 2618 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as< std::string > ()));
       }
-#line 4418 "seclang-parser.cc" // lalr1.cc:859
+#line 4409 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 378:
-#line 2624 "seclang-parser.yy" // lalr1.cc:859
+#line 2622 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4426 "seclang-parser.cc" // lalr1.cc:859
+#line 4417 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 379:
-#line 2628 "seclang-parser.yy" // lalr1.cc:859
+#line 2626 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as< std::string > ()));
       }
-#line 4434 "seclang-parser.cc" // lalr1.cc:859
+#line 4425 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 380:
-#line 2632 "seclang-parser.yy" // lalr1.cc:859
+#line 2630 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as< std::string > ()));
       }
-#line 4442 "seclang-parser.cc" // lalr1.cc:859
+#line 4433 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 381:
-#line 2636 "seclang-parser.yy" // lalr1.cc:859
+#line 2634 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as< std::string > ()));
       }
-#line 4450 "seclang-parser.cc" // lalr1.cc:859
+#line 4441 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 382:
-#line 2640 "seclang-parser.yy" // lalr1.cc:859
+#line 2638 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as< std::string > ()));
       }
-#line 4458 "seclang-parser.cc" // lalr1.cc:859
+#line 4449 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 383:
-#line 2644 "seclang-parser.yy" // lalr1.cc:859
+#line 2642 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as< std::string > ()));
       }
-#line 4466 "seclang-parser.cc" // lalr1.cc:859
+#line 4457 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 384:
-#line 2648 "seclang-parser.yy" // lalr1.cc:859
+#line 2646 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4474 "seclang-parser.cc" // lalr1.cc:859
+#line 4465 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 385:
-#line 2652 "seclang-parser.yy" // lalr1.cc:859
+#line 2650 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4482 "seclang-parser.cc" // lalr1.cc:859
+#line 4473 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 386:
-#line 2656 "seclang-parser.yy" // lalr1.cc:859
+#line 2654 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as< std::string > ()));
       }
-#line 4490 "seclang-parser.cc" // lalr1.cc:859
+#line 4481 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 387:
-#line 2660 "seclang-parser.yy" // lalr1.cc:859
+#line 2658 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as< std::string > ()));
       }
-#line 4498 "seclang-parser.cc" // lalr1.cc:859
+#line 4489 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 388:
-#line 2664 "seclang-parser.yy" // lalr1.cc:859
+#line 2662 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as< std::string > ()));
       }
-#line 4506 "seclang-parser.cc" // lalr1.cc:859
+#line 4497 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 389:
-#line 2668 "seclang-parser.yy" // lalr1.cc:859
+#line 2666 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as< std::string > ()));
       }
-#line 4514 "seclang-parser.cc" // lalr1.cc:859
+#line 4505 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 390:
-#line 2672 "seclang-parser.yy" // lalr1.cc:859
+#line 2670 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as< std::string > ()));
       }
-#line 4522 "seclang-parser.cc" // lalr1.cc:859
+#line 4513 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 391:
-#line 2676 "seclang-parser.yy" // lalr1.cc:859
+#line 2674 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as< std::string > ()));
       }
-#line 4530 "seclang-parser.cc" // lalr1.cc:859
+#line 4521 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 392:
-#line 2680 "seclang-parser.yy" // lalr1.cc:859
+#line 2678 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as< std::string > ()));
       }
-#line 4538 "seclang-parser.cc" // lalr1.cc:859
+#line 4529 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 393:
-#line 2684 "seclang-parser.yy" // lalr1.cc:859
+#line 2682 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as< std::string > ()));
       }
-#line 4546 "seclang-parser.cc" // lalr1.cc:859
+#line 4537 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 394:
-#line 2688 "seclang-parser.yy" // lalr1.cc:859
+#line 2686 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as< std::string > ()));
       }
-#line 4554 "seclang-parser.cc" // lalr1.cc:859
+#line 4545 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 395:
-#line 2695 "seclang-parser.yy" // lalr1.cc:859
+#line 2693 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
       }
-#line 4562 "seclang-parser.cc" // lalr1.cc:859
+#line 4553 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 396:
-#line 2699 "seclang-parser.yy" // lalr1.cc:859
+#line 2697 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ())));
       }
-#line 4570 "seclang-parser.cc" // lalr1.cc:859
+#line 4561 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 397:
-#line 2703 "seclang-parser.yy" // lalr1.cc:859
+#line 2701 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as< std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4578 "seclang-parser.cc" // lalr1.cc:859
+#line 4569 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 398:
-#line 2707 "seclang-parser.yy" // lalr1.cc:859
+#line 2705 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as< std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4586 "seclang-parser.cc" // lalr1.cc:859
+#line 4577 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 399:
-#line 2711 "seclang-parser.yy" // lalr1.cc:859
+#line 2709 "seclang-parser.yy" // lalr1.cc:847
     {
         ACTION_CONTAINER(yylhs.value.as< std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as< std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as< std::unique_ptr<RunTimeString> > ())));
       }
-#line 4594 "seclang-parser.cc" // lalr1.cc:859
+#line 4585 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 400:
-#line 2718 "seclang-parser.yy" // lalr1.cc:859
+#line 2716 "seclang-parser.yy" // lalr1.cc:847
     {
         yystack_[1].value.as< std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as< std::string > ());
         yylhs.value.as< std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as< std::unique_ptr<RunTimeString> > ());
       }
-#line 4603 "seclang-parser.cc" // lalr1.cc:859
+#line 4594 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 401:
-#line 2723 "seclang-parser.yy" // lalr1.cc:859
+#line 2721 "seclang-parser.yy" // lalr1.cc:847
     {
         yystack_[1].value.as< std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ()));
         yylhs.value.as< std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as< std::unique_ptr<RunTimeString> > ());
       }
-#line 4612 "seclang-parser.cc" // lalr1.cc:859
+#line 4603 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 402:
-#line 2728 "seclang-parser.yy" // lalr1.cc:859
+#line 2726 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as< std::string > ());
         yylhs.value.as< std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 4622 "seclang-parser.cc" // lalr1.cc:859
+#line 4613 "seclang-parser.cc" // lalr1.cc:847
     break;
 
   case 403:
-#line 2734 "seclang-parser.yy" // lalr1.cc:859
+#line 2732 "seclang-parser.yy" // lalr1.cc:847
     {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as< std::unique_ptr<Variable> > ()));
         yylhs.value.as< std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 4632 "seclang-parser.cc" // lalr1.cc:859
+#line 4623 "seclang-parser.cc" // lalr1.cc:847
     break;
 
 
-#line 4636 "seclang-parser.cc" // lalr1.cc:859
+#line 4627 "seclang-parser.cc" // lalr1.cc:847
             default:
               break;
             }
@@ -4660,7 +4651,8 @@ namespace yy {
     if (!yyerrstatus_)
       {
         ++yynerrs_;
-        error (yyla.location, yysyntax_error_ (yystack_[0].state, yyla));
+        error (yyla.location, yysyntax_error_ (yystack_[0].state,
+                                           yyempty ? yyempty_ : yyla.type_get ()));
       }
 
 
@@ -4673,10 +4665,10 @@ namespace yy {
         // Return failure if at end of input.
         if (yyla.type_get () == yyeof_)
           YYABORT;
-        else if (!yyla.empty ())
+        else if (!yyempty)
           {
             yy_destroy_ ("Error: discarding", yyla);
-            yyla.clear ();
+            yyempty = true;
           }
       }
 
@@ -4752,7 +4744,7 @@ namespace yy {
     goto yyreturn;
 
   yyreturn:
-    if (!yyla.empty ())
+    if (!yyempty)
       yy_destroy_ ("Cleanup: discarding lookahead", yyla);
 
     /* Do not reclaim the symbols of the rule whose action triggered
@@ -4772,7 +4764,7 @@ namespace yy {
                  << std::endl;
         // Do not try to display the values of the reclaimed symbols,
         // as their printer might throw an exception.
-        if (!yyla.empty ())
+        if (!yyempty)
           yy_destroy_ (YY_NULLPTR, yyla);
 
         while (1 < yystack_.size ())
@@ -4792,8 +4784,9 @@ namespace yy {
 
   // Generate an error message.
   std::string
-  seclang_parser::yysyntax_error_ (state_type yystate, const symbol_type& yyla) const
+  seclang_parser::yysyntax_error_ (state_type yystate, symbol_number_type yytoken) const
   {
+    std::string yyres;
     // Number of reported tokens (one for the "unexpected", one per
     // "expected").
     size_t yycount = 0;
@@ -4807,7 +4800,7 @@ namespace yy {
          the only way this function was invoked is if the default action
          is an error action.  In that case, don't check for expected
          tokens because there are none.
-       - The only way there can be no lookahead present (in yyla) is
+       - The only way there can be no lookahead present (in yytoken) is
          if this state is a consistent state with a default action.
          Thus, detecting the absence of a lookahead is sufficient to
          determine that there is no unexpected or expected token to
@@ -4827,9 +4820,8 @@ namespace yy {
          token that will not be accepted due to an error action in a
          later state.
     */
-    if (!yyla.empty ())
+    if (yytoken != yyempty_)
       {
-        int yytoken = yyla.type_get ();
         yyarg[yycount++] = yytname_[yytoken];
         int yyn = yypact_[yystate];
         if (!yy_pact_value_is_default_ (yyn))
@@ -4872,7 +4864,6 @@ namespace yy {
 #undef YYCASE_
       }
 
-    std::string yyres;
     // Argument number.
     size_t yyi = 0;
     for (char const* yyp = yyformat; *yyp; ++yyp)
@@ -5957,43 +5948,43 @@ namespace yy {
      745,   751,   757,   763,   769,   774,   779,   785,   792,   796,
      800,   806,   810,   814,   819,   824,   829,   833,   840,   844,
      851,   857,   867,   876,   886,   895,   908,   912,   916,   920,
-     924,   928,   932,   936,   940,   944,   949,   953,   957,   962,
-     967,   972,   977,   981,   985,   989,   993,   997,  1001,  1005,
-    1009,  1013,  1017,  1021,  1025,  1029,  1033,  1037,  1041,  1045,
-    1049,  1063,  1064,  1088,  1107,  1122,  1146,  1202,  1206,  1210,
-    1214,  1218,  1222,  1226,  1230,  1234,  1243,  1247,  1252,  1257,
-    1262,  1267,  1272,  1285,  1298,  1311,  1324,  1337,  1363,  1389,
-    1401,  1421,  1449,  1454,  1459,  1468,  1473,  1477,  1481,  1485,
-    1489,  1493,  1497,  1498,  1499,  1511,  1517,  1521,  1525,  1526,
-    1527,  1528,  1529,  1530,  1531,  1534,  1542,  1546,  1553,  1558,
-    1564,  1570,  1576,  1583,  1593,  1597,  1601,  1605,  1609,  1613,
-    1617,  1621,  1625,  1629,  1633,  1637,  1641,  1645,  1649,  1653,
-    1657,  1661,  1665,  1669,  1673,  1677,  1681,  1685,  1689,  1693,
-    1697,  1701,  1705,  1709,  1713,  1717,  1721,  1725,  1729,  1733,
-    1737,  1741,  1745,  1749,  1753,  1757,  1761,  1765,  1769,  1773,
-    1777,  1781,  1785,  1789,  1793,  1797,  1801,  1805,  1809,  1813,
-    1817,  1821,  1825,  1829,  1833,  1837,  1841,  1845,  1849,  1853,
-    1857,  1861,  1865,  1869,  1873,  1877,  1881,  1885,  1889,  1893,
-    1897,  1901,  1905,  1909,  1913,  1917,  1921,  1925,  1929,  1933,
-    1937,  1941,  1945,  1949,  1954,  1958,  1962,  1967,  1971,  1975,
-    1980,  1985,  1989,  1993,  1997,  2001,  2005,  2009,  2013,  2017,
-    2021,  2025,  2029,  2033,  2037,  2041,  2045,  2049,  2053,  2057,
-    2061,  2065,  2069,  2073,  2077,  2081,  2085,  2089,  2093,  2097,
-    2101,  2105,  2109,  2113,  2117,  2121,  2125,  2129,  2133,  2137,
-    2141,  2145,  2149,  2153,  2157,  2161,  2165,  2169,  2173,  2177,
-    2181,  2185,  2189,  2193,  2197,  2201,  2205,  2209,  2213,  2217,
-    2225,  2232,  2239,  2246,  2253,  2260,  2267,  2274,  2281,  2288,
-    2295,  2302,  2312,  2316,  2320,  2324,  2328,  2332,  2336,  2340,
-    2345,  2350,  2355,  2359,  2363,  2367,  2372,  2377,  2381,  2385,
-    2389,  2393,  2397,  2401,  2405,  2409,  2413,  2417,  2422,  2426,
-    2431,  2435,  2439,  2443,  2447,  2451,  2455,  2459,  2463,  2467,
-    2471,  2475,  2479,  2483,  2487,  2491,  2495,  2499,  2503,  2507,
-    2511,  2515,  2519,  2523,  2527,  2531,  2535,  2539,  2543,  2547,
-    2551,  2555,  2559,  2563,  2567,  2571,  2575,  2579,  2583,  2587,
-    2591,  2595,  2599,  2603,  2607,  2611,  2615,  2619,  2623,  2627,
-    2631,  2635,  2639,  2643,  2647,  2651,  2655,  2659,  2663,  2667,
-    2671,  2675,  2679,  2683,  2687,  2694,  2698,  2702,  2706,  2710,
-    2717,  2722,  2727,  2733
+     924,   928,   932,   936,   940,   944,   949,   953,   957,   961,
+     965,   970,   975,   979,   983,   987,   991,   995,   999,  1003,
+    1007,  1011,  1015,  1019,  1023,  1027,  1031,  1035,  1039,  1043,
+    1047,  1061,  1062,  1086,  1105,  1120,  1144,  1200,  1204,  1208,
+    1212,  1216,  1220,  1224,  1228,  1232,  1241,  1245,  1250,  1255,
+    1260,  1265,  1270,  1283,  1296,  1309,  1322,  1335,  1361,  1387,
+    1399,  1419,  1447,  1452,  1457,  1466,  1471,  1475,  1479,  1483,
+    1487,  1491,  1495,  1496,  1497,  1509,  1515,  1519,  1523,  1524,
+    1525,  1526,  1527,  1528,  1529,  1532,  1540,  1544,  1551,  1556,
+    1562,  1568,  1574,  1581,  1591,  1595,  1599,  1603,  1607,  1611,
+    1615,  1619,  1623,  1627,  1631,  1635,  1639,  1643,  1647,  1651,
+    1655,  1659,  1663,  1667,  1671,  1675,  1679,  1683,  1687,  1691,
+    1695,  1699,  1703,  1707,  1711,  1715,  1719,  1723,  1727,  1731,
+    1735,  1739,  1743,  1747,  1751,  1755,  1759,  1763,  1767,  1771,
+    1775,  1779,  1783,  1787,  1791,  1795,  1799,  1803,  1807,  1811,
+    1815,  1819,  1823,  1827,  1831,  1835,  1839,  1843,  1847,  1851,
+    1855,  1859,  1863,  1867,  1871,  1875,  1879,  1883,  1887,  1891,
+    1895,  1899,  1903,  1907,  1911,  1915,  1919,  1923,  1927,  1931,
+    1935,  1939,  1943,  1947,  1952,  1956,  1960,  1965,  1969,  1973,
+    1978,  1983,  1987,  1991,  1995,  1999,  2003,  2007,  2011,  2015,
+    2019,  2023,  2027,  2031,  2035,  2039,  2043,  2047,  2051,  2055,
+    2059,  2063,  2067,  2071,  2075,  2079,  2083,  2087,  2091,  2095,
+    2099,  2103,  2107,  2111,  2115,  2119,  2123,  2127,  2131,  2135,
+    2139,  2143,  2147,  2151,  2155,  2159,  2163,  2167,  2171,  2175,
+    2179,  2183,  2187,  2191,  2195,  2199,  2203,  2207,  2211,  2215,
+    2223,  2230,  2237,  2244,  2251,  2258,  2265,  2272,  2279,  2286,
+    2293,  2300,  2310,  2314,  2318,  2322,  2326,  2330,  2334,  2338,
+    2343,  2348,  2353,  2357,  2361,  2365,  2370,  2375,  2379,  2383,
+    2387,  2391,  2395,  2399,  2403,  2407,  2411,  2415,  2420,  2424,
+    2429,  2433,  2437,  2441,  2445,  2449,  2453,  2457,  2461,  2465,
+    2469,  2473,  2477,  2481,  2485,  2489,  2493,  2497,  2501,  2505,
+    2509,  2513,  2517,  2521,  2525,  2529,  2533,  2537,  2541,  2545,
+    2549,  2553,  2557,  2561,  2565,  2569,  2573,  2577,  2581,  2585,
+    2589,  2593,  2597,  2601,  2605,  2609,  2613,  2617,  2621,  2625,
+    2629,  2633,  2637,  2641,  2645,  2649,  2653,  2657,  2661,  2665,
+    2669,  2673,  2677,  2681,  2685,  2692,  2696,  2700,  2704,  2708,
+    2715,  2720,  2725,  2731
   };
 
   // Print the state stack on the debug stream.
@@ -6028,8 +6019,8 @@ namespace yy {
 
 
 } // yy
-#line 6032 "seclang-parser.cc" // lalr1.cc:1167
-#line 2740 "seclang-parser.yy" // lalr1.cc:1168
+#line 6023 "seclang-parser.cc" // lalr1.cc:1155
+#line 2738 "seclang-parser.yy" // lalr1.cc:1156
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.hh
+++ b/src/parser/seclang-parser.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.0.4.
+// A Bison parser, made by GNU Bison 3.0.2.
 
 // Skeleton interface for Bison LALR(1) parsers in C++
 
-// Copyright (C) 2002-2015 Free Software Foundation, Inc.
+// Copyright (C) 2002-2013 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@
 #ifndef YY_YY_SECLANG_PARSER_HH_INCLUDED
 # define YY_YY_SECLANG_PARSER_HH_INCLUDED
 // //                    "%code requires" blocks.
-#line 10 "seclang-parser.yy" // lalr1.cc:377
+#line 10 "seclang-parser.yy" // lalr1.cc:372
 
 #include <string>
 #include <iterator>
@@ -378,14 +378,13 @@ using modsecurity::operators::Operator;
 
 
 
-#line 382 "seclang-parser.hh" // lalr1.cc:377
+#line 382 "seclang-parser.hh" // lalr1.cc:372
 
 # include <cassert>
-# include <cstdlib> // std::abort
+# include <vector>
 # include <iostream>
 # include <stdexcept>
 # include <string>
-# include <vector>
 # include "stack.hh"
 # include "location.hh"
 #include <typeinfo>
@@ -455,7 +454,7 @@ using modsecurity::operators::Operator;
 
 
 namespace yy {
-#line 459 "seclang-parser.hh" // lalr1.cc:377
+#line 458 "seclang-parser.hh" // lalr1.cc:372
 
 
 
@@ -472,13 +471,13 @@ namespace yy {
 
     /// Empty construction.
     variant ()
-      : yytypeid_ (YY_NULLPTR)
+      : yytname_ (YY_NULLPTR)
     {}
 
     /// Construct and fill.
     template <typename T>
     variant (const T& t)
-      : yytypeid_ (&typeid (T))
+      : yytname_ (typeid (T).name ())
     {
       YYASSERT (sizeof (T) <= S);
       new (yyas_<T> ()) T (t);
@@ -487,7 +486,7 @@ namespace yy {
     /// Destruction, allowed only if empty.
     ~variant ()
     {
-      YYASSERT (!yytypeid_);
+      YYASSERT (!yytname_);
     }
 
     /// Instantiate an empty \a T in here.
@@ -495,9 +494,9 @@ namespace yy {
     T&
     build ()
     {
-      YYASSERT (!yytypeid_);
+      YYASSERT (!yytname_);
       YYASSERT (sizeof (T) <= S);
-      yytypeid_ = & typeid (T);
+      yytname_ = typeid (T).name ();
       return *new (yyas_<T> ()) T;
     }
 
@@ -506,9 +505,9 @@ namespace yy {
     T&
     build (const T& t)
     {
-      YYASSERT (!yytypeid_);
+      YYASSERT (!yytname_);
       YYASSERT (sizeof (T) <= S);
-      yytypeid_ = & typeid (T);
+      yytname_ = typeid (T).name ();
       return *new (yyas_<T> ()) T (std::move((T&)t));
     }
 
@@ -517,7 +516,7 @@ namespace yy {
     T&
     as ()
     {
-      YYASSERT (*yytypeid_ == typeid (T));
+      YYASSERT (yytname_ == typeid (T).name ());
       YYASSERT (sizeof (T) <= S);
       return *yyas_<T> ();
     }
@@ -527,7 +526,7 @@ namespace yy {
     const T&
     as () const
     {
-      YYASSERT (*yytypeid_ == typeid (T));
+      YYASSERT (yytname_ == typeid (T).name ());
       YYASSERT (sizeof (T) <= S);
       return *yyas_<T> ();
     }
@@ -544,8 +543,8 @@ namespace yy {
     void
     swap (self_type& other)
     {
-      YYASSERT (yytypeid_);
-      YYASSERT (*yytypeid_ == *other.yytypeid_);
+      YYASSERT (yytname_);
+      YYASSERT (yytname_ == other.yytname_);
       std::swap (as<T> (), other.as<T> ());
     }
 
@@ -575,7 +574,7 @@ namespace yy {
     destroy ()
     {
       as<T> ().~T ();
-      yytypeid_ = YY_NULLPTR;
+      yytname_ = YY_NULLPTR;
     }
 
   private:
@@ -610,7 +609,7 @@ namespace yy {
     } yybuffer_;
 
     /// Whether the content is built: if defined, the name of the stored type.
-    const std::type_info *yytypeid_;
+    const char *yytname_;
   };
 
 
@@ -1153,11 +1152,8 @@ namespace yy {
     /// (External) token type, as returned by yylex.
     typedef token::yytokentype token_type;
 
-    /// Symbol type: an internal symbol number.
+    /// Internal symbol number.
     typedef int symbol_number_type;
-
-    /// The symbol type number to denote an empty symbol.
-    enum { empty_symbol = -2 };
 
     /// Internal symbol number for tokens (subsumed by symbol_number_type).
     typedef unsigned short int token_number_type;
@@ -1204,14 +1200,7 @@ namespace yy {
                     const semantic_type& v,
                     const location_type& l);
 
-      /// Destroy the symbol.
       ~basic_symbol ();
-
-      /// Destroy contents, and record that is empty.
-      void clear ();
-
-      /// Whether empty.
-      bool empty () const;
 
       /// Destructive move, \a s is emptied into this.
       void move (basic_symbol& s);
@@ -1242,23 +1231,21 @@ namespace yy {
       /// Constructor from (external) token numbers.
       by_type (kind_type t);
 
-      /// Record that this symbol is empty.
-      void clear ();
-
       /// Steal the symbol type from \a that.
       void move (by_type& that);
 
       /// The (internal) type number (corresponding to \a type).
-      /// \a empty when empty.
+      /// -1 when this symbol is empty.
       symbol_number_type type_get () const;
 
       /// The token.
       token_type token () const;
 
+      enum { empty = 0 };
+
       /// The symbol type.
-      /// \a empty_symbol when empty.
-      /// An int, not token_number_type, to be able to store empty_symbol.
-      int type;
+      /// -1 when this symbol is empty.
+      token_number_type type;
     };
 
     /// "External" symbols: returned by the scanner.
@@ -2546,9 +2533,9 @@ namespace yy {
 
     /// Generate an error message.
     /// \param yystate   the state where the error occurred.
-    /// \param yyla      the lookahead token.
+    /// \param yytoken   the lookahead token type, or yyempty_.
     virtual std::string yysyntax_error_ (state_type yystate,
-                                         const symbol_type& yyla) const;
+                                         symbol_number_type yytoken) const;
 
     /// Compute post-reduction state.
     /// \param yystate   the current state
@@ -2651,21 +2638,16 @@ namespace yy {
       /// Copy constructor.
       by_state (const by_state& other);
 
-      /// Record that this symbol is empty.
-      void clear ();
-
       /// Steal the symbol type from \a that.
       void move (by_state& that);
 
       /// The (internal) type number (corresponding to \a state).
-      /// \a empty_symbol when empty.
+      /// "empty" when empty.
       symbol_number_type type_get () const;
 
-      /// The state number used to denote an empty symbol.
-      enum { empty_state = -1 };
+      enum { empty = 0 };
 
       /// The state.
-      /// \a empty when empty.
       state_type state;
     };
 
@@ -2706,12 +2688,13 @@ namespace yy {
     /// Pop \a n symbols the three stacks.
     void yypop_ (unsigned int n = 1);
 
-    /// Constants.
+    // Constants.
     enum
     {
       yyeof_ = 0,
       yylast_ = 3094,     ///< Last index in yytable_.
       yynnts_ = 15,  ///< Number of nonterminal symbols.
+      yyempty_ = -2,
       yyfinal_ = 297, ///< Termination state number.
       yyterror_ = 1,
       yyerrcode_ = 256,
@@ -3311,18 +3294,8 @@ namespace yy {
   inline
   seclang_parser::basic_symbol<Base>::~basic_symbol ()
   {
-    clear ();
-  }
-
-  template <typename Base>
-  inline
-  void
-  seclang_parser::basic_symbol<Base>::clear ()
-  {
     // User destructor.
     symbol_number_type yytype = this->type_get ();
-    basic_symbol<Base>& yysym = *this;
-    (void) yysym;
     switch (yytype)
     {
    default:
@@ -3537,15 +3510,6 @@ namespace yy {
         break;
     }
 
-    Base::clear ();
-  }
-
-  template <typename Base>
-  inline
-  bool
-  seclang_parser::basic_symbol<Base>::empty () const
-  {
-    return Base::type_get () == empty_symbol;
   }
 
   template <typename Base>
@@ -3767,7 +3731,7 @@ namespace yy {
   // by_type.
   inline
   seclang_parser::by_type::by_type ()
-    : type (empty_symbol)
+     : type (empty)
   {}
 
   inline
@@ -3782,17 +3746,10 @@ namespace yy {
 
   inline
   void
-  seclang_parser::by_type::clear ()
-  {
-    type = empty_symbol;
-  }
-
-  inline
-  void
   seclang_parser::by_type::move (by_type& that)
   {
     type = that.type;
-    that.clear ();
+    that.type = empty;
   }
 
   inline
@@ -5711,7 +5668,7 @@ namespace yy {
 
 
 } // yy
-#line 5715 "seclang-parser.hh" // lalr1.cc:377
+#line 5672 "seclang-parser.hh" // lalr1.cc:372
 
 
 

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -956,13 +956,11 @@ op_before_init:
       }
     | OPERATOR_VERIFY_CPF run_time_string
       {
-        /* $$ = new operators::VerifyCPF($1); */
-        OPERATOR_NOT_SUPPORTED("VerifyCPF", @0);
+        OPERATOR_CONTAINER($$, new operators::VerifyCPF(std::move($2)));
       }
     | OPERATOR_VERIFY_SSN run_time_string
       {
-        /* $$ = new operators::VerifySSN($1); */
-        OPERATOR_NOT_SUPPORTED("VerifySSN", @0);
+        OPERATOR_CONTAINER($$, new operators::VerifySSN(std::move($2)));
       }
     | OPERATOR_GSB_LOOKUP run_time_string
       {


### PR DESCRIPTION
Add missing references in the parser.

Solves the ``Operator: verifyCPF is not yet supported.`` and ``Operator: verifySSN is not yet supported.`` errors if one tries to use [verifyCPF](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#verifyCPF) or [verifySSN](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#verifySSN) with libModSecurity.