### PR TITLE
Allow empty strings to be evaluated by regex::searchAll

### DIFF
--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -87,6 +87,14 @@ std::list<SMatch> Regex::searchAll(const std::string& s) {
             size_t start = ovector[2*i];
             size_t end = ovector[2*i+1];
             size_t len = end - start;
+
+            match.match = std::string(tmpString, start, len);
+            match.m_offset = start;
+            match.m_length = len;
+            offset = start + len;
+
+            retList.push_front(match);
+
             if (end > s.size()) {
                 rc = 0;
                 break;
@@ -95,12 +103,6 @@ std::list<SMatch> Regex::searchAll(const std::string& s) {
                 rc = 0;
                 break;
             }
-            match.match = std::string(tmpString, start, len);
-            match.m_offset = start;
-            match.m_length = len;
-            offset = start + len;
-
-            retList.push_front(match);
         }
     } while (rc > 0);
 


### PR DESCRIPTION
Proposed fix for issue described at #1785. Confirmed working on my set of tests, and now empty strings seems to be evaluated properly by regex::searchAll when using the caret and dollar operators (^$)

``
ModSecurity: Warning. Matched "Operator `Rx' with parameter `^$' against variable `REQUEST_HEADERS:User-Agent' (Value: `' ) [file "/usr/local/nginx/conf/modsecur$ty.conf"] [line "287"] [id "123456"] [rev ""] [msg ""] [data "Matched data: "] [severity "0"] [ver ""] [maturity "0"] [accuracy "0"] [hostname "192.168.37.1"] [u$i "/"] [unique_id "152663695450.272548"] [ref "o0,0v56,0"]
ModSecurity: Warning. Matched "Operator `Rx' with parameter `^$' against variable `REQUEST_HEADERS:Accept' (Value: `' ) [file "/usr/local/nginx/conf/modsecurity.$onf"] [line "721"] [id "12345"] [rev ""] [msg ""] [data "Matched data: "] [severity "0"] [ver ""] [maturity "0"] [accuracy "0"] [hostname "192.168.37.1"] [uri "/$] [unique_id "152663695450.272548"] [ref "o0,0v81,0"]
ModSecurity: Warning. Matched "Operator `Rx' with parameter `^apache$' against variable `ARGS:param1' (Value: `apache' ) [file "/usr/local/nginx/conf/modsecurity$conf"] [line "722"] [id "1234"] [rev ""] [msg ""] [data "Matched data: apache"] [severity "0"] [ver ""] [maturity "0"] [accuracy "0"] [hostname "192.168.37.1"] [$ri "/"] [unique_id "152663695450.272548"] [ref "o0,6v21,6"]
``

Testsuites seems happy as well :)

![image](https://user-images.githubusercontent.com/15767386/40640522-62534e48-62e4-11e8-9ee7-7c298e0dbac1.png)