### PR TITLE
Get client public ip address in json audit log

### DIFF
--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -430,6 +430,11 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
      * Holds the HTTP version: 1.2, 2.0, 3.0 and so on....
      */
     std::string m_httpVersion;
+    
+    /**
+     * Holds the Public ip of user, as per X-Forwarded-For header
+     */
+    std::string m_remotePublicIp;
 
     /**
      * Holds the server IP Address

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1659,7 +1659,7 @@ std::string Transaction::toJSON(int parts) {
     yajl_gen_map_open(g);
     /* Part: A (header mandatory) */
     LOGFY_ADD("client_ip", this->m_clientIpAddress->c_str());
-    LOGFY_ADD("client_public_ip", m_remotePublicIp.c_str());
+    LOGFY_ADD("x_forwarded_for", m_remotePublicIp.c_str());
     LOGFY_ADD("time_stamp", ts.c_str());
     LOGFY_ADD("server_id", uniqueId.c_str());
     LOGFY_ADD_NUM("client_port", m_clientPort);


### PR DESCRIPTION
When Modsecurity running behind a proxy that send X-Forwarded-For header(for example load balancer), current remoteip module is broken. it's not able to get client public ip.
To get client public ip in v3, i removed remoteip module and added a new variable "client_public_ip" in audit log json, which have value sent by 'X-Forwarded-For' header.

Got the idea to remove remoteip module from here
https://github.com/SpiderLabs/ModSecurity/issues/756#issuecomment-612549616

My setup is
 - Modsecurity in a docker behind load balancer
 - Removed remoteip module and it's recommended config from apache
 - JSON logs with HTTPS type
     SecAuditLogType HTTPS
     SecAuditLog "http://127.0.0.1:8042/post/waflog"
     SecAuditLogFormat JSON