### PR TITLE
Fix SecResponseBodyAccess and ctl:requestBodyAccess directives

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.3 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Fix SecResponseBodyAccess and ctl:requestBodyAccess directives
+   [Issue #1531 - @victorhora, @defanator]
  - Adds support for ctl:requestBodyProcessor=URLENCODED
    [Issue #1797 - @victorhora]
  - Add LUA compatibility for CentOS and try to use LuaJIT first if available

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -766,14 +766,11 @@ int Transaction::processRequestBody() {
         m_variableReqbodyProcessorError.set("0", m_variableOffset);
     }
 
-#if 1
     if (m_rules->m_secRequestBodyAccess != RulesProperties::TrueConfigBoolean) {
         if (m_requestBodyAccess != RulesProperties::TrueConfigBoolean) {
 #ifndef NO_LOGS
             debug(4, "Request body processing is disabled");
 #endif
-
-            this->m_rules->evaluate(modsecurity::RequestBodyPhase, this);
             return true;
         } else {
 #ifndef NO_LOGS
@@ -786,14 +783,12 @@ int Transaction::processRequestBody() {
         if (m_requestBodyAccess == RulesProperties::FalseConfigBoolean) {
 #ifndef NO_LOGS
             debug(4, "Request body processing is enabled, but " \
-                "disable to this transaction due to ctl:requestBodyAccess " \
+                "disabled to this transaction due to ctl:requestBodyAccess " \
                 "action");
 #endif
-            this->m_rules->evaluate(modsecurity::RequestBodyPhase, this);
             return true;
         }
     }
-#endif
 
     /**
      * FIXME: This variable should be calculated on demand, it is

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -766,7 +766,7 @@ int Transaction::processRequestBody() {
         m_variableReqbodyProcessorError.set("0", m_variableOffset);
     }
 
-    if (m_rules->m_secRequestBodyAccess != RulesProperties::TrueConfigBoolean) {
+    if (m_rules->m_secRequestBodyAccess == RulesProperties::FalseConfigBoolean) {
         if (m_requestBodyAccess != RulesProperties::TrueConfigBoolean) {
 #ifndef NO_LOGS
             debug(4, "Request body processing is disabled");

--- a/test/test-cases/regression/action-ctl_request_body_access.json
+++ b/test/test-cases/regression/action-ctl_request_body_access.json
@@ -51,7 +51,7 @@
       ]
     },
     "expected":{
-      "debug_log":"Request body processing is enabled, but disable to this transaction due to ctl:requestBodyAccess action"
+      "debug_log":"Request body processing is enabled, but disabled to this transaction due to ctl:requestBodyAccess action"
     },
     "rules":[
       "SecRuleEngine On",


### PR DESCRIPTION
Small change to allow for SecResponseBodyAccess and ctl:requestBodyAccess directives to work as intended. Should fix #1531.