### PR TITLE
base64 decode

### DIFF
--- a/src/operators/pm_from_file.cc
+++ b/src/operators/pm_from_file.cc
@@ -25,6 +25,23 @@
 namespace modsecurity {
 namespace operators {
 
+bool PmFromFile::isComment(const std::string &s) {
+    if (s.size() == 0) {
+	  return true;
+    }
+    size_t pos = s.find("#");
+    if (pos != std::string::npos) {
+        for (int i = 0; i < pos; i++) {
+	    if (!std::isspace(s[i])) {
+		return false;
+	    }
+	}
+    } else {
+	return false;
+    }
+
+    return true;
+}
 
 bool PmFromFile::init(const std::string &config, std::string *error) {
     std::istream *iss;
@@ -50,7 +67,9 @@ bool PmFromFile::init(const std::string &config, std::string *error) {
     }
 
     for (std::string line; std::getline(*iss, line); ) {
-        acmp_add_pattern(m_p, line.c_str(), NULL, NULL, line.length());
+        if (isComment(line) == false) {
+            acmp_add_pattern(m_p, line.c_str(), NULL, NULL, line.length());
+	}
     }
 
     while (m_p->is_failtree_done == 0) {

--- a/src/operators/pm_from_file.h
+++ b/src/operators/pm_from_file.h
@@ -36,6 +36,8 @@ class PmFromFile : public Pm {
         : Pm(n, std::move(param)) { }
 
     bool init(const std::string &file, std::string *error) override;
+
+    bool isComment(const std::string &s);
 };
 
 

--- a/src/utils/base64.cc
+++ b/src/utils/base64.cc
@@ -66,10 +66,17 @@ std::string Base64::decode(const std::string& data) {
     size_t decoded_len = 0;
     unsigned char *d;
     std::string ret;
+    int err = 0;
     size_t len = strlen(data.c_str());
-
-    mbedtls_base64_decode(NULL, 0, &decoded_len,
+   
+    err = mbedtls_base64_decode(NULL, 0, &decoded_len,
         reinterpret_cast<const unsigned char*>(data.c_str()), len);
+
+    if (err == MBEDTLS_ERR_BASE64_INVALID_CHARACTER) {
+         /* input is invalid */
+         ret.assign(data);
+	 goto END;
+    }
 
     d = reinterpret_cast<unsigned char*>(malloc(sizeof(char) * decoded_len));
     if (d == NULL) {
@@ -84,6 +91,7 @@ std::string Base64::decode(const std::string& data) {
     ret.assign(reinterpret_cast<const char*>(d), decoded_len);
     free(d);
 
+END:
     return ret;
 }
 

--- a/src/utils/base64.cc
+++ b/src/utils/base64.cc
@@ -74,8 +74,7 @@ std::string Base64::decode(const std::string& data) {
 
     if (err == MBEDTLS_ERR_BASE64_INVALID_CHARACTER) {
          /* input is invalid */
-         ret.assign(data);
-	 goto END;
+         return data;
     }
 
     d = reinterpret_cast<unsigned char*>(malloc(sizeof(char) * decoded_len));
@@ -91,7 +90,6 @@ std::string Base64::decode(const std::string& data) {
     ret.assign(reinterpret_cast<const char*>(d), decoded_len);
     free(d);
 
-END:
     return ret;
 }
 


### PR DESCRIPTION
1. the base64decode not check the valid of input string，
if input is a invalid base64 string `VGVzdENhc2U=VGVzdENhc2U=`, we will get a `empty string`, I think it coulde lead false positive.

2. the input string len is strlen(data.c_str()), if input is `VGVzdENhc2U=\\u0000VGVzdENhc2U=`,  the variable len equal to 12, we will loss part of data. I'm not sure if it was a mistake?