### PR TITLE
Replace xml2-config, pcre-config with pkg-config.

### DIFF
--- a/build/libxml.m4
+++ b/build/libxml.m4
@@ -1,10 +1,11 @@
-dnl Check for LIBXML2 Libraries
-dnl CHECK_LIBXML2(ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND])
+heck for LIBXML2 Libraries
 dnl Sets:
+dnl  LIBXML2_VERSION
 dnl  LIBXML2_CFLAGS
-dnl  LIBXML2_LIBS
+dnl  LIBXML2_CPPFLAGS
+dnl  LIBXML2_LDADD
+dnl  LIBXML2_LDFLAGS
 
-LIBXML2_CONFIG=""
 LIBXML2_VERSION=""
 LIBXML2_CFLAGS=""
 LIBXML2_CPPFLAGS=""
@@ -12,73 +13,6 @@ LIBXML2_LDADD=""
 LIBXML2_LDFLAGS=""
 
 AC_DEFUN([CHECK_LIBXML2], [
-
-AC_ARG_WITH(
-    libxml,
-    [AC_HELP_STRING([--with-libxml=PATH],[Path to libxml2 prefix or config script])],
-    [test_paths="${with_libxml}"],
-    [test_paths="/usr/local/libxml2 /usr/local/xml2 /usr/local/xml /usr/local /opt/libxml2 /opt/libxml /opt/xml2 /opt/xml /opt /usr"])
-
-AC_MSG_CHECKING([for libxml2 config script])
-
-for x in ${test_paths}; do
-    dnl # Determine if the script was specified and use it directly
-    if test ! -d "$x" -a -e "$x"; then
-        LIBXML2_CONFIG=$x
-        libxml2_path="no"
-        break
-    fi
-
-    dnl # Try known config script names/locations
-    for LIBXML2_CONFIG in xml2-config xml-2-config xml-config; do
-        if test -e "${x}/bin/${LIBXML2_CONFIG}"; then
-            libxml2_path="${x}/bin"
-            break
-        elif test -e "${x}/${LIBXML2_CONFIG}"; then
-            libxml2_path="${x}"
-            break
-        else
-            libxml2_path=""
-        fi
-    done
-    if test -n "$libxml2_path"; then
-        break
-    fi
-done
-
-if test -n "${libxml2_path}"; then
-    if test "${libxml2_path}" != "no"; then
-        LIBXML2_CONFIG="${libxml2_path}/${LIBXML2_CONFIG}"
-    fi
-    AC_MSG_RESULT([${LIBXML2_CONFIG}])
-    LIBXML2_VERSION=`${LIBXML2_CONFIG} --version | sed 's/^[[^0-9]][[^[:space:]]][[^[:space:]]]*[[[:space:]]]*//'`
-    if test ! -z "${LIBXML2_VERSION}"; then AC_MSG_NOTICE(xml VERSION: $LIBXML2_VERSION); fi
-    LIBXML2_CFLAGS="`${LIBXML2_CONFIG} --cflags` -DWITH_LIBXML2"
-    if test ! -z "${LIBXML2_CFLAGS}"; then AC_MSG_NOTICE(xml CFLAGS: $LIBXML2_CFLAGS); fi
-    LIBXML2_LDADD="`${LIBXML2_CONFIG} --libs`"
-    if test ! -z "${LIBXML2_LDADD}"; then AC_MSG_NOTICE(xml LDADD: $LIBXML2_LDADD); fi
-
-    AC_MSG_CHECKING([if libxml2 is at least v2.6.29])
-    libxml2_min_ver=`echo 2.6.29 | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
-    libxml2_ver=`echo ${LIBXML2_VERSION} | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
-    if test "$libxml2_ver" -ge "$libxml2_min_ver"; then
-        AC_MSG_RESULT([yes, $LIBXML2_VERSION])
-    else
-        AC_MSG_RESULT([no, $LIBXML2_VERSION])
-        AC_MSG_ERROR([NOTE: libxml2 library must be at least 2.6.29])
-    fi
-
-else
-    AC_MSG_RESULT([no])
-fi
-
-AC_SUBST(LIBXML2_CONFIG)
-AC_SUBST(LIBXML2_VERSION)
-AC_SUBST(LIBXML2_CFLAGS)
-AC_SUBST(LIBXML2_CPPFLAGS)
-AC_SUBST(LIBXML2_LDADD)
-AC_SUBST(LIBXML2_LDFLAGS)
-
 
 if test "x${with_libxml}" == "xno"; then
     LIBXML2_DISABLED=yes
@@ -88,7 +22,27 @@ else
     fi
 fi
 
-if test -z "${LIBXML2_VERSION}"; then
+AC_REQUIRE([PKG_PROG_PKG_CONFIG])
+PKG_CHECK_MODULES([LIBXML2], [libxml-2.0], [
+    LIBXML2_FOUND=1
+    LIBXML2_VERSION="`${PKG_CONFIG} libxml-2.0 --modversion`"
+    LIBXML2_CFLAGS="`${PKG_CONFIG} libxml-2.0 --cflags -DWITH_LIBXML2`"
+    LIBXML2_LDADD="`${PKG_CONFIG} libxml-2.0 --libs`"
+    LIBXML2_DISPLAY="${LIBXML2_LDADD}, ${LIBXML2_CFLAGS}"
+
+    AC_MSG_CHECKING([if libxml2 is at least v2.6.29])
+    libxml2_min_ver=`echo 2.6.29 | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
+    libxml2_ver=`echo ${LIBXML2_VERSION} | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
+    if test "$libxml2_ver" -ge "$libxml2_min_ver"; then
+        AC_MSG_RESULT([yes, $LIBXML2_VERSION])
+        AC_MSG_NOTICE([using libxml2 v${LIBXML2_VERSION}])
+    else
+        AC_MSG_RESULT([no, $LIBXML2_VERSION])
+        AC_MSG_ERROR([NOTE: libxml2 library must be at least 2.6.29])
+    fi
+
+], [
+    AC_MSG_RESULT([no])
     AC_MSG_NOTICE([*** libxml2 library not found.])
     if test -z "${LIBXML2_MANDATORY}"; then
         if test -z "${LIBXML2_DISABLED}"; then
@@ -100,12 +54,13 @@ if test -z "${LIBXML2_VERSION}"; then
         AC_MSG_ERROR([Libxml2 was explicitly referenced but it was not found])
         LIBXML2_FOUND=-1
     fi
-else
-    LIBXML2_FOUND=1
-    AC_MSG_NOTICE([using libxml2 v${LIBXML2_VERSION}])
-    LIBXML2_DISPLAY="${LIBXML2_LDADD}, ${LIBXML2_CFLAGS}"
-fi
+])
 
+AC_SUBST(LIBXML2_VERSION)
+AC_SUBST(LIBXML2_CFLAGS)
+AC_SUBST(LIBXML2_CPPFLAGS)
+AC_SUBST(LIBXML2_LDADD)
+AC_SUBST(LIBXML2_LDFLAGS)
 AC_SUBST(LIBXML2_FOUND)
 AC_SUBST(LIBXML2_DISPLAY)
 ])

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -1,10 +1,12 @@
 dnl Check for PCRE Libraries
