### PR TITLE
Set match_limit and match_limit_recursion values to regex variables

### DIFF
--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -47,6 +47,10 @@ Regex::Regex(const std::string& pattern_)
         &errptr, &erroffset, NULL);
 
     m_pce = pcre_study(m_pc, pcre_study_opt, &errptr);
+    m_pce->match_limit = MODSEC_PCRE_MATCH_LIMIT;
+    m_pce->match_limit_recursion = MODSEC_PCRE_MATCH_LIMIT_RECURSION;
+    m_pce->flags |= PCRE_EXTRA_MATCH_LIMIT;
+    m_pce->flags |= PCRE_EXTRA_MATCH_LIMIT_RECURSION;
 }
 
 

--- a/src/utils/regex.h
+++ b/src/utils/regex.h
@@ -28,6 +28,8 @@ namespace modsecurity {
 namespace Utils {
 
 #define OVECCOUNT 900
+#define MODSEC_PCRE_MATCH_LIMIT 1500
+#define MODSEC_PCRE_MATCH_LIMIT_RECURSION 1500
 
 class SMatch {
  public:


### PR DESCRIPTION
Today there were some regex related issues under [owasp-modsecurity-crs](https://github.com/SpiderLabs/owasp-modsecurity-crs/issues), especially:

https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1354
https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1356
https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1357
https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1358
https://github.com/SpiderLabs/owasp-modsecurity-crs/issues/1359

These issues affected libmodsecurity3, because some rule can triggers the [catastrophic backtrace](https://www.regular-expressions.info/catastrophic.html).

The "bug" exists because there aren't set up the `match_limit` and `match_limit_recursion` members and flags on the `pcre_study` object. The result in practice will an overloaded HTTP daemon, which uses libmodsecurity3, eg. Nginx.

As a quick fix, I've set up the default values as 1500 for both values.

ModSecurity2 can avoid the overloaded state with [SecPcreMatchLimit](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#secpcrematchlimit) and [SecPcreMatchLimitRecursion](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#SecPcreMatchLimitRecursion)