### PR TITLE
fix include handle

### DIFF
--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -3,7 +3,6 @@
 #include <climits>
 #include <cstdlib>
 #include <string>
-#include <regex.h>
 
 #include "src/parser/driver.h"
 #include "src/parser/seclang-parser.hh"
@@ -1238,13 +1237,12 @@ EQUALS_MINUS                            (?i:=\-)
 
 {CONFIG_INCLUDE}[ \t]+{CONFIG_VALUE_PATH} {
     std::string err;
-    regex_t ex;
-    regmatch_t match;
-    regcomp(&ex, "include[ \t]+", REG_ICASE|REG_EXTENDED );
-    regexec(&ex, yytext, 1, &match,  0);  
-    const char *file = yytext+match.rm_eo;
-    std::cout << "file:" << file << std::endl;
-    regfree(&ex);
+    int i = strlen("include");
+    while((' ' == yytext[i]) ||( '\t' ==  yytext[i] ))
+    {
+        i++;
+    }
+    const char *file = yytext+i;
 
     std::string fi = modsecurity::utils::find_resource(file, *driver.loc.back()->end.filename, &err);
     if (fi.empty() == true) {
@@ -1272,16 +1270,15 @@ EQUALS_MINUS                            (?i:=\-)
 
 {CONFIG_INCLUDE}[ \t]+["]{CONFIG_VALUE_PATH}["] {
     std::string err;
-    regex_t ex;
-    regmatch_t match;
-    regcomp(&ex, "include[ \t]+", REG_ICASE|REG_EXTENDED );
-    regexec(&ex, yytext, 1, &match,  0);  
-    const char *file = yytext+match.rm_eo;
-    std::cout << "file:" << file << std::endl;
-    regfree(&ex);
 
-    char *f = strdup(file + 1);
-    f[strlen(f)-1] = '\0';
+    int i = strlen("include");
+    while((' ' == yytext[i]) ||( '\t' ==  yytext[i]  ))
+    {
+        i++;
+    }
+    const char *file = yytext+i;
+    char *f = strdup(file);
+
     std::string fi = modsecurity::utils::find_resource(f, *driver.loc.back()->end.filename, &err);
     if (fi.empty() == true) {
         BEGIN(INITIAL);

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -3,6 +3,7 @@
 #include <climits>
 #include <cstdlib>
 #include <string>
+#include <regex.h>
 
 #include "src/parser/driver.h"
 #include "src/parser/seclang-parser.hh"
@@ -1237,7 +1238,14 @@ EQUALS_MINUS                            (?i:=\-)
 
 {CONFIG_INCLUDE}[ \t]+{CONFIG_VALUE_PATH} {
     std::string err;
-    const char *file = strchr(yytext, ' ') + 1;
+    regex_t ex;
+    regmatch_t match;
+    regcomp(&ex, "include[ \t]+", REG_ICASE|REG_EXTENDED );
+    regexec(&ex, yytext, 1, &match,  0);  
+    const char *file = yytext+match.rm_eo;
+    std::cout << "file:" << file << std::endl;
+    regfree(&ex);
+
     std::string fi = modsecurity::utils::find_resource(file, *driver.loc.back()->end.filename, &err);
     if (fi.empty() == true) {
         BEGIN(INITIAL);
@@ -1264,7 +1272,14 @@ EQUALS_MINUS                            (?i:=\-)
 
 {CONFIG_INCLUDE}[ \t]+["]{CONFIG_VALUE_PATH}["] {
     std::string err;
-    const char *file = strchr(yytext, ' ') + 1;
+    regex_t ex;
+    regmatch_t match;
+    regcomp(&ex, "include[ \t]+", REG_ICASE|REG_EXTENDED );
+    regexec(&ex, yytext, 1, &match,  0);  
+    const char *file = yytext+match.rm_eo;
+    std::cout << "file:" << file << std::endl;
+    regfree(&ex);
+
     char *f = strdup(file + 1);
     f[strlen(f)-1] = '\0';
     std::string fi = modsecurity::utils::find_resource(f, *driver.loc.back()->end.filename, &err);

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -3,6 +3,7 @@
 #include <climits>
 #include <cstdlib>
 #include <string>
+#include <string.h>
 
 #include "src/parser/driver.h"
 #include "src/parser/seclang-parser.hh"
@@ -1237,12 +1238,11 @@ EQUALS_MINUS                            (?i:=\-)
 
 {CONFIG_INCLUDE}[ \t]+{CONFIG_VALUE_PATH} {
     std::string err;
-    int i = strlen("include");
-    while((' ' == yytext[i]) ||( '\t' ==  yytext[i] ))
-    {
-        i++;
-    }
-    const char *file = yytext+i;
+
+    char *tmpStr = strdup ( yytext+strlen("include")); 
+    char *fileNameStart  = strtok ( tmpStr, " \t");
+    const char *file = yytext +strlen("include") + (fileNameStart-tmpStr);
+    free(tmpStr);
 
     std::string fi = modsecurity::utils::find_resource(file, *driver.loc.back()->end.filename, &err);
     if (fi.empty() == true) {
@@ -1271,12 +1271,11 @@ EQUALS_MINUS                            (?i:=\-)
 {CONFIG_INCLUDE}[ \t]+["]{CONFIG_VALUE_PATH}["] {
     std::string err;
 
-    int i = strlen("include");
-    while((' ' == yytext[i]) ||( '\t' ==  yytext[i]  ))
-    {
-        i++;
-    }
-    const char *file = yytext+i;
+    char *tmpStr = strdup ( yytext+strlen("include")); 
+    char *fileNameStart  = strtok ( tmpStr, " \t");
+    const char *file = yytext +strlen("include") + (fileNameStart-tmpStr);
+    free(tmpStr);
+
     char *f = strdup(file);
 
     std::string fi = modsecurity::utils::find_resource(f, *driver.loc.back()->end.filename, &err);


### PR DESCRIPTION
"const char *file = strchr(yytext, ' ') + 1"  supposes only one space after Include, but the grammar "[ \t]+" mean multiple space and TAB including one space;