### PR TITLE
[V3] Allow the callback function to receive and log a http return code

### DIFF
--- a/headers/modsecurity/modsecurity.h
+++ b/headers/modsecurity/modsecurity.h
@@ -289,7 +289,7 @@ class ModSecurity {
      */
     void setServerLogCb(ModSecLogCb cb, int properties);
 
-    void serverLog(void *data, std::shared_ptr<RuleMessage> rm);
+    void serverLog(void *data, std::shared_ptr<RuleMessage> rm, int httpCodeReturned);
 
     const std::string& getConnectorInformation();
 

--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -186,7 +186,7 @@ const std::string& ModSecurity::getConnectorInformation() {
     return m_connector;
 }
 
-void ModSecurity::serverLog(void *data, std::shared_ptr<RuleMessage> rm) {
+void ModSecurity::serverLog(void *data, std::shared_ptr<RuleMessage> rm, int httpCodeReturned) {
     if (m_logCb == NULL) {
         std::cerr << "Server log callback is not set -- " << rm->errorLog();
         std::cerr << std::endl;
@@ -198,7 +198,7 @@ void ModSecurity::serverLog(void *data, std::shared_ptr<RuleMessage> rm) {
     }
 
     if (m_logProperties & TextLogProperty) {
-        std::string &&d = rm->log();
+        std::string &&d = rm->log(0, httpCodeReturned);
         const void *a = static_cast<const void *>(d.c_str());
         m_logCb(data, a);
         return;

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1781,7 +1781,7 @@ std::string Transaction::toJSON(int parts) {
 
 
 void Transaction::serverLog(std::shared_ptr<RuleMessage> rm) {
-    m_ms->serverLog(m_logCbData, rm);
+    m_ms->serverLog(m_logCbData, rm, this->m_httpCodeReturned);
 }
 
 


### PR DESCRIPTION
As discussed in #1916, there is an issue where the callback function will not insert the http return code into the message even though the audit log contained the correct message.
ex: callback: `ModSecurity: Access denied with code %d (phase 2). Matched "Operator Rx with parameter a....`
auditlog: `ModSecurity: Access denied with code 200 (phase 2). Matched "Operator Rx with parameter a...`

After some digging through the code for the process for the callback I found that the callback is only called through [`Transaction::serverLog()` ](https://github.com/SpiderLabs/ModSecurity/blob/bc3d3f19154793e23568103b931a15168b34d768/src/transaction.cc#L1783)which contains the function[ `ModSecurity::serverLog(m_logCbData, rm)`](https://github.com/SpiderLabs/ModSecurity/blob/v3/master/src/modsecurity.cc#L189). ModSecurity has no access/reference to the `Transaction::m_httpCodeReturned` so it would have had to been passed by `Transaction::serverLog()` with `this->m_httpCodeReturned` to be able to be passed into the [`RuleMessage::log()`](https://github.com/SpiderLabs/ModSecurity/blob/bc3d3f19154793e23568103b931a15168b34d768/src/rule_message.cc#L65) to generate the callback message. After this patch I am able to get the http return code into the callback function message parameter.

Though I am unsure how/if props should be set or in `ModSecurity::serverLog()`. I am also unsure in the case that `RuleMessageLogProperty` is set, how to best pass the `m_httpCodeReturned` to the rule message or callback function.

Additionally I noticed in [`ModSecurity::serverLog()` ](https://github.com/SpiderLabs/ModSecurity/blob/bc3d3f19154793e23568103b931a15168b34d768/src/modsecurity.cc#L207)there might be bug due to the repeated code in the if statement.