### PR TITLE
Configure script issues when packaging for Buildroot

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,7 @@ case $host in
     ;;
        *)
     echo "Unknown CANONICAL_HOST $host"
-    exit
+    exit 1
     ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ case $host in
     AC_DEFINE([MACOSX], [1], [Define if the operating system is Macintosh OSX])
     PLATFORM="MacOSX"
     ;;
-  *-*-linux*)
+  *-*-linux* | *-*uclinux*)
     echo "Checking platform... Identified as Linux"
     AC_DEFINE([LINUX], [1], [Define if the operating system is LINUX])
     PLATFORM="Linux"


### PR DESCRIPTION
I encountered these issues while packaging libmodsecurity for Buildroot.

Buildroot can be compiled for uClinux targetting ARM Cortex-M4 processors. The build for this platform fails due to the configure script not recognizing the platform `arm-buildroot-uclinux-uclibcgnueabi`. 
Another minor issue is that the configure script returns 0 even though no Makefile was generated. Returning a non-zero value causes the build to fail in the configure step instead of the make step.