### PR TITLE
Fix Regex::searchAll behaviour wrt empty capturing groups

### DIFF
--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -84,11 +84,12 @@ std::list<SMatch> Regex::searchAll(const std::string& s) const {
             std::string match = std::string(tmpString, start, len);
             offset = start + len;
             retList.push_front(SMatch(match, start));
+        }
 
-            if (len == 0) {
-                rc = 0;
-                break;
-            }
+        offset = ovector[1]; // end
+        if (offset == ovector[0]) { // start == end (size == 0)
+            // skip zero-length match (otherwise, the loop won't terminate)
+            offset++;
         }
     } while (rc > 0);
 


### PR DESCRIPTION
Previously, searchAll would stop search when it encountered an empty
matching group in any position. This means that, for example,
regular expression "(a)(b?)(c)" would match string "ac", but the
resulting group list would be ["ac", "a"].

After this change, the resulting list for the aforementioned regular
expression becomes ["ac", "a", "", "c"] like it should've been.

Additionally, this also changes behaviour for multiple matches. For
example, when "aaa00bbb" is matched by "[a-z]*", previously only "aaa"
would be returned. Now the matching list is ["aaa", "", "", "bbb", ""].

The old behaviour was confusing and almost certainly a bug. The new
behaviour is the same as in Python's re.findall.

For reference, though, Go does it somewhat differently: empty matches
at the end of non-empty matches are ignored, so in Go above example is
["aaa", "", "bbb"] instead.

This is the root cause of issue #2336 which has been already fixed by
replacing searchAll call there with a new function.

Cherry-picked from #2012 