### PR TITLE
Fix AnchoredSetVariableMatchVars(Names) fn with return val may ...

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
  
+  - Fix AnchoredSetVariableMatchVars(Names) function with return
+    value may reach end of function
+    [@martinhsv]
   - Replaces put with setenv in SetEnv action
     [#2469 - @martinhsv, @WGH-, @zimmerle]
   - Using a custom VariableMatch* implementation

--- a/src/anchored_set_variable_match_vars.cc
+++ b/src/anchored_set_variable_match_vars.cc
@@ -94,6 +94,7 @@ std::unique_ptr<std::string> AnchoredVariableMatchVars::resolveFirst(const std::
         }
         return std::unique_ptr<std::string>(new std::string(x->getValue()));
     }
+    return std::unique_ptr<std::string>();
 }
 
 

--- a/src/anchored_set_variable_match_vars_names.cc
+++ b/src/anchored_set_variable_match_vars_names.cc
@@ -93,6 +93,7 @@ std::unique_ptr<std::string> AnchoredVariableMatchVarsNames::resolveFirst(const 
         }
         return std::unique_ptr<std::string>(new std::string(x->getName()));
     }
+    return std::unique_ptr<std::string>();
 }
 
 


### PR DESCRIPTION
…reach end of fn

-----------------------------

I cannot prove ill effects just now, but since it is undefined behaviour, we should probably clean this up.
