### PR TITLE
Add commented-out sample rule to engage JSON Processor for more subtypes

### DIFF
--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -29,6 +29,13 @@ SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
 SecRule REQUEST_HEADERS:Content-Type "application/json" \
      "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
+# Sample rule to enable JSON request body parser for more subtypes.
+# Uncomment or adapt this rule if you want to engage the JSON
+# Processor for "+json" subtypes
+#
+#SecRule REQUEST_HEADERS:Content-Type "^application/.+[+]json$" \
+#     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
+
 # Maximum request body size we will accept for buffering. If you support
 # file uploads then the value given on the first line has to be as large
 # as the largest file you are willing to accept. The second value refers


### PR DESCRIPTION
This pull request is a replacement for #2574 in addressing #2564 

The rule provided here is the same as in the former pull request, but it is provided (like some other configuration items in the file) commented-out.

This is provided as a convenience for users so that they might be able to avoid having to think about how to compose a rule themselves.  Only removing the two comment characters is necessary to activate the new rule.

