### PR TITLE
Fix "make dist" target to include default configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -323,5 +323,7 @@ TESTS+=test/test-cases/secrules-language-tests/operators/lt.json
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = modsecurity.pc
-EXTRA_DIST = modsecurity.pc.in
+EXTRA_DIST = modsecurity.pc.in \
+             modsecurity.conf-recommended \
+             unicode.mapping
 


### PR DESCRIPTION
This change allows to grab fully functional distribution archive from arbitrary future commit, so there will no need to gather `modsecurity.conf` and its prerequisites (namely `unicode.mapping`) separately.