### PR TITLE
Allow LuaJIT 2.1 to be used

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.3 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Allow LuaJIT 2.1 to be used
+   [Issue #1909 - @victorhora, @mdunc]
  - Fix: function m.setvar in Lua scripts and add testcases
    [Issue #1859 - @nowaits, @victorhora]
  - Fix SecResponseBodyAccess and ctl:requestBodyAccess directives

--- a/build/lua.m4
+++ b/build/lua.m4
@@ -68,7 +68,8 @@ else
         case $LUA_PKG_VERSION in
            (5.1*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
            (5.2*) LUA_CFLAGS="-DWITH_LUA_5_2 ${LUA_CFLAGS}" ; lua_5_2=1 ;;
-           (2.*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
+           (2.0*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
+           (2.1*) LUA_CFLAGS="-DWITH_LUA_5_1 -DWITH_LUA_JIT_2_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
         esac
            AC_MSG_NOTICE([LUA pkg-config version: ${LUA_PKG_VERSION}])
         fi

--- a/src/engine/lua.h
+++ b/src/engine/lua.h
@@ -102,7 +102,7 @@ static const struct luaL_Reg mscLuaLib[] = {
 }  // namespace modsecurity
 
 #ifdef WITH_LUA
-#if defined LUA_VERSION_NUM && LUA_VERSION_NUM < 502
+#if defined LUA_VERSION_NUM && LUA_VERSION_NUM < 502 && !defined WITH_LUA_JIT_2_1
 /*
 ** Adapted from Lua 5.2.0
 */


### PR DESCRIPTION
Simple change to allow for LuaJIT 2.1 to be used with ModSecurity. 

The issue happened due to luaL_setfuncs() already being defined in LuaJIT 2.1 (see [lauxlib.h#L88](https://github.com/LuaJIT/LuaJIT/blob/v2.1/src/lauxlib.h#L88)).

Commit dee9898#diff-f120b67754e2c3ff8a98d4e3007f12efR111 defines this func as it is being used by the Lua engine inside ModSecurity (lua.cc#L138) but it is lacking in Lua 5.1 to make it compatible.

An extra if defined condition (WITH_LUA_JIT_2_1) was added to cover for LuaJIT 2.1.

Should fix #1909.