### PR TITLE
V2/json empty

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 18 Jul 2017 - 2.9.2
 -------------------
 
+ * Include unanmed JSON values in unnamed ARGS
+   [Issue #1576 - Marc Stern]
  * IIS build refactoring and dependencies update
    [Issue #1487 - @victorhora]
  * Best practice: Initialize msre_var pointers

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -25,8 +25,7 @@ int json_add_argument(modsec_rec *msr, const char *value, unsigned length)
      * to reference this argument; for now we simply ignore these
      */
     if (!msr->json->current_key) {
-        msr_log(msr, 3, "Cannot add scalar value without an associated key");
-        return 1;
+        msr->json->current_key = "";
     }
 
     arg = (msc_arg *) apr_pcalloc(msr->mp, sizeof(msc_arg));

--- a/tests/regression/misc/00-json-parser.t
+++ b/tests/regression/misc/00-json-parser.t
@@ -1,0 +1,60 @@
+### JSON parser tests
+
+# Normal
+{
+    type => "misc",
+    comment => "JSON parser (normal)",
+    conf => qq(
+        SecRuleEngine On
+        SecDebugLog $ENV{DEBUG_LOG}
+        SecDebugLogLevel 9
+        SecRequestBodyAccess On
+        SecRule REQBODY_PROCESSOR_ERROR "\@eq 1" "phase:2,deny,id:500657"
+    ),
+    match_response => {
+        status => qr/^200$/,
+    },
+    request => new HTTP::Request(
+        POST => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt",
+        [
+            "Content-Type" => q(application/json),
+        ],
+        normalize_raw_request_data(
+            q(
+                {
+                 "key1": "value",
+                 "key2": 10,
+                 "key3": [1, 2],
+                 "key4": {"key1": "value", "key2": 10, "key3": [1, 2]}
+                }
+            ),
+        ),
+    ),
+},
+
+# Empty key -> should still work
+{
+    type => "misc",
+    comment => "JSON parser (Empty key)",
+    conf => qq(
+        SecRuleEngine On
+        SecDebugLog $ENV{DEBUG_LOG}
+        SecDebugLogLevel 9
+        SecRequestBodyAccess On
+        SecRule REQBODY_PROCESSOR_ERROR "\@eq 1" "phase:2,deny,id:500660"
+    ),
+    match_response => {
+        status => qr/^200$/,
+    },
+    request => new HTTP::Request(
+        POST => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt",
+        [
+            "Content-Type" => q(application/json),
+        ],
+        normalize_raw_request_data(
+            q(
+                25
+            ),
+        ),
+    ),
+},


### PR DESCRIPTION
This accepts a valid JSON request with only a number or a string, nothing else.
Example:
--29000000-B--
POST /test/json/test.html HTTP/1.1
content-type: application/json
Host: test
Content-Length: 2
User-Agent: Mozilla 4.0
Accept: text/html, image/gif, image/jpeg, *; q=.2, /; q=.2

--29000000-C--
25
--29000000-F--

I added a test, so I hope it'll be accepted this time.
I had to create the complete (minimal) test for JSON parsing, so I hope it's correct.