### PR TITLE
Support reopening audit logs

### DIFF
--- a/headers/modsecurity/audit_log.h
+++ b/headers/modsecurity/audit_log.h
@@ -168,6 +168,7 @@ class AuditLog {
     bool setType(AuditLogType audit_type);
 
     bool init(std::string *error);
+    bool reopen(std::string *error);
     virtual bool close();
 
     bool saveIfRelevant(Transaction *transaction);

--- a/headers/modsecurity/rules_set.h
+++ b/headers/modsecurity/rules_set.h
@@ -104,6 +104,7 @@ int msc_rules_add_remote(RulesSet *rules, const char *key, const char *uri,
 int msc_rules_add_file(RulesSet *rules, const char *file, const char **error);
 int msc_rules_add(RulesSet *rules, const char *plain_rules, const char **error);
 int msc_rules_cleanup(RulesSet *rules);
+int msc_rules_reopen_audit_log(RulesSet *rules, const char **error);
 
 #ifdef __cplusplus
 }

--- a/src/audit_log/audit_log.cc
+++ b/src/audit_log/audit_log.cc
@@ -372,6 +372,13 @@ bool AuditLog::merge(AuditLog *from, std::string *error) {
     return init(error);
 }
 
+bool AuditLog::reopen(std::string *error) {
+    if (m_writer != NULL) {
+        return m_writer->reopen(error);
+    }
+    return true;
+}
+
 
 }  // namespace audit_log
 }  // namespace modsecurity

--- a/src/audit_log/writer/https.h
+++ b/src/audit_log/writer/https.h
@@ -42,6 +42,9 @@ class Https : public Writer {
     bool init(std::string *error) override;
     bool write(Transaction *transaction, int parts,
         std::string *error) override;
+    bool reopen(std::string *error) override {
+        return true;
+    }
 };
 
 }  // namespace writer

--- a/src/audit_log/writer/parallel.cc
+++ b/src/audit_log/writer/parallel.cc
@@ -191,6 +191,38 @@ bool Parallel::write(Transaction *transaction, int parts, std::string *error) {
     return true;
 }
 
+
+bool Parallel::reopen(std::string *error) {
+    bool        success1 = true;
+    bool        success2 = true;
+    std::string error1;
+    std::string error2;
+
+    if (!m_audit->m_path1.empty()) {
+        success1 = utils::SharedFiles::getInstance().reopen(m_audit->m_path1, &error1);
+    }
+    if (!m_audit->m_path2.empty()) {
+        success2 = utils::SharedFiles::getInstance().reopen(m_audit->m_path2, &error2);
+    } 
+
+    std::stringstream errorStream;
+    if (!success1 || !success2) {
+        errorStream << "There was an error reopening parallel audit logs.";
+
+        if (!success1 && !error1.empty()) {
+            errorStream << " " << error1;
+        }
+        if (!success2 && !error2.empty()) {
+            errorStream << " " << error2;
+        }
+
+        *error = errorStream.str();
+    }
+
+    return success1 && success2;
+}
+
+
 }  // namespace writer
 }  // namespace audit_log
 }  // namespace modsecurity

--- a/src/audit_log/writer/parallel.h
+++ b/src/audit_log/writer/parallel.h
@@ -40,6 +40,7 @@ class Parallel : public Writer {
     bool init(std::string *error) override;
     bool write(Transaction *transaction, int parts,
         std::string *error) override;
+    bool reopen(std::string *error) override;
 
 
     /**

--- a/src/audit_log/writer/serial.cc
+++ b/src/audit_log/writer/serial.cc
@@ -49,6 +49,21 @@ bool Serial::write(Transaction *transaction, int parts, std::string *error) {
         error);
 }
 
+
+bool Serial::reopen(std::string *error) {
+    bool success;
+    
+    std::string errorDetail;
+    success = utils::SharedFiles::getInstance().reopen(m_audit->m_path1, &errorDetail);
+    if (!success) {
+        *error = "There was an error reopening the serial audit log. ";
+        error->append(errorDetail);
+    }
+
+    return success;
+}
+
+
 }  // namespace writer
 }  // namespace audit_log
 }  // namespace modsecurity

--- a/src/audit_log/writer/serial.h
+++ b/src/audit_log/writer/serial.h
@@ -47,6 +47,7 @@ class Serial : public Writer {
     bool init(std::string *error) override;
     bool write(Transaction *transaction, int parts,
         std::string *error) override;
+    bool reopen(std::string *error) override;
 };
 
 }  // namespace writer

--- a/src/audit_log/writer/writer.h
+++ b/src/audit_log/writer/writer.h
@@ -50,6 +50,7 @@ class Writer {
     virtual bool init(std::string *error) = 0;
     virtual bool write(Transaction *transaction, int parts,
         std::string *error) = 0;
+    virtual bool reopen(std::string *error) = 0;
 
     static void generateBoundary(std::string *boundary);
 

--- a/src/rules_set.cc
+++ b/src/rules_set.cc
@@ -318,5 +318,26 @@ extern "C" int msc_rules_cleanup(RulesSet *rules) {
 }
 
 
+extern "C" int msc_rules_reopen_audit_log(RulesSet *rules, const char **error) {
+    bool succeeded = true;
+    std::string errorStr;
+
+    if (rules->m_auditLog != NULL) {
+        succeeded = rules->m_auditLog->reopen(&errorStr);
+    }
+
+    if (!succeeded) {
+        if (!errorStr.empty()) {
+            *error = strdup(errorStr.c_str());
+        } else {
+            // Guarantee an error message is always assigned in the event of a failure
+            *error = strdup("Unknown error reopening audit log");
+        }
+    }
+
+    return succeeded ? 0 : -1;
+}
+
+
 }  // namespace modsecurity
 

--- a/src/utils/shared_files.h
+++ b/src/utils/shared_files.h
@@ -57,6 +57,7 @@ typedef struct msc_file_handler {
 class SharedFiles {
  public:
     bool open(const std::string& fileName, std::string *error);
+    bool reopen(const std::string& filename, std::string *error);
     void close(const std::string& fileName);
     bool write(const std::string& fileName, const std::string &msg,
         std::string *error);

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -33,7 +33,8 @@ invalidScanfArgType_int:src/rules_set_properties.cc:102
 // ModSecurity v3 code...
 // 
 unmatchedSuppression:src/utils/geo_lookup.cc:82
-useInitializationList:src/utils/shared_files.h:87
+functionConst:src/utils/shared_files.h:60
+useInitializationList:src/utils/shared_files.h:88
 unmatchedSuppression:src/utils/msc_tree.cc
 functionStatic:headers/modsecurity/transaction.h:373
 duplicateBranch:src/audit_log/audit_log.cc:224


### PR DESCRIPTION
This PR adds support for reopening log files by:

* Exposing an `msc_rules_reopen_audit_log(rules, error)` function to trigger audit log reopen for a given rules set
* Adding a `reopen(error)` method to `AuditLog`
* Adding a `reopen(error)` method to the audit log `Writer` interface
* Adding a `reopen(filename, error)` method to `SharedFiles`

⚠️ Currently, I do not believe `SharedFiles::reopen()` to be thread-safe, and thread-safety must be ensured by the caller. Even if the SharedFiles general lock could be used, we may not want to lock for all SharedFile writes. Please let me know if you'd like to resolve the issue as part of this PR or a later PR.

This is based on work to support ModSecurity audit log rotation within [Automattic](https://automattic.com/). It is used in a ModSecurity-nginx patch, and the PR for that is [here](https://github.com/SpiderLabs/ModSecurity-nginx/pull/198).

resolves #1968