### PR TITLE
modsecurity.pc.in: add Libs.private

### DIFF
--- a/modsecurity.pc.in
+++ b/modsecurity.pc.in
@@ -8,3 +8,4 @@ Description: ModSecurity API
 Version: @MSC_VERSION_WITH_PATCHLEVEL@
 Cflags: -I@includedir@
 Libs: -L@libdir@ -lmodsecurity
+Libs.private: @CURL_LDADD@ @GEOIP_LDADD@ @MAXMIND_LDADD@ @GLOBAL_LDADD@ @LIBXML2_LDADD@ @LMDB_LDADD@ @LUA_LDADD@ @PCRE_LDADD@ @SSDEEP_LDADD@ @YAJL_LDADD@


### PR DESCRIPTION
Add Libs.private to save static dependencies so applications linking
statically with modsecurity will be able to retrieve them through
pkg-config

Fix #1918

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>