### PR TITLE
segfault with assigned user id on OpenShift

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -234,16 +234,20 @@ static char *construct_auditlog_filename(apr_pool_t *mp, const char *uniqueid) {
      * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
      * It also changes the return statement.
      */
-    char *username;
+    char *userinfo;
+    apr_status_t rc;
     apr_uid_t uid;
     apr_gid_t gid;
     apr_uid_current(&uid, &gid, mp);
-    apr_uid_name_get(&username, uid, mp);
+    rc = apr_uid_name_get(&userinfo, uid, mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(mp, "%u", uid);
+    }
 
     apr_time_exp_lt(&t, apr_time_now());
 
     apr_strftime(tstr, &len, 299, "/%Y%m%d/%Y%m%d-%H%M/%Y%m%d-%H%M%S", &t);
-    return apr_psprintf(mp, "/%s%s-%s", username, tstr, uniqueid);
+    return apr_psprintf(mp, "/%s%s-%s", userinfo, tstr, uniqueid);
 }
 
 /**

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -104,11 +104,14 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
     /**
      * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
      */
-    char *username;
+    char *userinfo;
     apr_uid_t uid;
     apr_gid_t gid;
     apr_uid_current(&uid, &gid, msr->mp);
-    apr_uid_name_get(&username, uid, msr->mp);
+    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(msr->mp, "%u", uid);
+    }
 
     if (msr->txcfg->data_dir == NULL) {
         msr_log(msr, 1, "collection_retrieve_ex: Unable to retrieve collection (name \"%s\", key \"%s\"). Use "
@@ -117,7 +120,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
         goto cleanup;
     }
 
-    dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", username, "-", col_name, NULL);
+    dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", userinfo, "-", col_name, NULL);
 
     if (msr->txcfg->debuglog_level >= 9) {
         msr_log(msr, 9, "collection_retrieve_ex: collection_retrieve_ex: Retrieving collection (name \"%s\", filename \"%s\")",log_escape(msr->mp, col_name),
@@ -385,11 +388,14 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
     /**
      * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
      */
-    char *username;
+    char *userinfo;
     apr_uid_t uid;
     apr_gid_t gid;
     apr_uid_current(&uid, &gid, msr->mp);
-    apr_uid_name_get(&username, uid, msr->mp);
+    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(msr->mp, "%u", uid);
+    }
 
     var_name = (msc_string *)apr_table_get(col, "__name");
     if (var_name == NULL) {
@@ -409,7 +415,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
     }
 
     // ENH: lowercase the var name in the filename
-    dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", username, "-", var_name->value, NULL);
+    dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", userinfo, "-", var_name->value, NULL);
 
     if (msr->txcfg->debuglog_level >= 9) {
         msr_log(msr, 9, "collection_store: Retrieving collection (name \"%s\", filename \"%s\")",log_escape(msr->mp, var_name->value),
@@ -675,11 +681,14 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
     /**
      * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
      */
-    char *username;
+    char *userinfo;
     apr_uid_t uid;
     apr_gid_t gid;
     apr_uid_current(&uid, &gid, msr->mp);
-    apr_uid_name_get(&username, uid, msr->mp);
+    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(msr->mp, "%u", uid);
+    }
 
     if (msr->txcfg->data_dir == NULL) {
         /* The user has been warned about this problem enough times already by now.
@@ -690,9 +699,9 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
     }
 
     if(strstr(col_name,"USER") || strstr(col_name,"SESSION") || strstr(col_name, "RESOURCE"))
-        dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", username, "-", msr->txcfg->webappid, "_", col_name, NULL);
+        dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", userinfo, "-", msr->txcfg->webappid, "_", col_name, NULL);
     else
-        dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", username, "-", col_name, NULL);
+        dbm_filename = apr_pstrcat(msr->mp, msr->txcfg->data_dir, "/", userinfo, "-", col_name, NULL);
 
     if (msr->txcfg->debuglog_level >= 9) {
         msr_log(msr, 9, "collections_remove_stale: Retrieving collection (name \"%s\", filename \"%s\")",log_escape(msr->mp, col_name),


### PR DESCRIPTION
When running httpd on OpenShift, by default the server instance will run with an assigned user ID not appearing in the UNIX password file.

There are several places in the code of mod_security where the user name is tried to retrieved by use of apr_uid_name_get(). As the function can not find a corresponding user name it returns with an error (and argument pointer being NULL). Due to missing error handling constant segmentation faults are faced on OpenShift.

As a fallback on OpenShift (and probably other container platforms), the user id should be used instead of the user name.