### PR TITLE
This commit closes the issue #2033.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 ------------------------------------
 
+ * Adds a sanity check before use ctl:ruleRemoveTargetById and ctl:ruleRemoveTargetByMsg.
+   [Issue #2033 - @studersi, @zimmerle]
  * Fix the order of error_msg validation
    [Issue #2128 - @marcstern, @zimmerle]
  * Added missing Geo Countries

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1235,6 +1235,11 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         if (msr->txcfg->debuglog_level >= 4) {
             msr_log(msr, 4, "Ctl: ruleRemoveTargetById id=%s targets=%s", p1, p2);
         }
+        if (p2 == NULL) {
+            msr_log(msr, 1, "ModSecurity: Missing target for id \"%s\"", p1);
+            return -1;
+        }
+
     re = apr_pcalloc(msr->mp, sizeof(rule_exception));
     re->type = RULE_EXCEPTION_REMOVE_ID;
     re->param = (const char *)apr_pstrdup(msr->mp, p1);
@@ -1253,10 +1258,10 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         if (msr->txcfg->debuglog_level >= 4) {
             msr_log(msr, 4, "Ctl: ruleRemoveTargetByTag tag=%s targets=%s", p1, p2);
         }
-	if (p2 == NULL) {
+        if (p2 == NULL) {
             msr_log(msr, 1, "ModSecurity: Missing target for tag \"%s\"", p1);
-	    return -1;
-	}
+            return -1;
+        }
 
     re = apr_pcalloc(msr->mp, sizeof(rule_exception));
     re->type = RULE_EXCEPTION_REMOVE_TAG;
@@ -1280,6 +1285,10 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
 
         if (msr->txcfg->debuglog_level >= 4) {
             msr_log(msr, 4, "Ctl: ruleRemoveTargetByMsg msg=%s targets=%s", p1, p2);
+        }
+        if (p2 == NULL) {
+            msr_log(msr, 1, "ModSecurity: Missing target for msg \"%s\"", p1);
+            return -1;
         }
 
     re = apr_pcalloc(msr->mp, sizeof(rule_exception));


### PR DESCRIPTION
Added a fix for issue #2033 based on #1353 and https://github.com/SpiderLabs/ModSecurity/commit/9ac9ff8223c0a9d7723a312204659ff72c9cc685.

The fix is basically the same as is used for #1353, adding a sanity check after the arguments are parsed. I added the check for `ctl:ruleRemoveTargetById` as well as `ctl:ruleRemoveTargetByMsg`.

I'm currently unable to check this in the environment where it first occurred and I currently cannot reproduce the error as it was reported to me.

Note: This change also fixes inconsistent whites pace on the original fix.