### PR TITLE
Fix double macros bug

### DIFF
--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -658,7 +658,6 @@ EQUALS_MINUS                            (?i:=\-)
 
 <EXPECTING_ACTION_PREDICATE_VARIABLE>{
 [}] { BEGIN_PREVIOUS(); }
-[}][%] { BEGIN_PREVIOUS(); }
 }
 
 <ACTION_PREDICATE_ENDS_WITH_QUOTE>{


### PR DESCRIPTION
Macro run strangely if I input double macros like "%{ARGS_COMBINED_SIZE}%{ARGS_COMBINED_SIZE}".

Example(id and phase are omitted for convenience):

		SecAction "setvar:tx.msg=%{ARGS_COMBINED_SIZE}%{ARGS_COMBINED_SIZE}"


The scanner(lexical analyzer)'s status change road:

		0. INITIAL
		1. -[SecAction]-> TRANSACTION_FROM_DIRECTIVE_TO_ACTIONS
		2. -[ "]-> EXPECTING_ACTIONS_ENDS_WITH_DOUBLE_QUOTE
		3. -[setvar:]-> SETVAR_ACTION_NONQUOTED
		4. -[tx.]-> EXPECTING_VAR_PARAMETER_OR_MACRO_NONQUOTED
		5. -[msg]-> EXPECTING_VAR_PARAMETER_OR_MACRO_NONQUOTED
		6. -[=]-> SETVAR_ACTION_NONQUOTED_WAITING_CONTENT
		7. -[%{]-> EXPECTING_ACTION_PREDICATE_VARIABLE
		8. -[ARGS_COMBINED_SIZE]-> EXPECTING_ACTION_PREDICATE_VARIABLE
		9. -[}%]-> SETVAR_ACTION_NONQUOTED_WAITING_CONTENT
		10. -[{ARGS_COMBINED_SIZE}]-> SETVAR_ACTION_NONQUOTED_WAITING_CONTENT
		11. -["]-> EXPECTING_ACTIONS_ENDS_WITH_DOUBLE_QUOTE
				-> INITIAL
				
The ninth step should be paid attention. Since the ninth step take }%, the tenth step doesn't have %. So the tenth step cannot know there is a macro expansion.