### PR TITLE
Initialize m_dtd member in ValidateDTD class as NULL

### DIFF
--- a/src/operators/validate_dtd.h
+++ b/src/operators/validate_dtd.h
@@ -93,7 +93,7 @@ class ValidateDTD : public Operator {
 
  private:
     std::string m_resource;
-    xmlDtdPtr m_dtd;
+    xmlDtdPtr m_dtd = NULL;
 #endif
 };
 


### PR DESCRIPTION
In case of using GCC (and also libxml2 is used), the [m_dtd](https://github.com/SpiderLabs/ModSecurity/blob/5018358371f3d1c7abe74ef67f3e4dfa6d43f575/src/operators/validate_dtd.h#L96)  just declared, but not initialized - GCC initialized it as NON NULL pointer. When destructor called, it checks the m_dtd, and if it's not NULL, calls [xmlFreeDtd](https://github.com/SpiderLabs/ModSecurity/blob/5018358371f3d1c7abe74ef67f3e4dfa6d43f575/src/operators/validate_dtd.h#L44). The result is a segfault:

```
airween@vm:~/src/ModSecurity$ test/regression_tests test/test-cases/regression/config-xml_external_entity.json 
ModSecurity 3.0.2 - tests
(options are not available -- missing GetOpt)

  # File Name                                         Test Name                                                             Passed?   
--- ---------                                         ---------                                                             -------   
Segmentation fault
```
The expected behavior would be:
```
airween@vm:~/src/ModSecurity$ test/regression_tests test/test-cases/regression/config-xml_external_entity.json 
ModSecurity 3.0.2 - tests
(options are not available -- missing GetOpt)

  # File Name                                         Test Name                                                             Passed?   
--- ---------                                         ---------                                                             -------   
  1 config-xml_external_entity.json                   Testing SecXMLExternalEntity/XXE 1                                    passed!
  2 config-xml_external_entity.json                   Testing SecXMLExternalEntity/XXE 2                                    failed!
  3 config-xml_external_entity.json                   Testing SecXMLExternalEntity/XXE 3                                    failed!

Test failed. From: test/test-cases/regression/config-xml_external_entity.json.
Test name: Testing SecXMLExternalEntity/XXE 2.
Reason: 
parse failed.
Rules error. File: config-xml_external_entity.json. Line: 6. Column: 11. XML: File not found: test-cases/data/SoapEnvelope.dtd. Looking at: 'test-cases/data/SoapEnvelope.dtd', 'test-cases/data/SoapEnvelope.dtd', 'config-xml_external_entity.json/test-cases/data/SoapEnvelope.dtd', 'config-xml_external_entity.json/test-cases/data/SoapEnvelope.dtd'. 

Test failed. From: test/test-cases/regression/config-xml_external_entity.json.
Test name: Testing SecXMLExternalEntity/XXE 3.
Reason: 
parse failed.
Rules error. File: config-xml_external_entity.json. Line: 6. Column: 11. XML: File not found: test-cases/data/SoapEnvelope.dtd. Looking at: 'test-cases/data/SoapEnvelope.dtd', 'test-cases/data/SoapEnvelope.dtd', 'config-xml_external_entity.json/test-cases/data/SoapEnvelope.dtd', 'config-xml_external_entity.json/test-cases/data/SoapEnvelope.dtd'. 

Ran a total of: 3 regression tests - 2 failed. 0 skipped test(s). 0 disabled test(s).
```

This patch prevents the segfault when the DTD is not found.

Note, that I've started the regression_test from the ROOT of ModSecurity source tree, then this check reproducable. If you go to src/ModSecurity/test, and the command is just "./regression_test test-cases/regression/config-xml_external_entity.json", then the test exits normally with passes of all tests.

Even so, it would be better to avoid the segfault...

Also note, that in case of using CLANG, the problem is not reproducible - perhaps CLANG initializes the member as NULL automatically.