### PR TITLE
Add correct C function prototypes for msc_init and msc_create_rule_set

### DIFF
--- a/headers/modsecurity/modsecurity.h
+++ b/headers/modsecurity/modsecurity.h
@@ -317,7 +317,7 @@ extern "C" {
 #endif
 
 /** @ingroup ModSecurity_C_API */
-ModSecurity *msc_init();
+ModSecurity *msc_init(void);
 /** @ingroup ModSecurity_C_API */
 const char *msc_who_am_i(ModSecurity *msc);
 /** @ingroup ModSecurity_C_API */

--- a/headers/modsecurity/rules.h
+++ b/headers/modsecurity/rules.h
@@ -96,7 +96,7 @@ class Rules : public RulesProperties {
 extern "C" {
 #endif
 
-Rules *msc_create_rules_set();
+Rules *msc_create_rules_set(void);
 void msc_rules_dump(Rules *rules);
 int msc_rules_merge(Rules *rules_dst, Rules *rules_from, const char **error);
 int msc_rules_add_remote(Rules *rules, const char *key, const char *uri,


### PR DESCRIPTION
C function prototypes require a void parameter otherwise the error: `function declaration isn't a prototype` will be thrown in some compilers with `-Werror=strict-prototype` set.