### PR TITLE
Allow LuaJIT to be used

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.3 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Allow LuaJIT to be used
+   [Issue #1809 - @victorhora, @p0pr0ck5]
  - Implement support for Lua 5.1
    [Issue #1809 - @p0pr0ck5, @victorhora]
  - Variable names must match fully, not partially. Match should be case

--- a/build/lua.m4
+++ b/build/lua.m4
@@ -6,7 +6,7 @@ AC_DEFUN([CHECK_LUA],
 [dnl
 
 # Possible names for the lua library/package (pkg-config)
-LUA_POSSIBLE_LIB_NAMES="lua lua53 lua5.3 lua52 lua5.2 lua51 lua5.1"
+LUA_POSSIBLE_LIB_NAMES="lua lua53 lua5.3 lua52 lua5.2 lua51 lua5.1 luajit luajit-5.1"
 
 # Possible extensions for the library
 LUA_POSSIBLE_EXTENSIONS="so so0 la sl dll dylib so.0.0.0"
@@ -68,6 +68,7 @@ else
         case $LUA_PKG_VERSION in
            (5.1*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
            (5.2*) LUA_CFLAGS="-DWITH_LUA_5_2 ${LUA_CFLAGS}" ; lua_5_2=1 ;;
+           (2.*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
         esac
            AC_MSG_NOTICE([LUA pkg-config version: ${LUA_PKG_VERSION}])
         fi
@@ -168,6 +169,9 @@ AC_DEFUN([CHECK_FOR_LUA_AT], [
 	LUA_VERSION=502
     elif test -e "${path}/include/lua5.1/lua.h"; then
         lua_inc_path="${path}/include/lua5.1"
+	LUA_VERSION=501
+    elif test -e "${path}/include/luajit-2.0/lua.h"; then
+        lua_inc_path="${path}/include/luajit-2.0"
 	LUA_VERSION=501
     fi
 


### PR DESCRIPTION
Following the addition of Lua 5.1 compatibility with libModSecurity at https://github.com/SpiderLabs/ModSecurity/commit/dee989844914f07e38367fb6b1ead906541c0849, this PR tries to address support for LuaJIT. The output of the configure script after applying the patch should be something like:
```

...
configure: LUA library found at: /usr/lib/x86_64-linux-gnu//libluajit-5.1.so
configure: LUA headers found at: /usr/include/luajit-2.0
configure: LUA version from includes: 501
configure: using LUA -lluajit-5.1
...

   + LUA                                           ....found v501
      -lluajit-5.1 -L/usr/lib/x86_64-linux-gnu/, -DWITH_LUA -DWITH_LUA_5_1 -I/usr/include/luajit-2.0
```

Should finish solving the issue regarding LuaJIT support at #1809 
