### PR TITLE
IIS: no lock on ProcessRequest. No reload of config. (#24)

### DIFF
--- a/iis/moduleconfig.cpp
+++ b/iis/moduleconfig.cpp
@@ -466,11 +466,8 @@ MODSECURITY_STORED_CONTEXT::~MODSECURITY_STORED_CONTEXT()
 MODSECURITY_STORED_CONTEXT::MODSECURITY_STORED_CONTEXT():
     m_bIsEnabled ( FALSE ),
     m_pszPath( NULL ),
-	m_Config( NULL ),
-	m_dwLastCheck( 0 )
+	m_Config( NULL )
 {
-	m_LastChange.dwLowDateTime = 0;
-	m_LastChange.dwHighDateTime = 0;
 }
 
 DWORD 

--- a/iis/moduleconfig.h
+++ b/iis/moduleconfig.h
@@ -68,8 +68,6 @@ class MODSECURITY_STORED_CONTEXT : public IHttpStoredContext
             USHORT*  pdwLengthDestination );
 
 	void*			  m_Config;
-	DWORD			  m_dwLastCheck;
-	FILETIME		  m_LastChange;
 
 private:
     HRESULT 

--- a/iis/mymodule.cpp
+++ b/iis/mymodule.cpp
@@ -752,11 +752,7 @@ CMyHttpModule::OnBeginRequest(
         goto Finished;
 	}
 
-	// every 3 seconds we check for changes in config file
-	//
-	DWORD ctime = GetTickCount();
-
-	if(pConfig->m_Config == NULL || (ctime - pConfig->m_dwLastCheck) > 3000)
+	if(pConfig->m_Config == NULL)
 	{
 		char *path;
 		USHORT pathlen;
@@ -769,55 +765,42 @@ CMyHttpModule::OnBeginRequest(
 			goto Finished;
 		}
 
-		WIN32_FILE_ATTRIBUTE_DATA fdata;
-		BOOL ret;
+		pConfig->m_Config = modsecGetDefaultConfig();
 
-		ret = GetFileAttributesEx(path, GetFileExInfoStandard, &fdata);
+		PCWSTR servpath = pHttpContext->GetApplication()->GetApplicationPhysicalPath();
+		char *apppath;
+		USHORT apppathlen;
 
-		pConfig->m_dwLastCheck = ctime;
+		hr = pConfig->GlobalWideCharToMultiByte((WCHAR *)servpath, wcslen(servpath), &apppath, &apppathlen);
 
-		if(pConfig->m_Config == NULL || (ret != 0 && (pConfig->m_LastChange.dwLowDateTime != fdata.ftLastWriteTime.dwLowDateTime ||
-			pConfig->m_LastChange.dwHighDateTime != fdata.ftLastWriteTime.dwHighDateTime)))
+		if ( FAILED( hr ) )
 		{
-			pConfig->m_LastChange.dwLowDateTime = fdata.ftLastWriteTime.dwLowDateTime;
-			pConfig->m_LastChange.dwHighDateTime = fdata.ftLastWriteTime.dwHighDateTime;
+			delete path;
+			hr = E_UNEXPECTED;
+			goto Finished;
+		}
 
-			pConfig->m_Config = modsecGetDefaultConfig();
+		if(path[0] != 0)
+		{
+			const char * err = modsecProcessConfig((directory_config *)pConfig->m_Config, path, apppath);
 
-			PCWSTR servpath = pHttpContext->GetApplication()->GetApplicationPhysicalPath();
-			char *apppath;
-			USHORT apppathlen;
-
-			hr = pConfig->GlobalWideCharToMultiByte((WCHAR *)servpath, wcslen(servpath), &apppath, &apppathlen);
-
-			if ( FAILED( hr ) )
+			if(err != NULL)
 			{
+				WriteEventViewerLog(err, EVENTLOG_ERROR_TYPE);
+				delete apppath;
 				delete path;
-				hr = E_UNEXPECTED;
 				goto Finished;
 			}
 
-			if(path[0] != 0)
+			modsecReportRemoteLoadedRules();
+			if (this->status_call_already_sent == false)
 			{
-				const char * err = modsecProcessConfig((directory_config *)pConfig->m_Config, path, apppath);
-
-				if(err != NULL)
-				{
-					WriteEventViewerLog(err, EVENTLOG_ERROR_TYPE);
-					delete apppath;
-					delete path;
-					goto Finished;
-				}
-
-				modsecReportRemoteLoadedRules();
-				if (this->status_call_already_sent == false)
-				{
-					this->status_call_already_sent = true;
-					modsecStatusEngineCall();
-				}
+				this->status_call_already_sent = true;
+				modsecStatusEngineCall();
 			}
-			delete apppath;
 		}
+
+		delete apppath;
 		delete path;
 	}
 
@@ -1072,7 +1055,9 @@ CMyHttpModule::OnBeginRequest(
 #endif
 	c->remote_host = NULL;
 
+    LeaveCriticalSection(&m_csLock);
 	int status = modsecProcessRequest(r);
+    EnterCriticalSection(&m_csLock);
 
 	if(status != DECLINED)
 	{


### PR DESCRIPTION
IIS: No lock on ProcessRequest. This allows for concurrent requests to happen on IIS.

Also removed the auto reload of config, as this is dangerous to do now where one thread might be using the config while another thread might be reloading it. It's worth sacrificing auto reload for the huge benefit of concurrent requests.

In this pull request the diff alignment around the if(pConfig->m_Config == NULL) section is hard to read, but what I've basically done is taken away the parts that dealt with checking for timestamps.