### PR TITLE
Add support for capturing group test cases

### DIFF
--- a/test/unit/unit.cc
+++ b/test/unit/unit.cc
@@ -41,6 +41,10 @@
 using modsecurity_test::UnitTest;
 using modsecurity_test::ModSecurityTest;
 using modsecurity_test::ModSecurityTestResults;
+using modsecurity::ModSecurity;
+using modsecurity::Rule;
+using modsecurity::Rules;
+using modsecurity::Transaction;
 using modsecurity::actions::transformations::Transformation;
 using modsecurity::operators::Operator;
 
@@ -53,8 +57,19 @@ void print_help() {
     std::cout << std::endl;
 }
 
+static std::vector<std::string> get_capturing_groups(Transaction &transaction) {
+    // capturing groups are stored in the TX collection as "0", "1", and so on
+    std::vector<std::string> res;
+    for (int i = 0;; i++) {
+        const std::string key = std::to_string(i);
+        auto s = transaction.m_collections.m_tx_collection->resolveFirst(key);
+        if (s == NULL) break;
+        res.push_back(*s);
+    }
+    return res;
+}
 
-void perform_unit_test(ModSecurityTest<UnitTest> *test, UnitTest *t,
+static void perform_unit_test(ModSecurity *modsec, ModSecurityTest<UnitTest> *test, UnitTest *t,
     ModSecurityTestResults<UnitTest>* res) {
     std::string error;
     bool found = true;
@@ -77,11 +92,27 @@ void perform_unit_test(ModSecurityTest<UnitTest> *test, UnitTest *t,
     }
 
     if (t->type == "op") {
+        Rules rules{};
+        Transaction transaction{modsec, &rules, NULL};
         Operator *op = Operator::instantiate(t->name, t->param);
+        Rule rule{NULL, NULL, NULL, "", 1};
+
+        // Rx operator won't capture groups otherwise
+        rule.m_containsCaptureAction = true;
+
         op->init(t->filename, &error);
-        int ret = op->evaluate(NULL, NULL, t->input, NULL);
+        int ret = op->evaluate(&transaction, &rule, t->input, NULL);
         t->obtained = ret;
-        if (ret != t->ret) {
+
+        bool pass = (ret == t->ret);
+        if (t->re_groups.size() > 0) {
+            t->obtained_re_groups = get_capturing_groups(transaction);
+            if (t->re_groups != t->obtained_re_groups) {
+                pass = false;
+            }
+        }
+
+        if (!pass) {
             res->push_back(t);
             if (test->m_automake_output) {
                 std::cout << "FAIL ";
@@ -152,6 +183,8 @@ int main(int argc, char **argv) {
         test.load_tests("test-cases/secrules-language-tests/transformations");
     }
 
+    ModSecurity modsec{};
+
     for (std::pair<std::string, std::vector<UnitTest *> *> a : test) {
         std::vector<UnitTest *> *tests = a.second;
 
@@ -162,7 +195,7 @@ int main(int argc, char **argv) {
             if (!test.m_automake_output) {
                 std::cout << "  " << a.first << "...\t";
             }
-            perform_unit_test(&test, t, &r);
+            perform_unit_test(&modsec, &test, t, &r);
 
             if (!test.m_automake_output) {
                 int skp = 0;

--- a/test/unit/unit_test.cc
+++ b/test/unit/unit_test.cc
@@ -88,6 +88,19 @@ void json2bin(std::string *str) {
 //    replaceAll(str, "\\f", '\f');
 }
 
+static void print_array(std::stringstream &i, const std::vector<std::string> array) {
+    i << "[";
+    bool first = true;
+    for (const auto &s : array) {
+        if (first) {
+            first = false;
+        } else {
+            i << ", ";
+        }
+        i << "\"" << modsecurity::utils::string::toHexIfNeeded(s) << "\"";
+    }
+    i << "]";
+}
 
 std::string UnitTest::print() {
     std::stringstream i;
@@ -101,6 +114,12 @@ std::string UnitTest::print() {
     i << "  \"input\": \"" << this->input << "\"" << std::endl;
     i << "  \"param\": \"" << this->param << "\"" << std::endl;
     i << "  \"output\": \"" << this->output << "\"" << std::endl;
+    if (this->re_groups.size() != 0) {
+        i << "  \"re_groups\": ";
+        print_array(i, this->re_groups);
+        i << std::endl;
+
+    }
     i << "}" << std::endl;
     if (this->ret != this->obtained) {
         i << "Expecting: \"" << this->ret << "\" - returned: \"";
@@ -112,6 +131,13 @@ std::string UnitTest::print() {
         i << "\" - returned: \"";
         i << modsecurity::utils::string::toHexIfNeeded(this->obtainedOutput);
         i << "\"";
+        i << std::endl;
+    }
+    if (this->re_groups.size() && this->re_groups != this->obtained_re_groups) {
+        i << "Expecting:\n  ";
+        print_array(i, this->re_groups);
+        i << "\nObtained:\n  ";
+        print_array(i, this->obtained_re_groups);
         i << std::endl;
     }
 
@@ -149,6 +175,16 @@ UnitTest *UnitTest::from_yajl_node(yajl_val &node) {
             * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53690
             *
             */
+        } else if (strcmp(key, "re_groups") == 0) {
+            auto arr = YAJL_GET_ARRAY(val);
+            if (arr == NULL) {
+                continue;
+            }
+            for (int i = 0; i < arr->len; i++) {
+                const char *s = YAJL_GET_STRING(arr->values[i]);
+                if (s == NULL) continue;
+                u->re_groups.push_back(s);
+            }
         }
     }
 

--- a/test/unit/unit_test.h
+++ b/test/unit/unit_test.h
@@ -42,6 +42,10 @@ class UnitTest {
     int obtained;
     int skipped;
     std::string obtainedOutput;
+
+    // for regular expression operator tests
+    std::vector<std::string> re_groups;
+    std::vector<std::string> obtained_re_groups;
 };
 
 }  // namespace modsecurity_test


### PR DESCRIPTION
This enables unit tests to compare the matching groups as well, not just binary match-no match.

The format of JSON test case is extended, new `"re_groups"` parameter is added:
```json
{
      "type" : "op",
      "name" : "rx",
      "param" : "(abc)(def)",
      "input" : "abcdef",
      "ret" : 1,
      "re_groups": ["abcdef", "abc", "def"]
},
{
      "type" : "op",
      "name" : "rx",
      "param" : "(abc)(def)",
      "input" : "abcdef   abcdef",
      "ret" : 1,
      "re_groups": ["abcdef", "abc", "def", "abcdef", "abc", "def"]
}
```

New tests cases will need to be added to https://github.com/SpiderLabs/secrules-language-tests, of course.