### PR TITLE
Fix parser to support GeoLookup with MaxMind

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.3 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Fix parser to support GeoLookup with MaxMind
+   [Issue #1884 - @victorhora, @everping]
  - Fix pc file
    [Issue #1847 - @gquintard]
  - modsec_rules_check: uses the gnu `.la' instead of `.a' file

--- a/build/libmaxmind.m4
+++ b/build/libmaxmind.m4
@@ -21,7 +21,7 @@ MAXMIND_POSSIBLE_LIB_NAMES="libmaxminddb maxminddb maxmind"
 MAXMIND_POSSIBLE_EXTENSIONS="so la sl dll dylib"
 
 # Possible paths (if pkg-config was not found, proceed with the file lookup)
-MAXMIND_POSSIBLE_PATHS="/usr/local/libmaxmind /usr/local/maxmind /usr/local /opt/libmaxmind /opt/maxmind /opt /usr /opt/local/include /opt/local /usr/lib /usr/local/lib /usr/lib64 /usr"
+MAXMIND_POSSIBLE_PATHS="/usr/local/libmaxmind /usr/local/maxmind /usr/local /opt/libmaxmind /opt/maxmind /opt /usr /opt/local/include /opt/local /usr/lib /usr/local/lib /usr/lib64 /usr /usr/include/x86_64-linux-gnu/"
 
 # Variables to be set by this very own script.
 MAXMIND_VERSION=""

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -848,7 +848,7 @@ namespace yy {
 
 
     // User initialization code.
-    #line 353 "/home/vhora/ModSecurity-v3-LATEST-JUNE/src/parser/seclang-parser.yy" // lalr1.cc:725
+    #line 353 "/home/vhora/ModSecurity-v3-AUGUST/src/parser/seclang-parser.yy" // lalr1.cc:725
 {
   // Initialize the initial location.
   yyla.location.begin.filename = yyla.location.end.filename = &driver.file;
@@ -1757,11 +1757,11 @@ namespace yy {
   case 71:
 #line 1082 "seclang-parser.yy" // lalr1.cc:847
     {
-#ifdef WITH_GEOIP
+#if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         OPERATOR_CONTAINER(yylhs.value.as< std::unique_ptr<Operator> > (), new operators::GeoLookup());
 #else
         std::stringstream ss;
-            ss << "This version of ModSecurity was not compiled with GeoIP support.";
+            ss << "This version of ModSecurity was not compiled with GeoIP or MaxMind support.";
             driver.error(yystack_[1].location, ss.str());
             YYERROR;
 #endif  // WITH_GEOIP
@@ -2438,7 +2438,7 @@ namespace yy {
   case 125:
 #line 1557 "seclang-parser.yy" // lalr1.cc:847
     {
-#ifdef WITH_GEOIP
+#if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
         std::string file = modsecurity::utils::find_resource(yystack_[0].value.as< std::string > (),
             driver.ref.back(), &err);
@@ -2458,7 +2458,7 @@ namespace yy {
         }
 #else
         std::stringstream ss;
-        ss << "This version of ModSecurity was not compiled with GeoIP support.";
+        ss << "This version of ModSecurity was not compiled with GeoIP or MaxMind support.";
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
 #endif  // WITH_GEOIP

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1080,11 +1080,11 @@ op_before_init:
       }
     | OPERATOR_GEOLOOKUP
       {
-#ifdef WITH_GEOIP
+#if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         OPERATOR_CONTAINER($$, new operators::GeoLookup());
 #else
         std::stringstream ss;
-            ss << "This version of ModSecurity was not compiled with GeoIP support.";
+            ss << "This version of ModSecurity was not compiled with GeoIP or MaxMind support.";
             driver.error(@0, ss.str());
             YYERROR;
 #endif  // WITH_GEOIP
@@ -1555,7 +1555,7 @@ expression:
     /* Debug log: end */
     | CONFIG_DIR_GEO_DB
       {
-#ifdef WITH_GEOIP
+#if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
         std::string file = modsecurity::utils::find_resource($1,
             driver.ref.back(), &err);
@@ -1575,7 +1575,7 @@ expression:
         }
 #else
         std::stringstream ss;
-        ss << "This version of ModSecurity was not compiled with GeoIP support.";
+        ss << "This version of ModSecurity was not compiled with GeoIP or MaxMind support.";
         driver.error(@0, ss.str());
         YYERROR;
 #endif  // WITH_GEOIP


### PR DESCRIPTION
Should fix issue where [SecGeoLookupDb](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#SecGeoLookupDb) directive and [@geoLookup](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#geoLookup) operator was not working as expected when using libMaxMind. 

Also a small change to libmaxmind.m4 to allow the script to find the headers on Ubuntu based distros where PkgConfig is not available. Should fix issue #1884 