### PR TITLE
Make sure m_rulesMessages is filled after successfull match

### DIFF
--- a/src/rule.cc
+++ b/src/rule.cc
@@ -812,7 +812,7 @@ end_exec:
             trans->serverLog(ruleMessage);
 	}
     }
-    else if (m_containsStaticBlockAction && !m_containsMultiMatchAction) {
+    else if (!m_containsMultiMatchAction) {
         /* warn */
         trans->m_rulesMessages.push_back(*ruleMessage);
         /* error */


### PR DESCRIPTION
This fixes issue #2000.

The problem seems to be that the conditions to push ruleMessage below is not met when only [deny](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#deny) action is used:

https://github.com/SpiderLabs/ModSecurity/blob/6d5198b1a60992416c9c8f1d77754e8e5edba996/src/rule.cc#L815-L822

Then when the for loop to append m_rulesMessages to the audit_log string stream is called, the content of this std::list seems to be empty:

https://github.com/SpiderLabs/ModSecurity/blob/6d5198b1a60992416c9c8f1d77754e8e5edba996/src/transaction.cc#L1486-L1489