### PR TITLE
fix: care non-null terminated chunk data

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -992,6 +992,7 @@ void sec_audit_logger_json(modsec_rec *msr) {
 
                         /* Write the sanitized chunk to the log
                          * and advance to the next chunk. */
+                        chunk->data[chunk->length] = 0;
                         yajl_string(g, chunk->data);
                         chunk_offset += chunk->length;
                     }


### PR DESCRIPTION
I encountered a broken JSON audit log when used sanitizeArg on the body.
```json
{"transaction":{"time":"17/May/2019:03:58:01 +0000","transaction_id":"AcVcAcAcAcAcAzAcAcWQ4cAc","remote_address":"172.17.0.1","remote_port":37868,"local_address":"127.0.0.1","local_port":80},"request":{"request_line":"POST / HTTP/1.1","headers":{"Host":"test.modsec.com","User-Agent":"curl/7.54.0","Accept":"*/*","Content-Type":"application/json","Content-Length":"41"},"body":["{\"password\":\"****\",\"user_id\":\"../../../\"}f�#IV"]},"response":{"protocol":"HTTP/1.1","status":405,"headers":{"Content-Type":"text/html","Content-Length":"173","Connection":"keep-alive"},"body":"<html>\r\n<head><title>405 Not Allowed</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>405 Not Allowed</h1></center>\r\n<hr><center>nginx/1.15.0</center>\r\n</body>\r\n</html>\r\n"},"audit_data":{"messages":["Warning. Unconditional match in SecAction. [file \"/etc/nginx/modsecurity.d/rules/modsecurity.conf\"] [line \"265\"] [id \"101\"]"],"handler":"IIS","stopwatch":{"p1":45,"p2":78,"p3":1,"p4":0,"p5":2,"sr":0,"sw":0,"l":0,"gc":0},"response_body_dechunked":true,"producer":"ModSecurity for nginx (STABLE)/2.9.3 (http://www.modsecurity.org/)","server":"ModSecurity Standalone","sanitized":{"args":["password"]},"engine_mode":"ENABLED"}}
```

I fixed this problem.