### PR TITLE
Fixed inspectFile operator does not pass FILES_TMPNAMES variable to lua engine

### DIFF
--- a/src/engine/lua.cc
+++ b/src/engine/lua.cc
@@ -121,7 +121,8 @@ const char *Lua::blob_reader(lua_State *L, void *ud, size_t *size) {
 }
 #endif
 
-int Lua::run(Transaction *t) {
+
+int Lua::run(Transaction *t,const std::string &str) {
 #ifdef WITH_LUA
     std::string luaRet;
     const char *a = NULL;
@@ -184,7 +185,14 @@ int Lua::run(Transaction *t) {
     lua_setglobal(L, "modsec");
 
     lua_getglobal(L, "main");
-    if (lua_pcall(L, 0, 1, 0)) {
+
+        ms_dbg_a(t, 1, str);
+        /* Put the parameter on the stack. */
+    if (!str.empty() ) {
+        lua_pushlstring(L, str.c_str(), str.length());
+    }
+
+    if (lua_pcall(L, ((!str.empty()) ? 1 : 0), 1, 0)) {
         std::string e;
         const char *luaerr = lua_tostring(L, -1);
         e.assign("Failed to execute lua script: " + m_scriptName + " (main)");

--- a/src/engine/lua.h
+++ b/src/engine/lua.h
@@ -69,7 +69,7 @@ class Lua {
     Lua() { }
 
     bool load(std::string script, std::string *err);
-    int run(Transaction *t);
+    int run(Transaction *t,const std::string &str="");
     static bool isCompatible(std::string script, Lua *l, std::string *error);
 
 #ifdef WITH_LUA

--- a/src/operators/inspect_file.cc
+++ b/src/operators/inspect_file.cc
@@ -51,7 +51,7 @@ bool InspectFile::init(const std::string &param2, std::string *error) {
 
 bool InspectFile::evaluate(Transaction *transaction, const std::string &str) {
     if (m_isScript) {
-        return m_lua.run(transaction);
+        return m_lua.run(transaction,str);
     } else {
         FILE *in;
         char buff[512];


### PR DESCRIPTION
Fixes the issues #2204 , #1699, #1700

Tested with inspectFile and exec operators with below rules
```
SecRule FILES_TMPNAMES "@inspectFile /usr/local/nginx/scanfile.lua" "id:1001,phase:2,t:none,log,auditlog,deny"
  
SecRule REQUEST_METHOD "@streq POST" "id:1002,exec:/usr/local/nginx/luatest.lua"
```

