### PR TITLE
Fix nolog rules logging to part H

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.0.4 - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+ - Fix rules with nolog are logging to part H
+   [Issue #2196 - @martinhsv]
  - Fix argument key-value pair parsing cases
    [Issue #1904 - @martinhsv]
  - Fix: audit log part for response body for JSON format to be E

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -802,8 +802,7 @@ end_exec:
 
     /* last rule in the chain. */
     bool isItToBeLogged = ruleMessage->m_saveMessage;
-    if (isItToBeLogged && !m_containsMultiMatchAction
-        && !ruleMessage->m_message.empty()) {
+    if (isItToBeLogged && !m_containsMultiMatchAction) {
         /* warn */
         trans->m_rulesMessages.push_back(*ruleMessage);
 
@@ -811,14 +810,6 @@ end_exec:
         if (!ruleMessage->m_isDisruptive) {
             trans->serverLog(ruleMessage);
 	}
-    }
-    else if (!m_containsMultiMatchAction) {
-        /* warn */
-        trans->m_rulesMessages.push_back(*ruleMessage);
-        /* error */
-        if (!ruleMessage->m_isDisruptive) {
-            trans->serverLog(ruleMessage);
-        }
     }
 
     return true;


### PR DESCRIPTION
This change is in a response to issue-2196.  Rules with 'nolog' were incorrectly logging to part H, including for innocent requests.

Note that this change does not address cases where a 1st rule in a chain has nolog but the subsequent rule(s) in the chain do not.  We may follow up with another code change to address that minority situation.