### PR TITLE
Fixed buffer overflow in Utils::Md5::hexdigest()

### DIFF
--- a/src/utils/md5.cc
+++ b/src/utils/md5.cc
@@ -13,7 +13,7 @@ std::string Md5::hexdigest(std::string& input) {
     mbedtls_md5(reinterpret_cast<const unsigned char *>(input.c_str()),
         input.size(), digest);
 
-    char buf[32];
+    char buf[33];
     for (int i = 0; i < 16; i++) {
         sprintf(buf+i*2, "%02x", digest[i]);
     }


### PR DESCRIPTION
Found via failed test (auditlog.json) on Alpine Linux 3.8.2:

```
$ cat test/test-cases/regression/auditlog.json.log
:test-result: PASS auditlog.json:auditlog : basic parser test - Parallel
test/test-suite.sh: line 14: 23740 Segmentation fault      (core dumped) $VALGRIND $PARAM ./regression_tests ../$FILE:$i
:test-result: FAIL segfault: .././test/test-cases/regression/auditlog.json:1
./regression_tests .././test/test-cases/regression/auditlog.json:1
:test-result: PASS auditlog.json:auditlog : basic parser test - Serial

./regression_tests .././test/test-cases/regression/auditlog.json:2

```

Backtrace:

```
Core was generated by `./regression_tests .././test/test-cases/regression/auditlog.json:1'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f4637b6bb8d in __stack_chk_fail () from /lib/ld-musl-x86_64.so.1
(gdb) bt
#0  0x00007f4637b6bb8d in __stack_chk_fail () from /lib/ld-musl-x86_64.so.1
#1  0x00005620f24b78c0 in modsecurity::Utils::Md5::hexdigest (input=...) at utils/md5.cc:22
#2  0x00005620f249115f in modsecurity::audit_log::writer::Parallel::write (this=0x5620f35fd060, transaction=0x5620f3606b60, parts=<optimized out>, error=0x7ffc0067f378)
    at audit_log/writer/parallel.cc:173
#3  0x00005620f249012d in modsecurity::audit_log::AuditLog::saveIfRelevant (this=0x7f4636c332e0, transaction=transaction@entry=0x5620f3606b60, parts=parts@entry=4430)
    at audit_log/audit_log.cc:326
#4  0x00005620f2482d54 in modsecurity::Transaction::processLogging (this=0x5620f3606b60) at transaction.cc:1302
#5  0x00005620f247e7fa in perform_unit_test (test=0x7ffc0067fc68, tests=<optimized out>, res=0x7ffc0067fc08, count=0x7ffc0067fa4c) at regression/regression.cc:348
#6  0x00005620f247b545 in main (argc=<optimized out>, argv=<optimized out>) at regression/regression.cc:500
(gdb) 
```