### PR TITLE
Fix memory leak in ValidateSchema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Manual Inputs
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Bump Version
+        default: v1.0.0
+        required: true
+jobs:
+  bump-version:
+    name: Bump Package Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Example variable usage
+        run: git tag ${{ github.event.inputs.version }}

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
  
 
+  - Fix memory leak in ValidateSchema
+    [#2469 - @martinhsv]
   - Using a custom VariableMatch* implementation
     [#2428 - @zimmerle]
   - Avoids to cleanup GeoIp on ModSecurity destructor

--- a/src/operators/validate_schema.cc
+++ b/src/operators/validate_schema.cc
@@ -82,6 +82,10 @@ bool ValidateSchema::evaluate(Transaction *transaction,
         return true;
     }
 
+    if (m_validCtx != NULL) {
+        xmlSchemaFreeValidCtxt(m_validCtx);
+        m_validCtx = NULL;
+    }
     m_validCtx = xmlSchemaNewValidCtxt(m_schema);
     if (m_validCtx == NULL) {
         std::stringstream err("XML: Failed to create validation context.");


### PR DESCRIPTION
This pull request addresses the memory leak listed as 3) in #2469 .

This is analogous to https://github.com/SpiderLabs/ModSecurity/pull/2471 .

Prior to this change, second and subsequent calls to this object's evaluate function would cause a memory leak, when m_validCtx was assigned a new pointer value before the previously-pointed-to memory had been free'd.
