### PR TITLE
Fix for apr_global_mutex_create() crashes with mod_security 2.9.2

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -692,9 +692,8 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
         first_time = 1;
         apr_pool_userdata_set((const void *)1, "modsecurity-init-flag",
                 apr_pool_cleanup_null, s->process->pool);
-    } else {
-        modsecurity_init(modsecurity, mp);
     }
+    modsecurity_init(modsecurity, mp);
 
     /* Store the original server signature */
     real_server_signature = apr_pstrdup(mp, apache_get_server_version());

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -133,7 +133,8 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     curl_global_init(CURL_GLOBAL_ALL);
 #endif
     /* Serial audit log mutext */
-    rc = apr_global_mutex_create(&msce->auditlog_lock, NULL, APR_LOCK_DEFAULT, mp);
+    tmpnam(auditlog_lock_name);
+    rc = apr_global_mutex_create(&msce->auditlog_lock, auditlog_lock_name, APR_LOCK_DEFAULT, mp);
     if (rc != APR_SUCCESS) {
         //ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_security: Could not create modsec_auditlog_lock");
         //return HTTP_INTERNAL_SERVER_ERROR;
@@ -154,7 +155,8 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     }
 #endif /* SET_MUTEX_PERMS */
 
-    rc = apr_global_mutex_create(&msce->geo_lock, NULL, APR_LOCK_DEFAULT, mp);
+    tmpnam(geo_lock_name);
+    rc = apr_global_mutex_create(&msce->geo_lock, geo_lock_name, APR_LOCK_DEFAULT, mp);
     if (rc != APR_SUCCESS) {
         return -1;
     }
@@ -171,7 +173,8 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 #endif /* SET_MUTEX_PERMS */
 
 #ifdef GLOBAL_COLLECTION_LOCK
-    rc = apr_global_mutex_create(&msce->dbm_lock, NULL, APR_LOCK_DEFAULT, mp);
+    tmpnam(dbm_lock_name);
+    rc = apr_global_mutex_create(&msce->dbm_lock, dbm_lock_name, APR_LOCK_DEFAULT, mp);
     if (rc != APR_SUCCESS) {
         return -1;
     }

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -133,6 +133,10 @@ typedef struct msc_parm msc_parm;
 
 #define FATAL_ERROR "ModSecurity: Fatal error (memory allocation or unexpected internal error)!"
 
+static char auditlog_lock_name[L_tmpnam];
+static char geo_lock_name[L_tmpnam];
+static char dbm_lock_name[L_tmpnam];
+
 extern DSOLOCAL char *new_server_signature;
 extern DSOLOCAL char *real_server_signature;
 extern DSOLOCAL char *chroot_dir;

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -135,7 +135,9 @@ typedef struct msc_parm msc_parm;
 
 static char auditlog_lock_name[L_tmpnam];
 static char geo_lock_name[L_tmpnam];
+#ifdef GLOBAL_COLLECTION_LOCK
 static char dbm_lock_name[L_tmpnam];
+#endif
 
 extern DSOLOCAL char *new_server_signature;
 extern DSOLOCAL char *real_server_signature;


### PR DESCRIPTION
- Call modsecurity_init() for the first invocation too.
- Provide names/files for apr_global_mutex_create() to prevent segfaults in some cases:

[Thu Nov  8 10:58:40 2018] pid 16679 mod_backtrace main() is at 7f949bb6bd30
/usr/lib64/apache2/mod_backtrace.so(+0xddd)[0x7f949bc77ddd]
/usr/sbin/httpd2-prefork(ap_run_fatal_exception+0x4a)[0x7f949bb8b0ba]
/usr/sbin/httpd2-prefork(+0x4f446)[0x7f949bb8b446]
/lib64/libpthread.so.0(+0xf850)[0x7f949a46c850]
/usr/lib64/libapr-1.so.0(apr_global_mutex_lock+0x11)[0x7f949aad6a31]
/usr/lib64/apache2/mod_security2.so(+0x7155e)[0x7f949365655e]
/usr/lib64/apache2/mod_security2.so(+0x72213)[0x7f9493657213]
/usr/lib64/apache2/mod_security2.so(+0x75981)[0x7f949365a981]
/usr/lib64/apache2/mod_security2.so(+0x77ff0)[0x7f949365cff0]
/usr/lib64/apache2/mod_security2.so(+0x7a566)[0x7f949365f566]
/usr/lib64/apache2/mod_security2.so(+0x7bbb7)[0x7f9493660bb7]
/usr/lib64/apache2/mod_security2.so(+0x5be57)[0x7f9493640e57]
/usr/lib64/apache2/mod_security2.so(+0x5b8df)[0x7f94936408df]
/usr/sbin/httpd2-prefork(ap_run_post_read_request+0x4a)[0x7f949bb72cfa]
/usr/sbin/httpd2-prefork(ap_read_request+0xd55)[0x7f949bb75f35]
/usr/sbin/httpd2-prefork(+0x52250)[0x7f949bb8e250]
/usr/sbin/httpd2-prefork(ap_run_process_connection+0x83)[0x7f949bb89d33]
/usr/sbin/httpd2-prefork(+0x5a8de)[0x7f949bb968de]
/usr/sbin/httpd2-prefork(+0x5abca)[0x7f949bb96bca]
/usr/sbin/httpd2-prefork(ap_mpm_run+0x425)[0x7f949bb97055]