### PR TITLE
Fix memory leak in rx operator when pattern includes macro

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Fix memory leak in rx operator when pattern includes macro
+    [@martinhsv]
   - Regression: Mark the test as failed in case of segfault.
     [@zimmerle]
   - Regex key selection should not be case-sensitive

--- a/src/operators/rx.cc
+++ b/src/operators/rx.cc
@@ -69,12 +69,12 @@ bool Rx::evaluate(Transaction *transaction, RuleWithActions *rule,
         logOffset(ruleMessage, capture.m_offset, capture.m_length);
     }
 
-    if (!captures.empty()) {
-        return true;
-    }
-
     if (m_string->m_containsMacro) {
         delete re;
+    }
+
+    if (!captures.empty()) {
+        return true;
     }
 
     return false;


### PR DESCRIPTION
This corrects an issue only very recently introduced in v3/master (just a few days ago).
