### PR TITLE
Fix test issue-1974

### DIFF
--- a/src/actions/transformations/transformation.cc
+++ b/src/actions/transformations/transformation.cc
@@ -114,7 +114,7 @@ Transformation* Transformation::instantiate(std::string a) {
     IF_MATCH(urlDecodeUni) { return new UrlDecodeUni(a); }
     IF_MATCH(urlDecode) { return new UrlDecode(a); }
     IF_MATCH(urlEncode) { return new UrlEncode(a); }
-    IF_MATCH(utf8ToUnicode) { return new Utf8ToUnicode(a); }
+    IF_MATCH(utf8toUnicode) { return new Utf8ToUnicode(a); }
 
     return new Transformation(a);
 }


### PR DESCRIPTION
A small typo that causes the related unit tests to not function correctly.  Note that this change should accompany the related updates to the secrules-language-tests repo.