### PR TITLE
Fix memory leak in msc_rules_* C APIs

### DIFF
--- a/src/rules.cc
+++ b/src/rules.cc
@@ -321,7 +321,7 @@ extern "C" int msc_rules_merge(Rules *rules_dst,
     Rules *rules_from, const char **error) {
     int ret = rules_dst->merge(rules_from);
     if (ret < 0) {
-        *error = strdup(rules_dst->getParserError().c_str());
+        *error = rules_dst->getParserError().c_str();
     }
     return ret;
 }
@@ -331,7 +331,7 @@ extern "C" int msc_rules_add_remote(Rules *rules,
     const char *key, const char *uri, const char **error) {
     int ret = rules->loadRemote(key, uri);
     if (ret < 0) {
-        *error = strdup(rules->getParserError().c_str());
+        *error = rules->getParserError().c_str();
     }
     return ret;
 }
@@ -341,7 +341,7 @@ extern "C" int msc_rules_add_file(Rules *rules, const char *file,
     const char **error) {
     int ret = rules->loadFromUri(file);
     if (ret < 0) {
-        *error = strdup(rules->getParserError().c_str());
+        *error = rules->getParserError().c_str();
     }
     return ret;
 }
@@ -351,7 +351,7 @@ extern "C" int msc_rules_add(Rules *rules, const char *plain_rules,
     const char **error) {
     int ret = rules->load(plain_rules);
     if (ret < 0) {
-        *error = strdup(rules->getParserError().c_str());
+        *error = rules->getParserError().c_str();
     }
     return ret;
 }


### PR DESCRIPTION
When msc_rules_* APIs fail, the error string will return to indicate the reason. It was a duplicate of an internal string. However, it will be duplicated again after those calls in Nginx connector. For example:

In ngx_http_modsecurity_merge_loc_conf():

rules = msc_rules_merge(c->rules_set, p->rules_set, &error);
if (rules < 0) {
    return strdup(error);
}

Since the type of error is 'const char **', I believe that we should not duplicate it inside those APIs and let the caller decide how to handle it.