### PR TITLE
fix memory leak in the example

### DIFF
--- a/examples/simple_example_using_c/test.c
+++ b/examples/simple_example_using_c/test.c
@@ -70,6 +70,7 @@ int main (int argc, char **argv)
 end:
     msc_rules_cleanup(rules);
     msc_cleanup(modsec);
+    free(error);
 
     return 0;
 }


### PR DESCRIPTION
`error` string is created via `strdup` and it must be passed to `free()` to avoid a memory leak.

Not really important in this particular case, but if would be consistent with `msc_rules_cleanup(rules)` and `msc_cleanup(modsec)`