### PR TITLE
Make the `configure` step more reliable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_PROG_MAKE_SET
 # AX_CXX_COMPILE_STDCXX_11(,mandatory)
 
 # Check for libinjection
-if ! test -f "${srcdir}others/libinjection/src/libinjection_html5.c"; then
+if ! test -f "${srcdir}/others/libinjection/src/libinjection_html5.c"; then
 AC_MSG_ERROR([\
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_PROG_MAKE_SET
 # AX_CXX_COMPILE_STDCXX_11(,mandatory)
 
 # Check for libinjection
-if ! test -f "others/libinjection/src/libinjection_html5.c"; then
+if ! test -f "${srcdir}others/libinjection/src/libinjection_html5.c"; then
 AC_MSG_ERROR([\
 
 


### PR DESCRIPTION
It appears that in cross-compile environments the location of the
"current" directory cannot be assumed. This fix makes it explicit.