### PR TITLE
Confusing variable name in setRequestBody method

### DIFF
--- a/src/utils/https_client.cc
+++ b/src/utils/https_client.cc
@@ -50,8 +50,8 @@ void HttpsClient::setKey(const std::string& key) {
     m_key = "ModSec-key: " + key;
 }
 
-void HttpsClient::setRequestBody(const std::string& requestType) {
-    m_requestBody = requestType;
+void HttpsClient::setRequestBody(const std::string& requestBody) {
+    m_requestBody = requestBody;
 }
 
 void HttpsClient::setRequestType(const std::string& requestType) {

--- a/src/utils/https_client.h
+++ b/src/utils/https_client.h
@@ -47,7 +47,7 @@ class HttpsClient {
     size_t handle_impl(char * data, size_t size, size_t nmemb);
     void setKey(const std::string& key);
     void setRequestType(const std::string& requestType);
-    void setRequestBody(const std::string& requestType);
+    void setRequestBody(const std::string& requestBody);
 
     std::string error;
  private:


### PR DESCRIPTION
There are 2 methods, `setRequestBody()` and `setRequestType()`
argument variable name is same in both, that is `requestType`
for better code readability, it should be `requestBody` for  `setRequestBody()`