### PR TITLE
Add LUA compatibility for CentOS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.3 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Add LUA compatibility for CentOS
+   [Issue #1622 - @victorhora, @dmitryzykov]
  - Implement support for Lua 5.1
    [Issue #1809 - @p0pr0ck5, @victorhora]
  - Variable names must match fully, not partially. Match should be case

--- a/build/lua.m4
+++ b/build/lua.m4
@@ -6,7 +6,7 @@ AC_DEFUN([CHECK_LUA],
 [dnl
 
 # Possible names for the lua library/package (pkg-config)
-LUA_POSSIBLE_LIB_NAMES="lua lua53 lua5.3 lua52 lua5.2 lua51 lua5.1"
+LUA_POSSIBLE_LIB_NAMES="lua lua53 lua5.3 lua-5.3 lua52 lua5.2 lua-5.2 lua51 lua5.1 lua-5.1"
 
 # Possible extensions for the library
 LUA_POSSIBLE_EXTENSIONS="so so0 la sl dll dylib so.0.0.0"


### PR DESCRIPTION
Very small change to the lua.m4 script to allow LUA support on CentOS as described at https://github.com/SpiderLabs/ModSecurity/issues/1622#issuecomment-356216294