### PR TITLE
Make all "rule id" variables of type RuleId

### DIFF
--- a/headers/modsecurity/rules_exceptions.h
+++ b/headers/modsecurity/rules_exceptions.h
@@ -28,6 +28,8 @@
 #include <memory>
 #endif
 
+#include "modsecurity/modsecurity.h"
+
 #ifndef HEADERS_MODSECURITY_RULES_EXCEPTIONS_H_
 #define HEADERS_MODSECURITY_RULES_EXCEPTIONS_H_
 
@@ -51,9 +53,9 @@ class RulesExceptions {
     ~RulesExceptions();
 
     bool load(const std::string &data, std::string *error);
-    bool addRange(int a, int b);
-    bool addNumber(int a);
-    bool contains(int a);
+    bool addRange(RuleId a, RuleId b);
+    bool addNumber(RuleId a);
+    bool contains(RuleId a);
     bool merge(RulesExceptions *from);
 
     bool loadRemoveRuleByMsg(const std::string &msg, std::string *error);
@@ -67,11 +69,11 @@ class RulesExceptions {
         std::unique_ptr<std::vector<std::unique_ptr<variables::Variable> > > v,
         std::string *error);
 
-    bool loadUpdateTargetById(double id,
+    bool loadUpdateTargetById(RuleId id,
         std::unique_ptr<std::vector<std::unique_ptr<variables::Variable> > > v,
         std::string *error);
 
-    bool loadUpdateActionById(double id,
+    bool loadUpdateActionById(RuleId id,
         std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > > actions,
         std::string *error);
 
@@ -79,18 +81,18 @@ class RulesExceptions {
         std::shared_ptr<variables::Variable>> m_variable_update_target_by_tag;
     std::unordered_multimap<std::shared_ptr<std::string>,
         std::shared_ptr<variables::Variable>> m_variable_update_target_by_msg;
-    std::unordered_multimap<double,
+    std::unordered_multimap<RuleId,
         std::shared_ptr<variables::Variable>> m_variable_update_target_by_id;
-    std::unordered_multimap<double,
+    std::unordered_multimap<RuleId,
         std::shared_ptr<actions::transformations::Transformation>> m_action_transformation_update_target_by_id;
-    std::unordered_multimap<double,
+    std::unordered_multimap<RuleId,
         std::shared_ptr<actions::Action>> m_action_pos_update_target_by_id;
     std::list<std::string> m_remove_rule_by_msg;
     std::list<std::string> m_remove_rule_by_tag;
 
  private:
-    std::list<std::pair<int, int> > m_ranges;
-    std::list<int> m_numbers;
+    std::list<std::pair<RuleId, RuleId> > m_ranges;
+    std::list<RuleId> m_numbers;
 };
 
 }  // namespace modsecurity

--- a/src/actions/rule_id.cc
+++ b/src/actions/rule_id.cc
@@ -26,18 +26,16 @@ namespace actions {
 bool RuleId::init(std::string *error) {
     std::string a = m_parserPayload;
 
-    try {
-        m_ruleId = std::stod(a);
-    } catch (...) {
+    std::istringstream iss(a);
+    iss >> m_ruleId;
+    if (iss.fail()) {
         m_ruleId = 0;
         error->assign("The input \"" + a + "\" does not " \
             "seems to be a valid rule id.");
         return false;
     }
 
-    std::ostringstream oss;
-    oss << std::setprecision(40) << m_ruleId;
-    if (a != oss.str() || m_ruleId < 0) {
+    if (a != std::to_string(m_ruleId) || m_ruleId < 0) {
         error->assign("The input \"" + a + "\" does not seems " \
             "to be a valid rule id.");
         return false;

--- a/src/actions/rule_id.h
+++ b/src/actions/rule_id.h
@@ -41,7 +41,7 @@ class RuleId : public ActionTypeRuleMetaData {
     }
 
  private:
-    double m_ruleId;
+    modsecurity::RuleId m_ruleId;
 };
 
 

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -2867,10 +2867,10 @@ namespace yy {
 #line 1472 "seclang-parser.yy"
       {
         std::string error;
-        double ruleId;
-        try {
-            ruleId = std::stod(yystack_[1].value.as < std::string > ());
-        } catch (...) {
+        std::istringstream iss(yystack_[1].value.as < std::string > ());
+        RuleId ruleId;
+        iss >> ruleId;
+        if (iss.fail()) {
             std::stringstream ss;
             ss << "SecRuleUpdateTargetById: failed to load:";
             ss << "The input \"" + yystack_[1].value.as < std::string > () + "\" does not ";
@@ -2897,10 +2897,10 @@ namespace yy {
 #line 1498 "seclang-parser.yy"
       {
         std::string error;
-        double ruleId;
-        try {
-            ruleId = std::stod(yystack_[1].value.as < std::string > ());
-        } catch (...) {
+        std::istringstream iss(yystack_[1].value.as < std::string > ());
+        RuleId ruleId;
+        iss >> ruleId;
+        if (iss.fail()) {
             std::stringstream ss;
             ss << "SecRuleUpdateActionById: failed to load:";
             ss << "The input \"" + yystack_[1].value.as < std::string > () + "\" does not ";

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1471,10 +1471,10 @@ expression:
     | CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID variables_pre_process
       {
         std::string error;
-        double ruleId;
-        try {
-            ruleId = std::stod($1);
-        } catch (...) {
+        std::istringstream iss($1);
+        RuleId ruleId;
+        iss >> ruleId;
+        if (iss.fail()) {
             std::stringstream ss;
             ss << "SecRuleUpdateTargetById: failed to load:";
             ss << "The input \"" + $1 + "\" does not ";
@@ -1497,10 +1497,10 @@ expression:
     | CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID actions
       {
         std::string error;
-        double ruleId;
-        try {
-            ruleId = std::stod($1);
-        } catch (...) {
+        std::istringstream iss($1);
+        RuleId ruleId;
+        iss >> ruleId;
+        if (iss.fail()) {
             std::stringstream ss;
             ss << "SecRuleUpdateActionById: failed to load:";
             ss << "The input \"" + $1 + "\" does not ";

--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -1,5 +1,5 @@
 
-#line 2 "seclang-scanner.cc"
+#line 3 "seclang-scanner.cc"
 
 #define  YY_INT_ALIGNED short int
 
@@ -5150,15 +5150,15 @@ static std::stack<int> YY_PREVIOUS_STATE;
 #define BEGIN_PREVIOUS() { BEGIN(YY_PREVIOUS_STATE.top()); YY_PREVIOUS_STATE.pop(); }
 
 // The location of the current token.
-#line 5153 "seclang-scanner.cc"
+#line 5154 "seclang-scanner.cc"
 #define YY_NO_INPUT 1
 
 #line 491 "seclang-scanner.ll"
   // Code run each time a pattern is matched.
   # define YY_USER_ACTION  driver.loc.back()->columns (yyleng);
 
-#line 5160 "seclang-scanner.cc"
 #line 5161 "seclang-scanner.cc"
+#line 5162 "seclang-scanner.cc"
 
 #define INITIAL 0
 #define EXPECTING_ACTION_PREDICATE_VARIABLE 1
@@ -5480,7 +5480,7 @@ YY_DECL
   // Code run each time yylex is called.
   driver.loc.back()->step();
 
-#line 5483 "seclang-scanner.cc"
+#line 5484 "seclang-scanner.cc"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -8567,7 +8567,7 @@ YY_RULE_SETUP
 #line 1330 "seclang-scanner.ll"
 ECHO;
 	YY_BREAK
-#line 8570 "seclang-scanner.cc"
+#line 8571 "seclang-scanner.cc"
 
 	case YY_END_OF_BUFFER:
 		{

--- a/src/rules_exceptions.cc
+++ b/src/rules_exceptions.cc
@@ -33,7 +33,7 @@ RulesExceptions::~RulesExceptions() {
 }
 
 
-bool RulesExceptions::loadUpdateActionById(double id,
+bool RulesExceptions::loadUpdateActionById(RuleId id,
     std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > > actions,
     std::string *error) {
 
@@ -48,14 +48,15 @@ bool RulesExceptions::loadUpdateActionById(double id,
         if (dynamic_cast<actions::transformations::Transformation *>(a.get())) {
             actions::transformations::Transformation *t = dynamic_cast<actions::transformations::Transformation *>(a.get());
             m_action_transformation_update_target_by_id.emplace(
-                std::pair<double,
+                std::pair<RuleId,
                 std::unique_ptr<actions::transformations::Transformation>>(id, std::unique_ptr<actions::transformations::Transformation>(t))
             );
             continue;
+
         }
 
         m_action_pos_update_target_by_id.emplace(
-            std::pair<double,
+            std::pair<RuleId,
             std::unique_ptr<actions::Action>>(id , std::move(a))
         );
     }
@@ -111,13 +112,13 @@ bool RulesExceptions::loadUpdateTargetByTag(const std::string &tag,
 }
 
 
-bool RulesExceptions::loadUpdateTargetById(double id,
+bool RulesExceptions::loadUpdateTargetById(RuleId id,
     std::unique_ptr<std::vector<std::unique_ptr<variables::Variable> > > var,
     std::string *error) {
 
     for (auto &i : *var) {
         m_variable_update_target_by_id.emplace(
-            std::pair<double,
+            std::pair<RuleId,
                 std::unique_ptr<variables::Variable>>(id,
                 std::move(i)));
     }
@@ -139,21 +140,24 @@ bool RulesExceptions::load(const std::string &a, std::string *error) {
         if (dash != std::string::npos) {
             std::string n1s = std::string(b, 0, dash);
             std::string n2s = std::string(b, dash + 1, b.size() - (dash + 1));
-            int n1n = 0;
-            int n2n = 0;
-            try {
-                n1n = std::stoi(n1s);
-                added = true;
-            } catch (...) {
+            std::istringstream n1ss(n1s), n2ss(n2s);
+            RuleId n1n = 0;
+            RuleId n2n = 0;
+
+            n1ss >> n1n;
+            if (n1ss.fail()) {
                 error->assign("Not a number: " + n1s);
                 return false;
-            }
-            try {
-                n2n = std::stoi(n2s);
+            } else {
                 added = true;
-            } catch (...) {
+            }
+
+            n2ss >> n2n;
+            if (n2ss.fail()) {
                 error->assign("Not a number: " + n2s);
                 return false;
+            } else {
+                added = true;
             }
 
             if (n1s > n2s) {
@@ -163,13 +167,15 @@ bool RulesExceptions::load(const std::string &a, std::string *error) {
             addRange(n1n, n2n);
             added = true;
         } else {
-            try {
-                int num = std::stoi(b);
-                addNumber(num);
-                added = true;
-            } catch (...) {
+            std::istringstream iss(b);
+            RuleId num;
+            iss >> num;
+            if (iss.fail()) {
                 error->assign("Not a number or range: " + b);
                 return false;
+            } else {
+                addNumber(num);
+                added = true;
             }
         }
     }
@@ -183,20 +189,20 @@ bool RulesExceptions::load(const std::string &a, std::string *error) {
 }
 
 
-bool RulesExceptions::addNumber(int a) {
+bool RulesExceptions::addNumber(RuleId a) {
     m_numbers.push_back(a);
     return true;
 }
 
 
-bool RulesExceptions::addRange(int a, int b) {
+bool RulesExceptions::addRange(RuleId a, RuleId b) {
     m_ranges.push_back(std::make_pair(a, b));
     return true;
 }
 
 
-bool RulesExceptions::contains(int a) {
-    for (int z : m_numbers) {
+bool RulesExceptions::contains(RuleId a) {
+    for (RuleId z : m_numbers) {
         if (a == z) {
             return true;
         }
@@ -213,7 +219,7 @@ bool RulesExceptions::contains(int a) {
 
 
 bool RulesExceptions::merge(RulesExceptions *from) {
-    for (int a : from->m_numbers) {
+    for (RuleId a : from->m_numbers) {
         bool ret = addNumber(a);
         if (ret == false) {
             return ret;
@@ -242,21 +248,21 @@ bool RulesExceptions::merge(RulesExceptions *from) {
 
     for (auto &p : from->m_variable_update_target_by_id) {
         m_variable_update_target_by_id.emplace(
-            std::pair<double,
+            std::pair<RuleId,
                 std::shared_ptr<variables::Variable>>(p.first,
                     p.second));
     }
 
     for (auto &p : from->m_action_pos_update_target_by_id) {
         m_action_pos_update_target_by_id.emplace(
-            std::pair<double,
+            std::pair<RuleId,
                 std::shared_ptr<actions::Action>>(p.first,
                     p.second));
     }
 
     for (auto &p : from->m_action_transformation_update_target_by_id) {
         m_action_transformation_update_target_by_id.emplace(
-            std::pair<double,
+            std::pair<RuleId,
                 std::shared_ptr<actions::transformations::Transformation>>(p.first,
                     p.second));
     }


### PR DESCRIPTION
Previously, ModSecurity inconsistently used int, int64_t and double for rule id variables in different places.