### PR TITLE
Define m_secmarker_skipped as an integer type

### DIFF
--- a/headers/modsecurity/rules.h
+++ b/headers/modsecurity/rules.h
@@ -80,7 +80,7 @@ class Rules : public RulesProperties {
 
  private:
     int m_referenceCount;
-    double m_secmarker_skipped;
+    uint8_t m_secmarker_skipped;
 };
 
 #endif

--- a/test/test-cases/regression/secmarker.json
+++ b/test/test-cases/regression/secmarker.json
@@ -110,7 +110,7 @@
     },
     "expected": {
       "audit_log": "",
-      "debug_log": "Out of a SecMarker after skip 6.000000 rules.",
+      "debug_log": "Out of a SecMarker after skip 6 rules.",
       "error_log": ""
     },
     "rules": [


### PR DESCRIPTION
There's no reason to treat this this as a double, since it represents a human-readable data value that is only meaningful as an integer. In doing so we write cleaner audit logs and save a small amount of space.