### PR TITLE
Fixed LMDB collection errors

### DIFF
--- a/src/collection/backend/lmdb.h
+++ b/src/collection/backend/lmdb.h
@@ -50,7 +50,7 @@ namespace backend {
 class LMDB :
     public Collection {
  public:
-    LMDB();
+    LMDB(std::string name);
     ~LMDB();
     void store(std::string key, std::string value) override;
 

--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -63,11 +63,11 @@ ModSecurity::ModSecurity()
     : m_connector(""),
     m_whoami(""),
 #ifdef WITH_LMDB
-    m_global_collection(new collection::backend::LMDB()),
-    m_resource_collection(new collection::backend::LMDB()),
-    m_ip_collection(new collection::backend::LMDB()),
-    m_session_collection(new collection::backend::LMDB()),
-    m_user_collection(new collection::backend::LMDB()),
+    m_global_collection(new collection::backend::LMDB("GLOBAL")),
+    m_resource_collection(new collection::backend::LMDB("RESOURCE")),
+    m_ip_collection(new collection::backend::LMDB("IP")),
+    m_session_collection(new collection::backend::LMDB("SESSION")),
+    m_user_collection(new collection::backend::LMDB("USER")),
 #else
     m_global_collection(new collection::backend::InMemoryPerProcess("GLOBAL")),
     m_ip_collection(new collection::backend::InMemoryPerProcess("IP")),


### PR DESCRIPTION
When I compiled ModSecurity with LMDB support, the related regression tests had failed, eg:

```
72 collection-resource-simple.json        Testing collection :: RESOURCE (2/2)           failed!
73 collection-resource.json               Testing collection :: RESOURCE (1/2)           failed!
74 collection-resource.json               Testing collection :: RESOURCE (2/2)           failed!
```
Looks like the LMDB backend isn't complete, but may be I'm wrong :).

Before you merge it, please review the comments here:
https://github.com/airween/ModSecurity/blob/908782a06af9d26962e244745bfa46d659d91828/src/collection/backend/lmdb.cc#L496
https://github.com/airween/ModSecurity/blob/908782a06af9d26962e244745bfa46d659d91828/src/collection/backend/lmdb.cc#L509
https://github.com/airween/ModSecurity/blob/908782a06af9d26962e244745bfa46d659d91828/src/collection/backend/lmdb.cc#L518

I don't understand some things, please help me to clarify them.

The patch fixed the regression tests without touched them.