### PR TITLE
V3/reqbodyproc

### DIFF
--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -583,6 +583,8 @@ int Transaction::addRequestHeader(const std::string& key,
     if (keyl == "content-type") {
         std::string multipart("multipart/form-data");
         std::string urlencoded("application/x-www-form-urlencoded");
+        std::string xml("application/xml");
+        std::string json("application/json");
         std::string l = utils::string::tolower(value);
         if (l.compare(0, multipart.length(), multipart) == 0) {
             this->m_requestBodyType = MultiPartRequestBody;
@@ -592,6 +594,18 @@ int Transaction::addRequestHeader(const std::string& key,
         if (l.compare(0, urlencoded.length(), urlencoded) == 0) {
             this->m_requestBodyType = WWWFormUrlEncoded;
             m_variableReqbodyProcessor.set("URLENCODED", m_variableOffset);
+        }
+
+        if (l.compare(0, xml.length(), xml) == 0) {
+            this->m_requestBodyType = XMLRequestBody;
+            m_variableReqbodyProcessor.set("XML", m_variableOffset);
+            m_requestBodyProcessor = XMLRequestBody;
+        }
+
+        if (l.compare(0, json.length(), json) == 0) {
+            this->m_requestBodyType = JSONRequestBody;
+            m_variableReqbodyProcessor.set("JSON", m_variableOffset);
+            m_requestBodyProcessor = JSONRequestBody;
         }
     }
 

--- a/test/test-cases/regression/offset-variable.json
+++ b/test/test-cases/regression/offset-variable.json
@@ -964,7 +964,7 @@
     ]
   },
   {
-    "enabled":1,
+    "enabled":0,
     "version_min":300000,
     "title":"Testing Variables :: REQUEST_BODY",
     "client":{
@@ -1013,7 +1013,7 @@
     ]
   },
   {
-    "enabled":1,
+    "enabled":0,
     "version_min":300000,
     "title":"Testing Variables :: REQUEST_BODY",
     "client":{

--- a/test/test-cases/regression/rule-944120_full.json
+++ b/test/test-cases/regression/rule-944120_full.json
@@ -1,0 +1,6850 @@
+[
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-0",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.clonetransformer"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-1",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.clonetransformer=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-2",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.clonetransformer"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-3",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.clonetransformer=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-4",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.clonetransformer"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-5",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.clonetransformer attribute_name=\"attribute_value\">value</ProcessBuilder.evil.clonetransformer></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-6",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.clonetransformer=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-7",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.clonetransformer\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-8",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.clonetransformer</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-9",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.clonetransformer</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-10",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.clonetransformer"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-11",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.clonetransformer\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-12",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.clonetransformer\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-13",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.clonetransformer\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-14",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.clonetransformer\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-15",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.clonetransformer</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-16",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.clonetransformer</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-17",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.forclosure"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-18",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.forclosure=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-19",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.forclosure"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-20",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.forclosure=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-21",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.forclosure"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-22",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.forclosure attribute_name=\"attribute_value\">value</ProcessBuilder.evil.forclosure></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-23",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.forclosure=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-24",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.forclosure\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-25",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.forclosure</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-26",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.forclosure</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-27",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.forclosure"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-28",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.forclosure\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-29",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.forclosure\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-30",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.forclosure\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-31",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.forclosure\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-32",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.forclosure</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-33",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.forclosure</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-34",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.instantiatefactory"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-35",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.instantiatefactory=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-36",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.instantiatefactory"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-37",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.instantiatefactory=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-38",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.instantiatefactory"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-39",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.instantiatefactory attribute_name=\"attribute_value\">value</ProcessBuilder.evil.instantiatefactory></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-40",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.instantiatefactory=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-41",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.instantiatefactory\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-42",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatefactory</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-43",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatefactory</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-44",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.instantiatefactory"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-45",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.instantiatefactory\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-46",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.instantiatefactory\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-47",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.instantiatefactory\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-48",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.instantiatefactory\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-49",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatefactory</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-50",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatefactory</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-51",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.instantiatetransformer"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-52",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.instantiatetransformer=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-53",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.instantiatetransformer"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-54",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.instantiatetransformer=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-55",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.instantiatetransformer"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-56",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.instantiatetransformer attribute_name=\"attribute_value\">value</ProcessBuilder.evil.instantiatetransformer></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-57",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.instantiatetransformer=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-58",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.instantiatetransformer\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-59",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatetransformer</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-60",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatetransformer</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-61",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.instantiatetransformer"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-62",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.instantiatetransformer\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-63",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.instantiatetransformer\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-64",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.instantiatetransformer\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-65",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.instantiatetransformer\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-66",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatetransformer</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-67",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.instantiatetransformer</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-68",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.invokertransformer"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-69",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.invokertransformer=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-70",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.invokertransformer"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-71",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.invokertransformer=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-72",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.invokertransformer"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-73",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.invokertransformer attribute_name=\"attribute_value\">value</ProcessBuilder.evil.invokertransformer></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-74",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.invokertransformer=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-75",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.invokertransformer\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-76",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.invokertransformer</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-77",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.invokertransformer</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-78",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.invokertransformer"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-79",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.invokertransformer\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-80",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.invokertransformer\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-81",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.invokertransformer\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-82",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.invokertransformer\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-83",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.invokertransformer</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-84",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.invokertransformer</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-85",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.prototypeclonefactory"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-86",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.prototypeclonefactory=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-87",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.prototypeclonefactory"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-88",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.prototypeclonefactory=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-89",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.prototypeclonefactory"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-90",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.prototypeclonefactory attribute_name=\"attribute_value\">value</ProcessBuilder.evil.prototypeclonefactory></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-91",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.prototypeclonefactory=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-92",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.prototypeclonefactory\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-93",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeclonefactory</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-94",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeclonefactory</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-95",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.prototypeclonefactory"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-96",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.prototypeclonefactory\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-97",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.prototypeclonefactory\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-98",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.prototypeclonefactory\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-99",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.prototypeclonefactory\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-100",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeclonefactory</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-101",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeclonefactory</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-102",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.prototypeserializationfactory"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-103",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.prototypeserializationfactory=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-104",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.prototypeserializationfactory"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-105",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.prototypeserializationfactory=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-106",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.prototypeserializationfactory"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-107",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.prototypeserializationfactory attribute_name=\"attribute_value\">value</ProcessBuilder.evil.prototypeserializationfactory></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-108",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.prototypeserializationfactory=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-109",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.prototypeserializationfactory\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-110",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeserializationfactory</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-111",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeserializationfactory</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-112",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.prototypeserializationfactory"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-113",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.prototypeserializationfactory\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-114",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.prototypeserializationfactory\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-115",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.prototypeserializationfactory\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-116",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.prototypeserializationfactory\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-117",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeserializationfactory</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-118",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.prototypeserializationfactory</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-119",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.whileclosure"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-120",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "ProcessBuilder.evil.whileclosure=test"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-121",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "test=ProcessBuilder.evil.whileclosure"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-122",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "ProcessBuilder.evil.whileclosure=test"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-123",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "test": "ProcessBuilder.evil.whileclosure"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=value"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-124",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><ProcessBuilder.evil.whileclosure attribute_name=\"attribute_value\">value</ProcessBuilder.evil.whileclosure></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-125",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element ProcessBuilder.evil.whileclosure=\"attribute_value\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-126",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"ProcessBuilder.evil.whileclosure\">element_value</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-127",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-128",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/xml"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "<?xml version=\"1.0\"?><xml><l1><l2><l3><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></l3></l2></l1></xml>"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-129",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "text/plain"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "test=ProcessBuilder.evil.whileclosure"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-130",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"test\": \"ProcessBuilder.evil.whileclosure\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-131",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "application/json"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "{\"ProcessBuilder.evil.whileclosure\": \"test\"}"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-132",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.whileclosure\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-133",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/json\r",
+          "\r",
+          "{\"ProcessBuilder.evil.whileclosure\": \"test\"}\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-134",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Positive tests for rule 944120 944120-135",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+          "Host": "localhost",
+          "User-Agent": "ModSecurity CRS 3 Tests",
+          "Accept": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+          "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+          "Accept-Encoding": "gzip,deflate",
+          "Accept-Language": "en-us,en;q=0.5",
+          "Content-Type": "multipart/form-data; boundary=---------------------------thisissparta"
+      },
+      "uri":"/",
+      "http_version":1.0,
+      "method":"POST",
+      "body": [
+          "-----------------------------thisissparta\r",
+          "Content-Disposition: form-data; name=\"payload\r",
+          "Content-Type: application/xml\r",
+          "\r",
+          "<?xml version=\"1.0\"?><xml><element attribute_name=\"attribute_value\">ProcessBuilder.evil.whileclosure</element></xml>\r",
+          "-----------------------------thisissparta--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecDefaultAction \"phase:2,deny,block,status:403,log\"",
+      "SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \"@rx (?:clonetransformer|forclosure|instantiatefactory|instantiatetransformer|invokertransformer|prototypeclonefactory|prototypeserializationfactory|whileclosure|getproperty|filewriter|xmldecoder)\" \"id:944120,phase:2,block,t:none,t:lowercase,log,msg:'Remote Command Execution: Java serialization (CVE-2015-5842)',logdata:'Matched Data: %{MATCHED_VAR} found within %{MATCHED_VAR_NAME}',ver:'OWASP_CRS/3.1.0',severity:'CRITICAL',chain\"",
+      "SecRule MATCHED_VARS \"@rx (?:runtime|processbuilder)\" \"t:none,t:lowercase,setvar:'tx.msg=%{rule.msg}',setvar:'tx.rce_score=+%{tx.critical_anomaly_score}',setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}',setvar:'tx.%{rule.id}-OWASP_CRS/WEB_ATTACK/RCE-%{MATCHED_VAR_NAME}=%{MATCHED_VAR}'\""
+    ]
+  }
+]


### PR DESCRIPTION
In the [v2 reference](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#REQUEST_BODY), the REQUEST_BODY variable info contains:

> Holds the raw request body. This variable is available **only** if the URLENCODED request body processor was used, which will occur by default when the application/x-www-form-urlencoded content type is detected, or if the use of the URLENCODED request body parser was forced. 

Now the REQUEST_BODY in libmodsec3 always evaluated, no matter what is the content-type. Eg. the CT is application/xml, and the SecRule operator is `@rx`, then it checked with the regex pattern.

CRS regression tests showed that in case of XML, JSON and Multipart CT's don't allows the REQUEST_BODY variable. See the attached regression test json file.

Note, that this modification needs to disable the REQUEST_BODY check in the offset_variable.json, when the CT is Multipart.