### PR TITLE
Fix SecRuleUpdateTargetById for ARGS_*NAMES with regex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
-
-
-
+  - Fix SecRuleUpdateTargetById for ARGS_*NAMES with regex
+    [Issue #2627 - @lontchianicet, @martinhsv]
 
 v3.0.5 - 2021-Jul-07
 --------------------

--- a/headers/modsecurity/anchored_set_variable_translation_proxy.h
+++ b/headers/modsecurity/anchored_set_variable_translation_proxy.h
@@ -44,7 +44,7 @@ class AnchoredSetVariableTranslationProxy {
     {
         m_translate = [](std::string *name, std::vector<const VariableValue *> *l) {
             for (int i = 0; i < l->size(); ++i) {
-                VariableValue *newVariableValue = new VariableValue(name, &l->at(i)->getKey());
+                VariableValue *newVariableValue = new VariableValue(name, &l->at(i)->getKey(), &l->at(i)->getKey());
                 const VariableValue *oldVariableValue = l->at(i);
                 l->at(i) = newVariableValue;
                 for (auto &oldOrigin : oldVariableValue->getOrigin()) {

--- a/test/test-cases/regression/config-update-target-by-id.json
+++ b/test/test-cases/regression/config-update-target-by-id.json
@@ -118,5 +118,85 @@
       "SecRuleUpdateTargetById 1 !ARGS:mixpanel",
       "SecRule ARGS \"@contains value\" \"id:1,t:trim,tag:'test',deny\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"SecRuleUpdateTargetById - exclude from ARGS_NAMES using regex (match)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?xxxyyy=value",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRuleUpdateTargetById 1 \"!ARGS:/xxx/\"",
+      "SecRule ARGS_NAMES \"@contains yyy\" \"id:1,phase:2,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"SecRuleUpdateTargetById - exclude from ARGS_NAMES using regex (no match)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?xxyyy=value",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRuleUpdateTargetById 1 \"!ARGS:/xxx/\"",
+      "SecRule ARGS_NAMES \"@contains yyy\" \"id:1,phase:2,deny,status:403\""
+    ]
   }
 ]

--- a/test/test-cases/regression/variable-ARGS_NAMES.json
+++ b/test/test-cases/regression/variable-ARGS_NAMES.json
@@ -209,7 +209,7 @@
       ]
     },
     "expected":{
-      "debug_log":"Target value: \"name1\" \\(Variable: ARGS_NAMES\\)"
+      "debug_log":"Target value: \"name1\" \\(Variable: ARGS_NAMES:name1\\)"
     },
     "rules":[
         "SecRuleEngine On",

--- a/test/test-cases/regression/variable-ARGS_POST_NAMES.json
+++ b/test/test-cases/regression/variable-ARGS_POST_NAMES.json
@@ -131,7 +131,7 @@
       ]
     },
     "expected":{
-      "debug_log":"Target value: \"name1\" \\(Variable: ARGS_POST_NAMES\\)"
+      "debug_log":"Target value: \"name1\" \\(Variable: ARGS_POST_NAMES:name1\\)"
     },
     "rules":[
         "SecRuleEngine On",


### PR DESCRIPTION
This a tentative pull request to close #2627 .

This will not be merged for at least a couple of more weeks (I hope to do some more testing on it), but it is available for anyone who wishes to try it out on an experimental basis.
