### PR TITLE
Initialize invalid_count in UrlDecode::evaluate

### DIFF
--- a/src/actions/transformations/url_decode.cc
+++ b/src/actions/transformations/url_decode.cc
@@ -40,7 +40,7 @@ UrlDecode::UrlDecode(std::string action)
 std::string UrlDecode::evaluate(std::string value,
     Transaction *transaction) {
     unsigned char *val = NULL;
-    int invalid_count;
+    int invalid_count = 0;
     int changed;
 
     val = (unsigned char *) malloc(sizeof(char) * value.size() + 1);


### PR DESCRIPTION
The other caller of urldecode_nonstrict_inplace initialized the third param, but UrlDecode::evaluate did not.