### PR TITLE
build/libmaxmind.m4: fix build with host-pkgconf

### DIFF
--- a/build/libmaxmind.m4
+++ b/build/libmaxmind.m4
@@ -60,12 +60,10 @@ else
             # Nothing about MaxMind was informed, using the pkg-config to figure things out.
             if test -n "${PKG_CONFIG}"; then
                 MAXMIND_PKG_NAME=""
-                for x in ${MAXMIND_POSSIBLE_LIB_NAMES}; do
-                    if ${PKG_CONFIG} --exists ${x}; then
-                        MAXMIND_PKG_NAME="$x"
-                        break
-                    fi
-                done
+                if ${PKG_CONFIG} --exists libmaxminddb; then
+                    MAXMIND_PKG_NAME="libmaxminddb"
+                    break
+                fi
             fi
             AC_MSG_NOTICE([Nothing about MaxMind was informed during the configure phase. Trying to detect it on the platform...])
             if test -n "${MAXMIND_PKG_NAME}"; then


### PR DESCRIPTION
Build with maxminddb is broken since version 3.0.5 and https://github.com/SpiderLabs/ModSecurity/commit/785958f9b5089b918c7d054cbcc2fe4a3c7b3788 because `libmaxminddb` has been removed from `MAXMIND_POSSIBLE_LIB_NAMES`

So, as suggested by Arnout in #2131, don't use `MAXMIND_POSSIBLE_LIB_NAMES` for pkg-config, because it was never called
anything other than `libmaxminddb`

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>