### PR TITLE
Make multipart boundary check a bit less strict by default

### DIFF
--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -102,23 +102,22 @@ FL %{MULTIPART_FILE_LIMIT_EXCEEDED}'"
 # is wrong, then parser returns with value 1 (also a non-zero).
 #
 # You can choose, which one is what you need. The example below contains the
-# 'strict' mode, which means if there are any lines with start of "--", then
-# ModSecurity blocked the content. But the next, commented example contains
+# 'strict' logging mode, which means if there are any lines with start of "--", then
+# ModSecurity warns about the request. But the next, example contains
 # the 'permissive' mode, then you check only if the necessary lines exists in
 # correct order. Whit this, you can enable to upload PEM files (eg "----BEGIN.."),
 # or other text files, which contains eg. HTTP headers.
 #
-# The difference is only the operator - in strict mode (first) the content blocked
+# The difference is only the operator - in strict mode (first) the content logs
 # in case of any non-zero value. In permissive mode (second, commented) the
 # content blocked only if the value is explicit 1. If it 0 or 2, the content will
 # allowed.
 #
 
 SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
-"id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
-#SecRule MULTIPART_UNMATCHED_BOUNDARY "@eq 1" \
-#"id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
-
+"id:'200004',phase:2,t:none,log,pass,msg:'Multipart parser detected a possible unmatched boundary.'"
+SecRule MULTIPART_UNMATCHED_BOUNDARY "@eq 1" \
+"id:'200006',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
 
 # PCRE Tuning
 # We want to avoid a potential RegEx DoS condition

--- a/test/test-cases/regression/variable-MULTIPART_UNMATCHED_BOUNDARY.json
+++ b/test/test-cases/regression/variable-MULTIPART_UNMATCHED_BOUNDARY.json
@@ -57,5 +57,66 @@
       "SecRuleEngine On",
       "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@contains small_text_file.txt\" \"id:1,phase:3,pass,t:trim\""
     ]
+  },
+  {  
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_UNMATCHED_BOUNDARY - DENY",
+    "client":{  
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{  
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{  
+      "headers":{  
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[  
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"name\"",
+        "",
+        "test",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "This is a very small test file..",
+        "A----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "This is another very small test file..",
+        "----------------------------756b6d74fa1a8ee2--",
+        ""
+      ]
+    },
+    "response":{  
+      "headers":{  
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[  
+        "no need."
+      ]
+    },
+    "expected":{  
+      "debug_log":"Target value: \"1\" \\(Variable: MULTIPART_UNMATCHED_BOUNDARY\\)",
+      "http_code": 403
+    },
+    "rules":[  
+      "SecRuleEngine On",
+      "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@eq 1\" \"id:1,phase:2,deny,t:none\""
+    ]
   }
 ]


### PR DESCRIPTION
This pull request is sort of a workaround for multipart/form-data requests that have multiple boundaries such as common ```Content-Disposition``` POST requests.

The issue is that the fix proposed at https://github.com/SpiderLabs/ModSecurity/pull/1747 and merged at https://github.com/SpiderLabs/ModSecurity/commit/4d0ca94490fdcc233228987c6b10ef010d967249 could lead to cases where ```Content-Disposition``` POST requests such as the one below are denied by default after this commit:

```
POST /test.html HTTP/1.1
Host: example.org
Content-Type: multipart/form-data;boundary=boundary
Content-Length: 174

--boundary
Content-Disposition: form-data; name="field1"

value1
--boundary
Content-Disposition: form-data; name="field2"; filename="example.txt"

value2
--boundary--
```

Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

I suggesting making rule 200004 less strict by replacing a "deny" with a "pass", but still alerting the WAF operator. The operator can choose the disable or change the rule to not log if need be.

In addition, a new rule (200006) would be created in order to actually block cases where an unmatched boundary is actually found in the request.