### PR TITLE
Make the boundary check less strict as per RFC2046

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 v3.0.4 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
-
+ - Make the boundary check less strict as per RFC2046
+   [Issue #1943 - @victorhora, @allanbomsft]
 
 
 v3.0.3 - 2018-Nov-05

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -158,41 +158,27 @@ int Multipart::boundary_characters_valid(const char *boundary) {
     }
 
     while ((c = *p) != '\0') {
-        /* Control characters and space not allowed. */
-        if (c < 32) {
+        // Check against allowed list defined in RFC2046 page 22
+        if (!(
+            ('0' <= c && c <= '9')
+            || ('A' <= c && c <= 'Z')
+            || ('a' <= c && c <= 'z')
+            || (c == ' ' && *(p + 1) != '\0') // space allowed, but not as last character
+            || c == '\''
+            || c == '('
+            || c == ')'
+            || c == '+'
+            || c == '_'
+            || c == ','
+            || c == '-'
+            || c == '.'
+            || c == '/'
+            || c == ':'
+            || c == '='
+            || c == '?'
+            )) {
             return 0;
         }
-
-        /* Non-ASCII characters not allowed. */
-        if (c > 126) {
-            return 0;
-        }
-
-        switch (c) {
-            /* Special characters not allowed. */
-            case '(' :
-            case ')' :
-            case '<' :
-            case '>' :
-            case '@' :
-            case ',' :
-            case ';' :
-            case ':' :
-            case '\\' :
-            case '"' :
-            case '/' :
-            case '[' :
-            case ']' :
-            case '?' :
-            case '=' :
-                return 0;
-                break;
-
-            default :
-                /* Do nothing. */
-                break;
-        }
-
         p++;
     }
 

--- a/test/test-cases/regression/request-body-parser-multipart.json
+++ b/test/test-cases/regression/request-body-parser-multipart.json
@@ -1618,7 +1618,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"multipart parser (boundary special char - trailing comma+token)",
+    "title":"multipart parser (boundary special char - trailing exclamation+token)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -1633,7 +1633,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data;boundary=0000,1111",
+        "Content-Type":"multipart/form-data;boundary=0000!1111",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -1850,7 +1850,7 @@
     },
     "expected":{
       "http_code": 403,
-      "debug_log": "boundary was quoted.*No boundaries found in payload"
+      "debug_log": "Invalid boundary in C-T \\(characters\\).*boundary was quoted."
     },
     "rules":[
         "SecRuleEngine On",
@@ -1911,7 +1911,7 @@
     },
     "expected":{
       "http_code": 403,
-      "debug_log": "boundary was quoted.*No boundaries found in payload"
+      "debug_log": "Invalid boundary in C-T \\(characters\\).*boundary was quoted."
     },
     "rules":[
         "SecRuleEngine On",

--- a/test/test-cases/regression/variable-MULTIPART_STRICT_ERROR.json
+++ b/test/test-cases/regression/variable-MULTIPART_STRICT_ERROR.json
@@ -293,6 +293,55 @@
       "SecRuleEngine On",
       "SecRule MULTIPART_STRICT_ERROR \"@contains 0\" \"id:1,phase:3,pass,t:trim\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_STRICT_ERROR - RFC2046",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz '()+_,-./:=?",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "--0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz '()+_,-./:=?",
+        "Content-Disposition: form-data; name=\"name\"",
+        "",
+        "1",
+        "--0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz '()+_,-./:=?--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"Target value: \"0\" \\(Variable: REQBODY_ERROR\\)"
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule REQBODY_ERROR \"@contains 0\" \"id:1,phase:3,pass,t:trim\""
+    ]
   }
 ]
 


### PR DESCRIPTION
This PR is based on #1821 but directed at the v3 branch and with a test case to validate the changes.

According to the [RFC2046 page 22](https://tools.ietf.org/html/rfc2046#page-22), indeed the parser seemed to be more strict than it should. I believe this is safe to be merged.