### PR TITLE
Fix race condition in UniqueId::uniqueId()

### DIFF
--- a/src/unique_id.cc
+++ b/src/unique_id.cc
@@ -55,6 +55,8 @@
 
 namespace modsecurity {
 
+std::once_flag UniqueId::onceFlag;
+
 void UniqueId::fillUniqueId() {
     std::string macAddress;
     std::string name;

--- a/src/unique_id.h
+++ b/src/unique_id.h
@@ -15,6 +15,7 @@
 
 #ifdef __cplusplus
 #include <string>
+#include <mutex>
 #endif
 
 #ifndef SRC_UNIQUE_ID_H_
@@ -37,9 +38,9 @@ class UniqueId {
     }
 
     static std::string uniqueId() {
-        if (UniqueId::getInstance().uniqueId_str.empty()) {
+        std::call_once(UniqueId::onceFlag,[]() {
             UniqueId::getInstance().fillUniqueId();
-        }
+        });
 
         return UniqueId::getInstance().uniqueId_str;
     }
@@ -59,6 +60,8 @@ class UniqueId {
     // C++ 11
     // UniqueId(UniqueId const&) = delete;
     // void operator=(UniqueId const&) = delete;
+
+    static std::once_flag onceFlag;
 };
 
 }  // namespace modsecurity


### PR DESCRIPTION
There exists a race condition in UniqueId::uniqueId(). I called msc_init() simultaneously in many threads, so they can have their own instance of ModSecurity. However, the process get core dumped every once in a while. The stack looks like this:
![1](https://user-images.githubusercontent.com/1566837/40537222-f86a4d92-6040-11e8-9447-d56ff794d146.png)
This PR uses std::once_flag to make sure UniqueId::getInstance().fillUniqueId() only called once.