### PR TITLE
Reverse logic of checking output in @inspectFile

### DIFF
--- a/src/operators/inspect_file.cc
+++ b/src/operators/inspect_file.cc
@@ -73,10 +73,11 @@ bool InspectFile::evaluate(Transaction *transaction, const std::string &str) {
         pclose(in);
 
         res.append(s.str());
-        if (res.size() > 1 && res.at(0) == '1') {
-            return true;
+        if (res.size() > 1 && res.at(0) != '1') {
+            return true; /* match */
         }
 
+        /* no match */
         return false;
     }
 }

--- a/test/test-cases/regression/operator-inpectFile.json
+++ b/test/test-cases/regression/operator-inpectFile.json
@@ -19,7 +19,7 @@
         "Content-Length": "27",
         "Content-Type": "application/x-www-form-urlencoded"
       },
-      "uri":"/whee?res=0",
+      "uri":"/whee?res=1",
       "method":"GET",
       "body": [ ]
     },
@@ -57,7 +57,7 @@
         "Content-Length": "27",
         "Content-Type": "application/x-www-form-urlencoded"
       },
-      "uri":"/whee?res=1",
+      "uri":"/whee?res=0",
       "method":"GET",
       "body": [ ]
     },
@@ -106,7 +106,7 @@
       ]
     },
     "expected":{
-      "debug_log":"Rule returned 0."
+      "debug_log":"Rule returned 1."
     },
     "rules":[
       "SecRuleEngine On",


### PR DESCRIPTION
This change makes `@inspectFile` in ModSecurity 3.x to operate in exact the same way as it operates in ModSecurity 2.x, so existing helper scripts like `runav.pl` [1] will work without any changes.

See the difference in the corresponding logic of existing code:

ModSecurity 2.x: https://github.com/SpiderLabs/ModSecurity/blob/v2/master/apache2/re_operators.c#L4069-L4074

libmodsecurity (ModSecurity 3.x): https://github.com/SpiderLabs/ModSecurity/blob/v3/master/src/operators/inspect_file.cc#L76-L78

(I would say that it could be better rather to check exit code than output, but for the sake of compatibility of existing setups the proposed solution will also work.)

[1] https://github.com/SpiderLabs/owasp-modsecurity-crs/blob/v3.0/master/util/av-scanning/runav.pl