### PR TITLE
ModSecurity V2 - added missing Geo Countries

### DIFF
--- a/apache2/msc_geo.c
+++ b/apache2/msc_geo.c
@@ -43,7 +43,8 @@ static const char geo_country_code[GEO_COUNTRY_LAST + 1][4] = {
     "TJ","TK","TM","TN","TO","TL","TR","TT","TV","TW",
     "TZ","UA","UG","UM","US","UY","UZ","VA","VC","VE",
     "VG","VI","VN","VU","WF","WS","YE","YT","RS","ZA",
-    "ZM","ME","ZW","A1","A2","O1","AX","GG","IM","JE"
+    "ZM","ME","ZW","A1","A2","O1","AX","GG","IM","JE",
+    "BL","BQ","CW","MF","SS","SX"
 };
 
 static const char geo_country_code3[GEO_COUNTRY_LAST + 1][4] = {
@@ -72,7 +73,8 @@ static const char geo_country_code3[GEO_COUNTRY_LAST + 1][4] = {
     "TJK","TKL","TKM","TUN","TON","TLS","TUR","TTO","TUV","TWN",
     "TZA","UKR","UGA","UM","USA","URY","UZB","VAT","VCT","VEN",
     "VGB","VIR","VNM","VUT","WLF","WSM","YEM","YT","SRB","ZAF",
-    "ZMB","MNE","ZWE","A1","A2","O1","ALA","GGY","IMN","JEY"
+    "ZMB","MNE","ZWE","A1","A2","O1","ALA","GGY","IMN","JEY",
+    "BLM","BES","CUW","MAF","SSD","SXM"
 };
 
 static const char *const geo_country_name[GEO_COUNTRY_LAST + 1] = {
@@ -101,7 +103,8 @@ static const char *const geo_country_name[GEO_COUNTRY_LAST + 1] = {
     "Tajikistan","Tokelau","Turkmenistan","Tunisia","Tonga","Timor-Leste","Turkey","Trinidad and Tobago","Tuvalu","Taiwan",
     "Tanzania, United Republic of","Ukraine","Uganda","United States Minor Outlying Islands","United States","Uruguay","Uzbekistan","Holy See (Vatican City State)","Saint Vincent and the Grenadines","Venezuela",
     "Virgin Islands, British","Virgin Islands, U.S.","Vietnam","Vanuatu","Wallis and Futuna","Samoa","Yemen","Mayotte","Serbia","South Africa",
-    "Zambia","Montenegro","Zimbabwe","Anonymous Proxy","Satellite Provider","Other","Aland Islands","Guernsey","Isle of Man","Jersey"
+    "Zambia","Montenegro","Zimbabwe","Anonymous Proxy","Satellite Provider","Other","Aland Islands","Guernsey","Isle of Man","Jersey",
+    "Saint Barthélemy","Bonaire, Sint Eustatius and Saba","Curaçao","Saint Martin (French part)","South Sudan","Sint Maarten (Dutch part)"
 };
 
 static const char geo_country_continent[GEO_COUNTRY_LAST + 1][4] = {
@@ -130,7 +133,8 @@ static const char geo_country_continent[GEO_COUNTRY_LAST + 1][4] = {
     "AS","OC","AS","AF","OC","AS","AS","SA","OC","AS",
     "AF","EU","AF","OC","NA","SA","AS","EU","SA","SA",
     "SA","SA","AS","OC","OC","OC","AS","AF","EU","AF",
-    "AF","EU","AF","--","--","--","EU","EU","EU","EU"
+    "AF","EU","AF","--","--","--","EU","EU","EU","EU",
+    "--","--","--","--","AF","--"
 };
 
 typedef enum {

--- a/apache2/msc_geo.h
+++ b/apache2/msc_geo.h
@@ -25,7 +25,7 @@
 #define GEO_COUNTRY_DATABASE      1
 #define GEO_CITY_DATABASE_0       6
 #define GEO_CITY_DATABASE_1       2
-#define GEO_COUNTRY_LAST          250
+#define GEO_COUNTRY_LAST          256
 #define GEO_SEGMENT_RECORD_LENGTH 3
 #define GEO_STATE_BEGIN_REV0      16700000
 #define GEO_STATE_BEGIN_REV1      16000000


### PR DESCRIPTION
Antillas:
Following the reorganization of the political situation on 10 October 2010, Curaçao and Sint Maarten are autonomous countries within the Kingdom of the Netherlands, comparable to Aruba. The islands of Bonaire, Saba and St. Eustatius are special municipalities in the Netherlands, but do not belong to any province. Since then, one generally speaks of the Dutch Caribbean Islands, if one means the six islands together.

````
BL - BLM - -- Saint Barthélemy
BQ - BES - -- Bonaire, Sint Eustatius and Saba
CW - CUW - -- Curaçao
MF - MAF - -- Saint Martin (French part)
SX - SXM - -- Sint Maarten (Dutch part)
````


South Sudan:
He gained independence from Sudan on 9 July 2011
````
SS - SSD - AF South Sudan
````




