### PR TITLE
Add configure option to parameterize Modsecurity/libcurl timeout for …

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -2362,7 +2362,7 @@ static const char *cmd_remote_timeout(cmd_parms *cmd, void *_dcfg, const char *p
     if (dcfg == NULL) return NULL;
 
     timeout = strtol(p1, NULL, 10);
-    if ((timeout == LONG_MAX)||(timeout == LONG_MIN)||(timeout <= 0)) {
+    if ((timeout == LONG_MAX)||(timeout == LONG_MIN)||(timeout < 0)) {
         return apr_psprintf(cmd->pool, "ModSecurity: Invalid value for SecRemoteTimeout: %s", p1);
     }
 

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -2354,6 +2354,24 @@ static const char *cmd_remote_rules(cmd_parms *cmd, void *_dcfg, const char *p1,
 }
 
 
+static const char *cmd_remote_timeout(cmd_parms *cmd, void *_dcfg, const char *p1)
+{
+    directory_config *dcfg = (directory_config *)_dcfg;
+    long int timeout;
+
+    if (dcfg == NULL) return NULL;
+
+    timeout = strtol(p1, NULL, 10);
+    if ((timeout == LONG_MAX)||(timeout == LONG_MIN)||(timeout <= 0)) {
+        return apr_psprintf(cmd->pool, "ModSecurity: Invalid value for SecRemoteTimeout: %s", p1);
+    }
+
+    remote_rules_timeout = timeout;
+
+    return NULL;
+}
+
+
 static const char *cmd_status_engine(cmd_parms *cmd, void *_dcfg, const char *p1)
 {
     if (strcasecmp(p1, "on") == 0) {
@@ -3665,6 +3683,14 @@ const command_rec module_directives[] = {
         NULL,
         CMD_SCOPE_ANY,
         "Abort or Warn"
+    ),
+
+    AP_INIT_TAKE1 (
+        "SecRemoteTimeout",
+        cmd_remote_timeout,
+        NULL,
+        CMD_SCOPE_ANY,
+        "timeout in seconds"
     ),
 
 

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -79,6 +79,8 @@ msc_remote_rules_server DSOLOCAL *remote_rules_server = NULL;
 #endif
 int DSOLOCAL remote_rules_fail_action = REMOTE_RULES_ABORT_ON_FAIL;
 char DSOLOCAL *remote_rules_fail_message = NULL;
+unsigned long int DSOLOCAL remote_rules_timeout = NOT_SET;
+
 
 int DSOLOCAL status_engine_state = STATUS_ENGINE_DISABLED;
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -156,6 +156,7 @@ extern DSOLOCAL msc_remote_rules_server *remote_rules_server;
 #endif
 extern DSOLOCAL int remote_rules_fail_action;
 extern DSOLOCAL char *remote_rules_fail_message;
+extern DSOLOCAL unsigned long int remote_rules_timeout;
 
 extern DSOLOCAL int status_engine_state;
 

--- a/apache2/msc_remote_rules.c
+++ b/apache2/msc_remote_rules.c
@@ -358,6 +358,11 @@ int msc_remote_download_content(apr_pool_t *mp, const char *uri, const char *key
         /* We want Curl to return error in case there is an HTTP error code */
         curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 
+        /* In case we want different timeout than a default one */
+        if (remote_rules_timeout != NOT_SET){
+            curl_easy_setopt(curl, CURLOPT_TIMEOUT, remote_rules_timeout);
+        }
+
         res = curl_easy_perform(curl);
 
         if (res != CURLE_OK)


### PR DESCRIPTION
…retrieving rules.

- There are scenarios where the internet connection is not available for the httpd,
for example during the test of Disaster Recovery or other failures. In these cases,
it would be great to have a possibility to start the httpd in the same (more or less)
timing of when there is an internet connection. Moreover, being the currently timeout
a default, it is not possible to control this value.