### PR TITLE
Fix memory leak in ValidateDTD m_dtd

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
  
 
+  - Fix memory leak in ValidateDTD's m_dtd
+    [#2469 - @martinhsv]
   - Using a custom VariableMatch* implementation
     [#2428 - @zimmerle]
   - Avoids to cleanup GeoIp on ModSecurity destructor

--- a/src/operators/validate_dtd.cc
+++ b/src/operators/validate_dtd.cc
@@ -49,6 +49,10 @@ bool ValidateDTD::evaluate(Transaction *transaction,
         RuleMessage *ruleMessage) {
     xmlValidCtxtPtr cvp;
 
+    if (m_dtd != NULL) {
+        xmlFreeDtd(m_dtd);
+        m_dtd = NULL;
+    }
     m_dtd = xmlParseDTD(NULL, (const xmlChar *)m_resource.c_str());
     if (m_dtd == NULL) {
         std::string err = std::string("XML: Failed to load DTD: ") \


### PR DESCRIPTION
This pull request addresses the memory leak listed as 3) in https://github.com/SpiderLabs/ModSecurity/issues/2469 .

The function call in this line of code allocates heap memory.  The second and subsequent calls to this function resulted in the the m_dtd pointer simply being assigned a new value, which meant that the heap memory previously pointed-to was leaked on a per-transaction basis.
```
m_dtd = xmlParseDTD(NULL, (const xmlChar *)m_resource.c_str());
```

With this new code, before the new parse-and-assign, we'll check if m_dtd is not null, and if so do the proper cleanup.

(I have addressed the leak in this pull request, but a larger issue we may want to consider for later implementation:  Do we really want to be calling xmlParseDTD for every transaction?  Granted, if we only want to do this once rather than per-transaction, we would need to consider the use case where the resource content changes over time -- particularly if it is an internet resource.  We could decide we don't care, or perhaps adopt a cacheing-and-periodic-update strategy)
