### PR TITLE
fix when multiple lines for curl version

### DIFF
--- a/build/find_curl.m4
+++ b/build/find_curl.m4
@@ -54,7 +54,7 @@ if test -n "${curl_path}"; then
         CURL_CONFIG="${curl_path}/${CURL_CONFIG}"
     fi
     AC_MSG_RESULT([${CURL_CONFIG}])
-    CURL_VERSION=`${CURL_CONFIG} --version | sed 's/^[[^0-9]][[^[:space:]]][[^[:space:]]]*[[[:space:]]]*//'`
+    CURL_VERSION=`${CURL_CONFIG} --version | sed 's/^[[^0-9]][[^[:space:]]][[^[:space:]]]*[[[:space:]]]*//' | tr '\r\n' ' '`
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(curl VERSION: $CURL_VERSION); fi
     CURL_CFLAGS="`${CURL_CONFIG} --cflags`"
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(curl CFLAGS: $CURL_CFLAGS); fi


### PR DESCRIPTION
example....

### before fix

```bash
# /usr/bin/curl  --version | sed 's/^[^0-9][^[:space:]][^[:space:]]*[[:space:]]*//'
7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.27.1 zlib/1.2.3 libidn/1.18 libssh2/1.4.2
tftp ftp telnet dict ldap ldaps http file https ftps scp sftp
GSS-Negotiate IDN IPv6 Largefile NTLM SSL libz
```

### after fix

```bash
 # /usr/bin/curl  --version | sed 's/^[^0-9][^[:space:]][^[:space:]]*[[:space:]]*//' | tr '\r\n' ' '
7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.27.1 zlib/1.2.3 libidn/1.18 libssh2/1.4.2 tftp ftp telnet dict ldap ldaps http file https ftps scp sftp  GSS-Negotiate IDN IPv6 Largefile NTLM SSL libz
```