### PR TITLE
Fix utils::string::ssplit() to handle delimiter in the end of string

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,6 +136,7 @@ TESTS+=test/test-cases/regression/issue-1576.json
 TESTS+=test/test-cases/regression/issue-1591.json
 TESTS+=test/test-cases/regression/issue-394.json
 TESTS+=test/test-cases/regression/issue-960.json
+TESTS+=test/test-cases/regression/issue-1743.json
 TESTS+=test/test-cases/regression/misc.json
 TESTS+=test/test-cases/regression/misc-variable-under-quotes.json
 TESTS+=test/test-cases/regression/offset-variable.json

--- a/src/utils/string.cc
+++ b/src/utils/string.cc
@@ -178,9 +178,14 @@ std::vector<std::string> ssplit(std::string str, char delimiter) {
     std::vector<std::string> internal;
     std::stringstream ss(str);  // Turn the string into a stream.
     std::string tok;
+    ssize_t n = str.length();
+    int i = 0;
 
     while (getline(ss, tok, delimiter)) {
-        internal.push_back(tok);
+        n -= tok.length();
+        if (i > 0) n--;
+        internal.push_back(n == 1 ? tok + delimiter : tok);
+        i++;
     }
 
     return internal;

--- a/test/test-cases/regression/action-tnf-base64.json
+++ b/test/test-cases/regression/action-tnf-base64.json
@@ -66,7 +66,7 @@
       "uri":"/",
       "method":"POST",
       "body": [
-        "param1=dmFsdWUyCg==&param2=value2"
+        "param1=dmFsdWUy&param2=value2"
       ]
     },
     "response":{

--- a/test/test-cases/regression/issue-1743.json
+++ b/test/test-cases/regression/issue-1743.json
@@ -5,7 +5,7 @@
   "version_max": -1,
   "title": "Regex match does not work when arg ends with unescaped equal char (1/2)",
   "url": "https:\/\/github.com\/SpiderLabs\/ModSecurity\/issues\/1743",
-  "gihub_issue": 9999,
+  "gihub_issue": 1743,
   "client": {
     "ip": "200.249.12.31",
     "port": 2313
@@ -41,7 +41,7 @@
   "version_max": -1,
   "title": "Regex match does not work when arg ends with unescaped equal char (2/2)",
   "url": "https:\/\/github.com\/SpiderLabs\/ModSecurity\/issues\/1743",
-  "gihub_issue": 9999,
+  "gihub_issue": 1743,
   "client": {
     "ip": "200.249.12.31",
     "port": 2313

--- a/test/test-cases/regression/issue-1743.json
+++ b/test/test-cases/regression/issue-1743.json
@@ -1,0 +1,74 @@
+[
+{
+  "enabled": 1,
+  "version_min": 209000,
+  "version_max": -1,
+  "title": "Regex match does not work when arg ends with unescaped equal char (1/2)",
+  "url": "https:\/\/github.com\/SpiderLabs\/ModSecurity\/issues\/1743",
+  "gihub_issue": 9999,
+  "client": {
+    "ip": "200.249.12.31",
+    "port": 2313
+  },
+  "server": {
+    "ip": "200.249.12.31",
+    "port": 80
+  },
+  "request": {
+    "uri":"/?x=foo%3d",
+    "headers": "",
+    "body": "",
+    "method": "GET",
+    "http_version": 1.1
+  },
+  "response": {
+    "headers": "",
+    "body": ""
+  },
+  "expected": {
+    "debug_log": "Rule returned 1",
+    "error_log": "Value: `foo='",
+    "http_code": 403
+  },
+  "rules": [
+    "SecRuleEngine On",
+    "SecRule ARGS \"foo?=\" \"phase:2,id:1,capture,t:none,t:lowercase,deny,msg:'XSS Attack Detected',logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}'\""
+  ]
+},
+{
+  "enabled": 1,
+  "version_min": 209000,
+  "version_max": -1,
+  "title": "Regex match does not work when arg ends with unescaped equal char (2/2)",
+  "url": "https:\/\/github.com\/SpiderLabs\/ModSecurity\/issues\/1743",
+  "gihub_issue": 9999,
+  "client": {
+    "ip": "200.249.12.31",
+    "port": 2313
+  },
+  "server": {
+    "ip": "200.249.12.31",
+    "port": 80
+  },
+  "request": {
+    "uri":"/?x=foo=",
+    "headers": "",
+    "body": "",
+    "method": "GET",
+    "http_version": 1.1
+  },
+  "response": {
+    "headers": "",
+    "body": ""
+  },
+  "expected": {
+    "debug_log": "Rule returned 1",
+    "error_log": "Value: `foo='",
+    "http_code": 403
+  },
+  "rules": [
+    "SecRuleEngine On",
+    "SecRule ARGS \"foo?=\" \"phase:2,id:1,capture,t:none,t:lowercase,deny,msg:'XSS Attack Detected',logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}'\""
+  ]
+}
+]


### PR DESCRIPTION
This closes #1743.

Also, just for the record: the `action-tnf-base64.json` test includes both encoding and decoding tests. Decoding part was modified in this PR to match valid string without leading `\n`. Encoding part still works due to the fact that regression_test.cc adds extra `\n` to every constructed body:

https://github.com/SpiderLabs/ModSecurity/blob/v3/master/test/regression/regression_test.cc#L51

I suppose changing this behavior will require adjustments in other tests as well, and it is not directly related to this PR and linked issue, so I'd leave it as is for now.