### PR TITLE
Multipart names may include single quote if double-quote enclosed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Multipart names/filenames may include single quote if double-quote enclosed
+   [Issue #2352 @martinhsv]
  * Add SecRequestBodyJsonDepthLimit to modsecurity.conf-recommended
    [Issue #2647 @theMiddleBlue, @airween, @877509395 ,@martinhsv]
  * IIS: Update dependencies for Windows build as of v2.9.5


### PR DESCRIPTION
The parsing of multipart parts in Apache HTTP Server is quite permissive. So much so that a serious issue was identified nearly 10 years ago whereby an attacker could use single quotes to bypass many rules by exploiting parsing differences between Apache and ModSecurity.

One reference to this is located here:
https://blog.ivanristic.com/2012/06/modsecurity-and-modsecurity-core-rule-set-multipart-bypasses.html

In response, ModSecurity was updated to always set the 'Invalid Quoting' flag if a single quote appears anywhere in the 'name' or 'filename' value of the Content-Disposition header of a multipart part ( #460 ).

This has been a hindrance for some users, since a single quote character within such a name can be a perfectly legitimate use case.

There has always been a workaround: to not use the standard check of MULTIPART_STRICT_ERROR that is included with modsecurity.conf-recommended, but instead use an equivalent check that excludes testing of MULTIPART_INVALID_QUOTING. Not only is the workaround somewhat inconvenient, doing that also means abandoning testing for constructs like: name='abc', which is invalid.

I have carefully examined the Apache HTTP Server code at issue and determined that it is safe to loosen this restriction. With this pull request, ModSecurity will no longer raise the 'Invalid Quoting' condition on encountering a single quote within the 'name' or 'filename' as long as the entire value is encapsulated in double quotes.

The following will no longer result in 'Invalid Quoting':
```
name="ab'cd"
```

The following will continue to result in 'Invalid Quoting':
```
name='abcd'
name=ab'cd
```

The equivalent change for ModSecurity v3 will follow.
