### PR TITLE
Fix tests on FreeBSD

### DIFF
--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd test 1> /dev/null
 


### PR DESCRIPTION
FreeBSD has different prefix for bash (which is non-standard shell there), thus `make check-TESTS` actually was doing nothing:

```
$ gmake check-TESTS
(   0/  0/   0): test/test-cases/regression/issue-1591.json
(   0/  0/   0): test/test-cases/regression/issue-1785.json
(   0/  0/   0): test/test-cases/regression/issue-1812.json
(   0/  0/   0): test/test-cases/regression/issue-1831.json
(   0/  0/   0): test/test-cases/regression/issue-1844.json
(   0/  0/   0): test/test-cases/regression/issue-1850.json
[..]
Testsuite summary for modsecurity 3.0
# TOTAL: 0
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

This change allows to run libmodsecurity tests on FreeBSD if bash is installed.