### PR TITLE
Clean up MD5 hexdigest

### DIFF
--- a/src/utils/md5.cc
+++ b/src/utils/md5.cc
@@ -13,10 +13,10 @@ std::string Md5::hexdigest(std::string& input) {
     mbedtls_md5(reinterpret_cast<const unsigned char *>(input.c_str()),
         input.size(), digest);
 
-    char buf[33];
-    for (int i=0; i<16; i++)
+    char buf[32];
+    for (int i = 0; i < 16; i++) {
         sprintf(buf+i*2, "%02x", digest[i]);
-        buf[32]=0;
+    }
 
     return std::string(buf, 32);
 }


### PR DESCRIPTION
The null terminator is not necessary when using this form of the std::string constructor, and its use was confusing given the extra indent.