### PR TITLE
Optimize returning of transformation results

### DIFF
--- a/headers/modsecurity/rule.h
+++ b/headers/modsecurity/rule.h
@@ -52,9 +52,8 @@ namespace operators {
 class Operator;
 }
 
-using TransformationResult = std::pair<std::shared_ptr<std::string>,
-    std::shared_ptr<std::string>>;
-using TransformationResults = std::list<TransformationResult>;
+using TransformationResult = std::pair<std::string, std::string>;
+using TransformationResults = std::vector<TransformationResult>;
 
 using Transformation = actions::transformations::Transformation;
 using Transformations = std::vector<Transformation *>;

--- a/headers/modsecurity/rule_with_actions.h
+++ b/headers/modsecurity/rule_with_actions.h
@@ -72,10 +72,10 @@ class RuleWithActions : public Rule {
 
     inline void executeTransformation(
         actions::transformations::Transformation *a,
-        std::shared_ptr<std::string> *value,
+        std::string &value,
         Transaction *trans,
-        TransformationResults *ret,
-        std::string *path,
+        TransformationResults &ret,
+        std::string &path,
         int *nth) const;
 
 

--- a/headers/modsecurity/rule_with_operator.h
+++ b/headers/modsecurity/rule_with_operator.h
@@ -56,7 +56,7 @@ class RuleWithOperator : public RuleWithActions {
         variables::Variables *eclusion, Transaction *trans);
 
     bool executeOperatorAt(Transaction *trasn, const std::string &key,
-        std::string value, std::shared_ptr<RuleMessage> rm);
+        const std::string &value, std::shared_ptr<RuleMessage> rm);
 
     static void updateMatchedVars(Transaction *trasn, const std::string &key,
         const std::string &value);

--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -101,7 +101,7 @@ void RuleWithOperator::cleanMatchedVars(Transaction *trans) {
 
 
 bool RuleWithOperator::executeOperatorAt(Transaction *trans, const std::string &key,
-    std::string value, std::shared_ptr<RuleMessage> ruleMessage) {
+    const std::string &value, std::shared_ptr<RuleMessage> ruleMessage) {
 #if MSC_EXEC_CLOCK_ENABLED
     clock_t begin = clock();
     clock_t end;
@@ -309,7 +309,7 @@ bool RuleWithOperator::evaluate(Transaction *trans,
 
             for (const auto &valueTemp : values) {
                 bool ret;
-                std::string valueAfterTrans = std::move(*valueTemp.first);
+                const std::string &valueAfterTrans = valueTemp.first;
 
                 ret = executeOperatorAt(trans, key, valueAfterTrans, ruleMessage);
 
@@ -320,7 +320,7 @@ bool RuleWithOperator::evaluate(Transaction *trans,
                         ruleMessage->m_reference.append(i->toText());
                     }
 
-                    ruleMessage->m_reference.append(*valueTemp.second);
+                    ruleMessage->m_reference.append(valueTemp.second);
                     updateMatchedVars(trans, key, valueAfterTrans);
                     executeActionsIndependentOfChainedRuleResult(trans,
                         &containsBlock, ruleMessage);


### PR DESCRIPTION
There's no point in using `shared_ptr`s here, because the strings are never reused (except for the rare case of multiMatch).
Likewise, `std::list` has considerable overhead which goes wasted, because there's no random insertions or iterators needed to be preserved after modifications.

In my test, this leads to increase from 117 requests per second to 127 RPS.