### PR TITLE
Fix variables output in debug logs

### DIFF
--- a/src/variables/variable.cc
+++ b/src/variables/variable.cc
@@ -77,7 +77,7 @@ void Variable::addsKeyExclusion(Variable *v) {
 
 
 std::string operator+(std::string a, Variable *v) {
-    return *v->m_fullName.get();
+    return a + *v->m_fullName.get();
 }
 
 


### PR DESCRIPTION
Just a little fix for variable lists in debug logs. Without this, printing a `Variables` object in the debug log actually only printed one variable of the list, not the whole pipe-separated list.