### PR TITLE
Fix pc file

### DIFF
--- a/modsecurity.pc.in
+++ b/modsecurity.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: ModSecurity
 Description: ModSecurity API
 Version: @MSC_VERSION_WITH_PATCHLEVEL@
-Cflags: -I@includedir@/@PACKAGE@
+Cflags: -I@includedir@
 Libs: -L@libdir@ -lmodsecurity


### PR DESCRIPTION
the include path can't have @PACKAGE@ at the end as we include headers
with

 #include <modsecurity/modsecurity.h>

so it's already in there