### PR TITLE
Fix OpenBSD build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.3 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Fix OpenBSD build
+   [Issue #1841 - @victorhora, @zimmerle, @juanfra684]
  - Variable names must match fully, not partially. Match should be case
    insensitive.
    [Issue #1818, #1820, #1810, #1808 - @michaelgranzow-avi, @victorhora,

--- a/configure.ac
+++ b/configure.ac
@@ -332,7 +332,7 @@ AM_CONDITIONAL([USE_MUTEX_ON_PM], [test $mutexPm = true])
 
 
 # General link options
-if test "$PLATFORM" != "MacOSX"; then
+if test "$PLATFORM" != "MacOSX" -a "$PLATFORM" != "OpenBSD"; then
     GLOBAL_LDADD="-lrt  "
 fi
 

--- a/examples/multiprocess_c/multi.c
+++ b/examples/multiprocess_c/multi.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/time.h>
 
 #define FORKS 5
 #define REQUESTS_PER_PROCESS 100

--- a/src/utils/string.cc
+++ b/src/utils/string.cc
@@ -17,7 +17,11 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#ifdef __OpenBSD__
+#include <glob.h>
+#else
 #include <wordexp.h>
+#endif
 #include <stdint.h>
 #include <inttypes.h>
 


### PR DESCRIPTION
OpenBSD build was breaking due to the lack of _wordexp.h_. Patch fixes the build by using glob.h when building on OpenBSD. Should fix #1841.