### PR TITLE
Add commented-out sample rule to engage JSON Processor for more subtypes

### DIFF
--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -29,6 +29,13 @@ SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
 SecRule REQUEST_HEADERS:Content-Type "application/json" \
      "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
+# Sample rule to enable JSON request body parser for more subtypes.
+# Uncomment or adapt this rule if you want to engage the JSON
+# Processor for "+json" subtypes
+#
+#SecRule REQUEST_HEADERS:Content-Type "^application/.+[+]json$" \
+#     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
+
 # Maximum request body size we will accept for buffering. If you support
 # file uploads then the value given on the first line has to be as large
 # as the largest file you are willing to accept. The second value refers


### PR DESCRIPTION
This is the same change for the v2 version of the file as was done recently for the v3 version of the file ( https://github.com/SpiderLabs/ModSecurity/pull/2586 )

If there are no concerns expressed, I will plan to merge this within a day or two.