-dnl CHECK_PCRE(ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND])
 dnl Sets:
+dnl  PCRE_VERSION
+dnl  PCRE_CPPFLAGS
 dnl  PCRE_CFLAGS
-dnl  PCRE_LIBS
+dnl  PCRE_LDFLAGS
+dnl  PCRE_LDADD
+dnl  PCRE_LD_PATH
 
-PCRE_CONFIG=""
 PCRE_VERSION=""
 PCRE_CPPFLAGS=""
 PCRE_CFLAGS=""
@@ -13,82 +15,19 @@ PCRE_LDADD=""
 PCRE_LD_PATH=""
 
 AC_DEFUN([CHECK_PCRE],
-[dnl
+[
 
-AC_ARG_WITH(
-    pcre,
-    [AC_HELP_STRING([--with-pcre=PATH],[Path to pcre prefix or config script])],
-    [test_paths="${with_pcre}"],
-    [test_paths="/usr/local/libpcre /usr/local/pcre /usr/local /opt/libpcre /opt/pcre /opt /usr /opt/local"])
+AC_REQUIRE([PKG_PROG_PKG_CONFIG])
+PKG_CHECK_MODULES([PCRE], [libpcre], [
+    PCRE_VERSION="`${PKG_CONFIG} libpcre --modversion`"
+    PCRE_CFLAGS="`${PKG_CONFIG} libpcre --cflags`"
+    PCRE_LDADD="`${PKG_CONFIG} libpcre --libs`"
+    PCRE_LD_PATH="`${PKG_CONFIG} libpcre --libs-only-l`"
+],[
+    AC_MSG_NOTICE([*** pcre library not found.])
+    AC_MSG_ERROR([pcre library is required]) 
+])
 
-AC_MSG_CHECKING([for libpcre config script])
-
-for x in ${test_paths}; do
-    dnl # Determine if the script was specified and use it directly
-    if test ! -d "$x" -a -e "$x"; then
-        PCRE_CONFIG=$x
-        pcre_path="no"
-        break
-    fi
-
-    dnl # Try known config script names/locations
-    for PCRE_CONFIG in pcre-config; do
-        if test -e "${x}/bin/${PCRE_CONFIG}"; then
-            pcre_path="${x}/bin"
-            break
-        elif test -e "${x}/${PCRE_CONFIG}"; then
-            pcre_path="${x}"
-            break
-        else
-            pcre_path=""
-        fi
-    done
-    if test -n "$pcre_path"; then
-        break
-    fi
-done
-
-if test -n "${pcre_path}"; then
-    if test "${pcre_path}" != "no"; then
-        PCRE_CONFIG="${pcre_path}/${PCRE_CONFIG}"
-    fi
-    AC_MSG_RESULT([${PCRE_CONFIG}])
-    PCRE_VERSION="`${PCRE_CONFIG} --version`"
-    if test ! -z "${PCRE_VERSION}"; then AC_MSG_NOTICE(pcre VERSION: $PCRE_VERSION); fi
-    PCRE_CFLAGS="`${PCRE_CONFIG} --cflags`"
-    if test ! -z "${PCRE_CFLAGS}"; then AC_MSG_NOTICE(pcre CFLAGS: $PCRE_CFLAGS); fi
-    PCRE_LDADD="`${PCRE_CONFIG} --libs`"
-    if test ! -z "${PCRE_LDADD}"; then AC_MSG_NOTICE(pcre LDADD: $PCRE_LDADD); fi
-    PCRE_LD_PATH="/`${PCRE_CONFIG} --libs | cut -d'/' -f2,3,4,5,6 | cut -d ' ' -f1`"
-    if test ! -z "${PCRE_LD_PATH}"; then AC_MSG_NOTICE(pcre PCRE_LD_PATH: $PCRE_LD_PATH); fi
-else
-    AC_MSG_RESULT([no])
-fi
-
-if test -n "${PCRE_VERSION}"; then
-    AC_MSG_CHECKING(for PCRE JIT)
-    save_CFLAGS=$CFLAGS
-    save_LDFLAGS=$LDFLAGS
-    CFLAGS="${PCRE_CFLAGS} ${CFLAGS}"
-    LDFLAGS="${LDFLAGS} ${PCRE_LDADD}"
-    AC_TRY_COMPILE([ #include <stdio.h>
-                     #include <pcre.h> ],
-        [ int jit = 0;
-          pcre_free_study(NULL);
-          pcre_config(PCRE_CONFIG_JIT, &jit);
-          if (jit != 1) return 1; ],
-        [ pcre_jit_available=yes ], [:]
-    )
-
-    if test "x$pcre_jit_available" = "xyes"; then
-        AC_MSG_RESULT(yes)
-        PCRE_CFLAGS="${PCRE_CFLAGS} -DPCRE_HAVE_JIT"
-    else
-        AC_MSG_RESULT(no)
-    fi
-    CFLAGS=$save_CFLAGS
-    LDFLAGS=$save_$LDFLAGS
-fi
 
 AC_SUBST(PCRE_CONFIG)
 AC_SUBST(PCRE_VERSION)
@@ -98,12 +37,5 @@ AC_SUBST(PCRE_LDFLAGS)
 AC_SUBST(PCRE_LDADD)
 AC_SUBST(PCRE_LD_PATH)
 
-if test -z "${PCRE_VERSION}"; then
-    AC_MSG_NOTICE([*** pcre library not found.])
-    ifelse([$2], , AC_MSG_ERROR([pcre library is required]), $2)
-else
-    AC_MSG_NOTICE([using pcre v${PCRE_VERSION}])
-    ifelse([$1], , , $1) 
-    PCRE_LDADD="${PCRE_LDADD} -lpcre"
-fi 
 ])
+


### PR DESCRIPTION
Yocto deprecates xml2-config and pcre-config for pkg-config. As pkg-config is
commonly found (and is used in other parts of the modsecurity v3), this change
should be compatible with existing build environments.

This addresses issue #2013 .