### PR TITLE
@ju5t patch to fix mpm-itk / mod_ruid2 compatibility

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -230,10 +230,20 @@ static char *construct_auditlog_filename(apr_pool_t *mp, const char *uniqueid) {
     char tstr[300];
     apr_size_t len;
 
+    /**
+     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
+     * It also changes the return statement.
+     */
+    char *username;
+    apr_uid_t uid;
+    apr_gid_t gid;
+    apr_uid_current(&uid, &gid, mp);
+    apr_uid_name_get(&username, uid, mp);
+
     apr_time_exp_lt(&t, apr_time_now());
 
     apr_strftime(tstr, &len, 299, "/%Y%m%d/%Y%m%d-%H%M/%Y%m%d-%H%M%S", &t);
-    return apr_psprintf(mp, "%s-%s", tstr, uniqueid);
+    return apr_psprintf(mp, "/%s%s-%s", username, tstr, uniqueid);
 }
 
 /**


### PR DESCRIPTION
This PR contains the [patch](https://gist.github.com/ju5t/0d61ee80b23f0987d65e) by @ju5t (with minor adjustments due to change in lines). It's meant to fixing compatibility issues with apache2-itk and mod_ruid2 Apache modules and ModSecurity 2.9.x.

The tests are passing for this patch and [according to some users](https://github.com/SpiderLabs/ModSecurity/issues/712#issuecomment-288653357) the patch is safe.
