### PR TITLE
Accepts JSON without key [Issue #1576]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 ------------------------------------
 
+ * Accepts JSON without key
+   [Issue #1576 - @marcstern]
  * Adds a sanity check before use ctl:ruleRemoveTargetById and ctl:ruleRemoveTargetByMsg.
    [Issue #2033 - @studersi]
  * Fix the order of error_msg validation

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -27,8 +27,7 @@ int json_add_argument(modsec_rec *msr, const char *value, unsigned length)
      * to reference this argument; for now we simply ignore these
      */
     if (!msr->json->current_key) {
-        msr_log(msr, 3, "Cannot add scalar value without an associated key");
-        return 1;
+        return "";
     }
 
     arg = (msc_arg *) apr_pcalloc(msr->mp, sizeof(msc_arg));


### PR DESCRIPTION
This accepts a valid JSON request with only a number or a string, nothing else.
Example:
--29000000-B--
POST /test/json/test.html HTTP/1.1
content-type: application/json
Host: test
Content-Length: 2
User-Agent: Mozilla 4.0
Accept: text/html, image/gif, image/jpeg, *; q=.2, /; q=.2

--29000000-C--
25
--29000000-F--