### PR TITLE
Avoid using NULL string (match) in Pm::evaluate

### DIFF
--- a/src/operators/pm.cc
+++ b/src/operators/pm.cc
@@ -103,7 +103,7 @@ bool Pm::evaluate(Transaction *transaction, Rule *rule,
         transaction->m_matched.push_back(match_);
     }
 
-    if (rule && rule->m_containsCaptureAction && transaction && rc) {
+    if (rule && rule->m_containsCaptureAction && transaction && rc >= 0) {
         transaction->m_collections.m_tx_collection->storeOrUpdateFirst("0",
             std::string(match));
         ms_dbg_a(transaction, 7, "Added pm match TX.0: " + \


### PR DESCRIPTION
Closes #2178.