### PR TITLE
Add Regex::searchAllMatches method, remove searchAll

### DIFF
--- a/src/operators/rx.cc
+++ b/src/operators/rx.cc
@@ -51,7 +51,7 @@ bool Rx::evaluate(Transaction *transaction, RuleWithActions *rule,
         re = m_re;
     }
 
-    std::vector<Utils::SMatchCapture> captures;
+    Regex::match_type captures;
     re->searchOneMatch(input, captures);
 
     if (rule && rule->hasCaptureAction() && transaction) {

--- a/src/operators/verify_ssn.cc
+++ b/src/operators/verify_ssn.cc
@@ -121,16 +121,19 @@ bool VerifySSN::evaluate(Transaction *t, RuleWithActions *rule,
     }
 
     for (i = 0; i < input.size() - 1 && is_ssn == false; i++) {
-        matches = m_re->searchAll(input.substr(i, input.size()));
-        for (const auto & j : matches) {
-            is_ssn = verify(j.str().c_str(), j.str().size());
+        std::string val = input.substr(i);
+        auto matches = m_re->searchAllMatches(val);
+        for (const auto & m : matches) {
+            const auto &g = m[0];
+            is_ssn = verify(&val[g.m_offset], g.m_length);
             if (is_ssn) {
-                logOffset(ruleMessage, j.offset(), j.str().size());
+                logOffset(ruleMessage, g.m_offset, g.m_length);
                 if (rule && t && rule->hasCaptureAction()) {
+                    std::string str = g.to_string(val);
                     t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                        "0", j.str());
+                        "0", str);
                     ms_dbg_a(t, 7, "Added VerifySSN match TX.0: " + \
-                        j.str());
+                        str);
                 }
 
                 goto out;

--- a/src/operators/verify_svnr.cc
+++ b/src/operators/verify_svnr.cc
@@ -88,17 +88,20 @@ bool VerifySVNR::evaluate(Transaction *t, RuleWithActions *rule,
     }
 
     for (i = 0; i < input.size() - 1 && is_svnr == false; i++) {
-        matches = m_re->searchAll(input.substr(i, input.size()));
+        std::string val = input.substr(i);
+        auto matches = m_re->searchAllMatches(val);
 
-        for (const auto & j : matches) {
-            is_svnr = verify(j.str().c_str(), j.str().size());
+        for (const auto & m : matches) {
+            const auto &g = m[0];
+            is_svnr = verify(&val[g.m_offset], g.m_length);
             if (is_svnr) {
-                logOffset(ruleMessage, j.offset(), j.str().size());
+                logOffset(ruleMessage, g.m_offset, g.m_length);
                 if (rule && t && rule->hasCaptureAction()) {
+                    std::string str = g.to_string(val);
                     t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                        "0", j.str());
+                        "0", str);
                     ms_dbg_a(t, 7, "Added VerifySVNR match TX.0: " + \
-                        j.str());
+                        str);
                 }
 
                 goto out;

--- a/src/utils/regex.h
+++ b/src/utils/regex.h
@@ -57,10 +57,19 @@ struct SMatchCapture {
     size_t m_group; // E.g. 0 = full match; 6 = capture group 6
     size_t m_offset; // offset of match within the analyzed string
     size_t m_length;
+
+    // to_string is convenience method for returning string for the match.
+    // You must supply the same string that was used to obtain the match,
+    // as offset would be invalid otherwise.
+    std::string to_string(const std::string &matched_string) const {
+        return matched_string.substr(m_offset, m_length);
+    }
 };
 
 class Regex {
  public:
+    typedef std::vector<SMatchCapture> match_type;
+
     explicit Regex(const std::string& pattern_);
     ~Regex();
 
@@ -68,8 +77,8 @@ class Regex {
     Regex(const Regex&) = delete;
     Regex& operator=(const Regex&) = delete;
 
-    std::list<SMatch> searchAll(const std::string& s) const;
-    bool searchOneMatch(const std::string& s, std::vector<SMatchCapture>& captures) const;
+    bool searchOneMatch(const std::string& s, match_type& captures) const;
+    std::vector<match_type> searchAllMatches(const std::string &s) const;
     int search(const std::string &s, SMatch *match) const;
     int search(const std::string &s) const;
 

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -123,7 +123,7 @@ class KeyExclusionRegex : public KeyExclusion {
     ~KeyExclusionRegex() override { }
 
     bool match(const std::string &a) override {
-        return m_re.searchAll(a).size() > 0;
+        return m_re.search(a);
     }
 
     Utils::Regex m_re;
@@ -615,7 +615,7 @@ class Variables : public std::vector<Variable *> {
             [v](Variable *m) -> bool {
                 VariableRegex *r = dynamic_cast<VariableRegex *>(m);
                 if (r) {
-                    return r->m_r.searchAll(v->getKey()).size() > 0;
+                    return r->m_r.search(v->getKey());
                 }
                 return v->getKeyWithCollection() == *m->m_fullName.get();
             }) != end();


### PR DESCRIPTION
`searchAll` interface was pretty strange, as it returned a reversed flattened list of all groups of all matches. For example, given the regexp `"([a-z])([0-9])"`, and the string `"a1b2"`, it would return the list `["2", "b", "b2", "1", "a", "a1"]`.

`searchAllMatches` introduces better interface. In the aforementioned scenario it would return `[["a1", "a", "1"], ["b2", "b", "2"]]`. Also, unlike `searchAll`, it doesn't make string copies itself, and returns just offsets, like `searchOneMatch` does.