### PR TITLE
#1818: Variable names must match fully, not partially; also revert to…

### DIFF
--- a/src/collection/backend/in_memory-per_process.cc
+++ b/src/collection/backend/in_memory-per_process.cc
@@ -105,10 +105,9 @@ void InMemoryPerProcess::resolveMultiMatches(const std::string& var,
             l->insert(l->begin(), new VariableValue(&m_name, &i.first, &i.second));
         }
     } else {
-        for (auto &a : *this) {
-            if (a.first.compare(0, var.size(), var) == 0) {
-                l->insert(l->begin(), new VariableValue(&m_name, &var, &a.second));
-            }
+        auto range = this->equal_range(var);
+        for (auto it = range.first; it != range.second; ++it) {
+            l->insert(l->begin(), new VariableValue(&m_name, &var, &it->second));
         }
     }
 }

--- a/test/test-cases/regression/collection-tx.json
+++ b/test/test-cases/regression/collection-tx.json
@@ -1,4 +1,43 @@
 [
+   {
+    "enabled": 1,
+    "version_min":300000,
+    "version_max":0,
+    "title":"Collection :: TX full vs partial match",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":2313
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "User-Agent":"Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5 (.NET CLR 3.5.30729)"
+      },
+      "uri":"/",
+      "method":"GET",
+      "http_version":1.1,
+      "body":""
+    },
+    "response":{
+      "headers":{
+        "Content-Type":"text/xml; charset=utf-8\n"
+      },
+      "body":[
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+      ]
+    },
+    "expected":{
+	"http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule REMOTE_ADDR \"@unconditionalMatch\" \"id:1,deny,setvar:TX.partial_match=1,chain\"",
+      "SecRule TX.partial \"@gt 0\" \"id:2,t:lowercase,t:none,status:444\""
+    ]
+  },
   {
     "enabled":1,
     "version_min":300000,


### PR DESCRIPTION
… hash table lookup instead of linear search; add test case

Propsed fix for https://github.com/SpiderLabs/ModSecurity/issues/1818