### PR TITLE
Fix LMDB compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   - OPTS="--without-curl $OPTS"
   - OPTS="--without-yajl $OPTS"
   - OPTS="--without-geoip $OPTS"
-  - OPTS="--without-lmdb $OPTS"
+  - OPTS="--with-lmdb $OPTS"
   - OPTS="--without-ssdeep $OPTS"
   - OPTS="--without-lua $OPTS"
   - OPTS="--without-maxmind $OPTS"
@@ -36,6 +36,7 @@ before_script:
   - '[ "$TRAVIS_OS_NAME" != osx ] || brew update'
   - '[ "$TRAVIS_OS_NAME" != osx ] || brew install cppcheck'
   - '[ "$TRAVIS_OS_NAME" != osx ] || brew install libmaxminddb'
+  - '[ "$TRAVIS_OS_NAME" != osx ] || brew install lmdb'
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo add-apt-repository --yes ppa:maxmind/ppa'
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-get update'
   - '[ "$TRAVIS_OS_NAME" != linux ] || sudo apt-cache search maxmind'

--- a/src/collection/backend/lmdb.cc
+++ b/src/collection/backend/lmdb.cc
@@ -538,7 +538,7 @@ void LMDB::resolveRegularExpression(const std::string& var,
     MDB_cursor *cursor;
     size_t pos;
 
-    Utils::Regex r = Utils::Regex(var);
+    Utils::Regex r(var);
 
     rc = mdb_txn_begin(m_env, NULL, 0, &txn);
     lmdb_debug(rc, "txn", "resolveRegularExpression");

--- a/test/regression/regression.cc
+++ b/test/regression/regression.cc
@@ -15,6 +15,8 @@
 
 #include <string.h>
 
+#include <unistd.h>
+
 #include <ctime>
 #include <iostream>
 #include <string>
@@ -135,6 +137,12 @@ void perform_unit_test(ModSecurityTest<RegressionTest> *test,
             testRes->reason << "JSON disabled";
             continue;
         }
+
+#ifdef WITH_LMDB
+        // some tests (e.g. issue-1831.json)  don't like it when data persists between runs
+        unlink("./modsec-shared-collections");
+        unlink("./modsec-shared-collections-lock");
+#endif
 
         modsec = new modsecurity::ModSecurity();
         modsec->setConnectorInformation("ModSecurity-regression v0.0.1-alpha" \


### PR DESCRIPTION
See #2008 

When I re-enabled LMDB testing in Travis, I also discovered a regression test that fails when LMDB is enabled, and fixed it as well. The fix is ugly, but so is the LMDB backend code that stores data in hardcoded location relative to the current working dir `¯\_(ツ)_/¯`.