### PR TITLE
Fix memory leak in VariableModificatorCount

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
  
+  - Avoids to cleanup GeoIp on ModSecurity destructor
+    [#2041 - @zimmerle, @jptosso, @victorhora]
   - Fix memory leak of RuleMessages objects
     [#2376 - @WGH-, @martinhsv]
   - Produce not-supported error for ctl:forceRequestBodyVariable

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
  
+  - Fix memory leak in VariableModificatorCount
+    [#2376 - @WGH-, @martinhsv]
   - Avoids to cleanup GeoIp on ModSecurity destructor
     [#2041 - @zimmerle, @jptosso, @victorhora]
   - Fix memory leak of RuleMessages objects

--- a/headers/modsecurity/variable_value.h
+++ b/headers/modsecurity/variable_value.h
@@ -91,7 +91,7 @@ class VariableValue {
 
     /**
      *
-     *  Use case C + VariableModificatorCount
+     *  Use case C
      *
      *
      **/
@@ -182,7 +182,7 @@ class VariableValue {
     };
 
 
-    /* Use case E.2. - DURATION */
+    /* Use case E.2. - DURATION, VariableModificatorCount */
     VariableValue(std::unique_ptr<std::string> value,
         const std::string *collection)
         : m_origin(),

--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -95,9 +95,6 @@ ModSecurity::~ModSecurity() {
 #ifdef MSC_WITH_CURL
     curl_global_cleanup();
 #endif
-#ifdef WITH_GEOIP
-    Utils::GeoLookup::getInstance().cleanUp();
-#endif
 #ifdef WITH_LIBXML2
     xmlCleanupParser();
 #endif

--- a/src/utils/geo_lookup.h
+++ b/src/utils/geo_lookup.h
@@ -55,13 +55,16 @@ class GeoLookup {
  private:
     GeoLookup() :
         m_version(NOT_LOADED)
+#if WITH_MAXMIND
+        ,mmdb()
+#endif
 #if WITH_GEOIP
         ,m_gi(NULL)
 #endif
         { }
     ~GeoLookup();
-    GeoLookup(GeoLookup const&);
-    void operator=(GeoLookup const&);
+    GeoLookup(GeoLookup const&) = delete;
+    void operator=(GeoLookup const&) = delete;
 
     GeoLookupVersion m_version;
 #if WITH_MAXMIND

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -772,8 +772,8 @@ class VariableModificatorCount : public Variable {
         m_base->evaluate(t, &reslIn);
         auto count = reslIn.size();
 
-        std::string res(std::to_string(count));
-        l->push_back(std::make_shared<VariableValue>(getVariableKeyWithCollection().get(), &res));
+        std::unique_ptr<std::string> res(new std::string(std::to_string(count)));
+        l->push_back(std::make_shared<VariableValue>(std::move(res), getVariableKeyWithCollection().get()));
         return;
     }
 

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -51,14 +51,14 @@ functionStatic:src/engine/lua.h:80
 functionConst:src/utils/geo_lookup.h:49
 useInitializationList:src/operators/rbl.h:69
 constStatement:test/common/modsecurity_test.cc:82
-danglingTemporaryLifetime:src/modsecurity.cc:204
+danglingTemporaryLifetime:src/modsecurity.cc:201
 functionStatic:src/operators/geo_lookup.h:35
 duplicateBreak:src/operators/validate_utf8_encoding.cc
 duplicateBranch:src/request_body_processor/multipart.cc:91
 syntaxError:src/transaction.cc:62
 noConstructor:src/variables/variable.h:152
 duplicateBranch:src/request_body_processor/multipart.cc:93
-danglingTempReference:src/modsecurity.cc:204
+danglingTempReference:src/modsecurity.cc:201
 knownConditionTrueFalse:src/operators/validate_url_encoding.cc:79
 knownConditionTrueFalse:src/operators/verify_svnr.cc:90
 noConstructor:src/actions/rule_id.h:30


### PR DESCRIPTION
This addresses the memory leak described in the 3rd of 3 call stacks recently cited within issue #2376 