### PR TITLE
New recommended rule to enable JSON parser for subtypes with +json su…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - New rule to enable JSON parser for subtypes with +json suffix
+    [@dune73, @martinhsv]
   - Having ARGS_NAMES, variables proxied
     [@zimmerle, @martinhsv, @KaNikita]
   - Use explicit path for cross-compile environments.

--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -29,6 +29,12 @@ SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
 SecRule REQUEST_HEADERS:Content-Type "application/json" \
      "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
+# Enable JSON request body parser for more subtypes.
+# Initiate JSON Processor in case of JSON suffix in subtype
+#
+SecRule REQUEST_HEADERS:Content-Type "^application/.+[+]json$" \
+     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
+
 # Maximum request body size we will accept for buffering. If you support
 # file uploads then the value given on the first line has to be as large
 # as the largest file you are willing to accept. The second value refers


### PR DESCRIPTION
This pull request includes one way to address the underlying ask in #2564 .

Without assuming that this change (or anything similar) will necessarily proceed within the ModSecurity project and its modsecurity.conf-recommended file, this pull request is made available at least for assessment and comment.

Rather than adjust the existing rule 200001, I have opted to create a new rule 200006 to cover the additional use cases (the type is 'application' with the subtype not 'json', but has a +json subtype).  This separation of rules might be advantageous if we are at all worried that some ModSecurity users might experience undesired effects from this change.  Having a separate rule for the additional functionality makes it simpler to disable or comment-out the new rule and restore former behaviour.

A second nuance/detail of note may be that I chose to specify the literal '+' plus character within a character class.  This was done to avoid any inconsistencies (especially between v2.9 and v3) with backslash-escaping.

If are hesitant to take even this level of risk with rules that activate the JSON parser, yet another option could be to include the new rule in the file, but leave it commented-out.  This would not be entirely unprecedented; we already have several configuration items in the file present but commented-out.  This would at least save users interested in the functionality from having to think about and compose a new or modified regex themselves.
