### PR TITLE
Fix #610: fix memory leaks caused by unfreed compiled regex data

### DIFF
--- a/apache2/msc_pcre.c
+++ b/apache2/msc_pcre.c
@@ -21,11 +21,7 @@
 static apr_status_t msc_pcre_cleanup(msc_regex_t *regex) {
     if (regex != NULL) {
         if (regex->pe != NULL) {
-#if defined(VERSION_NGINX)
-            pcre_free(regex->pe);
-#else
-            free(regex->pe);
-#endif
+            pcre_free_study(regex->pe);
             regex->pe = NULL;
         }
         if (regex->re != NULL) {
@@ -67,19 +63,15 @@ void *msc_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
 
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
-                pe = pcre_study(regex->re, PCRE_STUDY_JIT_COMPILE, &errptr);
+                pe = pcre_study(regex->re, PCRE_STUDY_EXTRA_NEEDED|PCRE_STUDY_JIT_COMPILE, &errptr);
         #else
-                pe = pcre_study(regex->re, 0, &errptr);
+                pe = pcre_study(regex->re, PCRE_STUDY_EXTRA_NEEDED, &errptr);
         #endif
     #endif
 
     /* Setup the pcre_extra record if pcre_study did not already do it */
     if (pe == NULL) {
-#if defined(VERSION_NGINX)
         pe = pcre_malloc(sizeof(pcre_extra));
-#else
-        pe = malloc(sizeof(pcre_extra));
-#endif
         if (pe == NULL) {
             return NULL;
         }

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1018,7 +1018,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 msr_log(msr, 6, "Escaping pattern [%s]",pattern);
             }
 
-            regex = msc_pregcomp_ex(rule->ruleset->mp, pattern, PCRE_DOTALL | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
+            regex = msc_pregcomp_ex(msr->mp, pattern, PCRE_DOTALL | PCRE_DOLLAR_ENDONLY, &errptr, &erroffset, msc_pcre_match_limit, msc_pcre_match_limit_recursion);
             if (regex == NULL) {
                 *error_msg = apr_psprintf(rule->ruleset->mp, "Error compiling pattern (offset %d): %s",
                         erroffset, errptr);


### PR DESCRIPTION
This pull request aims to fix 2 memory leaks in ModSecurity v2:
1. PCRE JIT data produced by `pcre_study` not freed by  `msc_pcre_cleanup` because `free()`/`pcre_free`  is used to deallocate `pcre_extra` structure. The proposed fix is to use  `pcre_free_study` instead of `free`/`pcre_free` in `msc_pcre_cleanup`. This change was already proposed in #610.
2. Regex data not freed (`msc_pcre_cleanup` not called) for `@rx` rules which regexes contain variable substitutions.  OWASP CRS contains such rules: 920420 and 920480. The proposed  fix is to allocate memory for regexes in `msr->mp` pool instead of `rule->ruleset->mp` in `msre_op_rx_execute`. `msre_op_rx_execute` is called for each request (unlike `msre_op_rx_param_init`) and creates volatile regexes used for that one request only (which is done when regex contains variable substitution and therefore can't be compiled once and reused for each request), that regex does not seem to be stored anywhere in ruleset data.

These two fixes are related: without the second one, for rules with regex depending on a variable, function  `msc_pcre_cleanup` is never called, so the first fix does not help. The other way around, when PCRE JIT is used, the second fix is of little use for such rules, because only the lesser part of memory is freed by `msc_pcre_cleanup`. As noted in #610, first leak also occurs when apache with `mod_security2` is reloaded (and so all the rules are freed and re-allocated again, but PCRE study data from the first config load remains unfreed for all regexes).

It should be noted that first leak is rather hard to trace as it can't be detected by most automated tools including Valgrind because PCRE uses it's own allocator for allocating memory for JIT, this allocator is not based on `malloc` and allocates memory by directly calling `mmap`, and it does not have annotations for Valgrind (`VALGRIND_MALLOCLIKE_BLOCK`/`VALGRIND_MEMPOOL_ALLOC`).

#### Reproducing the leaks

[This test program](https://gist.github.com/asterite3/4458835ec64b50ee980b16ac6b75e27d)  (using ModSecurity 2 built as a standalone module, code is mostly based on `standalone/main.cpp`) with [this minimal config](https://gist.github.com/asterite3/5dc749430f13fe6aa9a29d226cf74448) can be used to demonstrate the leaks. ([This config with more rules can be used instead, with it memory leaks more](https://gist.github.com/asterite3/73185d0f3fa7686a871a5da54e304f0c)). These test configs include rules 920420 and 920480 from OWASP CRS. To test it with PCRE JIT, ModSecurity build was configured with `./configure --with-curl  --with-yajl --enable-standalone-module --disable-mlogc --enable-pcre-jit --without-lua`. When run without the proposed fixes, it consumes a lot of RAM. Note that applying only one of the fixes does not solve the problem - using only the first fix does not change the situation at all (as `msc_pcre_cleanup` is not called), using only the second one reduces memory leak only slightly (as most of the memory allocated belongs to PCRE JIT data).

If PCRE  JIT is disabled (`--enable-pcre-jit` configure flag is omitted), memory leaks slower, but leak still occurs. In my tests, after 200000 requests test program reached RSS 145M when ModSecurity was compiled without PCRE JIT (with PCRE JIT RSS reached nearly 869M).

The other way to reproduce the leak is to use the same config with ModSecurity 2 running as Apache module and continuously sending requests to it - without the fixes memory usage of Apache workers can be seen to grow constantly, with the fixes memory usage of workers in my tests stayed nead 8 megabytes.

#### Fixes

The first leak is fixed by calling `pcre_free_study` on `pcre_extra` structure pointer instead of `free`/`pcre_free` in `msc_pcre_cleanup`. Function `msc_pregcomp_ex` that creates `msc_regex_t` can allocate `pcre_extra`  "manually" with `malloc`/`pcre_malloc` instead of with `pcre_study`. That's why the logic is added that check that `pcre_extra` indeed came from `pcre_study` by checking if `PCRE_EXTRA_EXECUTABLE_JIT` is set in `flags` of `pcre_study` (and `pcre_free_study` is only called in that case). `msc_pregcomp_ex` does not set that flag itself, and in fact `pcre_free_study` works the same way: it checks that flag, if it is not set, it calls `pcre_free` on `pcre_extra` pointer (`pcre_free` defaults for `free`, but can be set to other function by library user).
Please review this solution and tell if it's not the best one. Alternative options are, for example, to call `pcre_free_study` unconditionally or add an extra field to `msc_regex_t` that will indicate whether `pe` field was obtained by `pcre_study`.

The second leak is fixed by "attaching" allocated data to `msr->mp` instead of to `rule->ruleset->mp` . This seems safe because `msc_regex_t` created in `msre_op_rx_execute` seems to be stored nowhere and for subsequent requests a new `msc_regex_t` will be created with calls to `msc_pregcomp_ex`. Anyway, the review here would be appreciated too.

#### Similar leaks in other operators

It seems the same problem exists with `validateHash` https://github.com/SpiderLabs/ModSecurity/blob/12cefbd70f2aab802e1bff53c50786f3b8b89359/apache2/re_operators.c#L787 and similar case is with `gsbLookup` https://github.com/SpiderLabs/ModSecurity/blob/12cefbd70f2aab802e1bff53c50786f3b8b89359/apache2/re_operators.c#L1687 and below. 
I was not able to find the examples of usage of these operators in OWASP CRS or figure out how they work enough to make my own examples - to make working examples reproducing the leaks there.
Still, I can provide analogous fixes for them in this or separate pull request.

Fixes #610