### PR TITLE
Store values extracted from json to ARGS_POST

### DIFF
--- a/src/request_body_processor/json.cc
+++ b/src/request_body_processor/json.cc
@@ -142,7 +142,7 @@ int JSON::addArgument(const std::string& value) {
     }
 
 
-    m_transaction->addArgument("JSON", path + data, value, 0);
+    m_transaction->addArgument("POST", path + data, value, 0);
 
     return 1;
 }


### PR DESCRIPTION
Variables extracted from the body of requests in multipart or urlencoded contents are stored in both the ARGS/ARGS_NAMES and ARGS_POST/ARGS_POST_NAMES, so we can choose to match or exclude them with ARGS_GET/ARGS_POST.

However, when the body of the request is JSON, its content can be optionally extracted to variables only in the ARGS and ARGS_NAMES collections. The ARGS_POST/ARGS_POST_NAMES collections stay empty.

My change stores them into both like multipart/urlencoded bodies, for consistency and simpler rules.

The only side effect is a change in the debug log line where the source is used, JSON is replaced with POST.