### PR TITLE
Multipart names may include single quote if double-quote enclosed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Multipart names/filenames may include single quote if double-quote enclosed
+    [Issue #2352 @martinhsv]
   - Add SecRequestBodyJsonDepthLimit to modsecurity.conf-recommended
     [Issue #2647 @theMiddleBlue, @airween, @877509395 ,@martinhsv]
 

--- a/src/request_body_processor/multipart.h
+++ b/src/request_body_processor/multipart.h
@@ -162,7 +162,7 @@ class Multipart {
     int process_part_header(std::string *error, int offset);
     int process_part_data(std::string *error, size_t offset);
 
-    void validate_quotes(const char *data);
+    void validate_quotes(const char *data, char quote);
 
     size_t m_reqbody_no_files_length;
     std::list<MultipartPart *> m_parts;

--- a/test/test-cases/regression/variable-MULTIPART_STRICT_ERROR.json
+++ b/test/test-cases/regression/variable-MULTIPART_STRICT_ERROR.json
@@ -342,6 +342,126 @@
       "SecRuleEngine On",
       "SecRule REQBODY_ERROR \"@contains 0\" \"id:1,phase:3,pass,t:trim\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_STRICT_ERROR - IQ ",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"name\"",
+        "",
+        "test",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=file'data; filename=\"small_text_file.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "This is a very small test file..",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "This is another very small test file..",
+        "----------------------------756b6d74fa1a8ee2--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403,
+      "debug_log":"Warning: invalid quoting used"
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule MULTIPART_STRICT_ERROR \"!@eq 0\" \"id:1,phase:2,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_STRICT_ERROR - IQ ",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"name\"",
+        "",
+        "test",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"file'data\"; filename=\"small_text_file.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "This is a very small test file..",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"",
+        "Content-Type: text/plain",
+        "",
+        "This is another very small test file..",
+        "----------------------------756b6d74fa1a8ee2--"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule MULTIPART_INVALID_QUOTING \"!@eq 0\" \"id:1,phase:2,deny,status:403\"",
+      "SecRule MULTIPART_STRICT_ERROR \"!@eq 0\" \"id:2,phase:2,pass\""
+    ]
   }
 ]
 


### PR DESCRIPTION
This pull request reduces the set of use cases that result in 'Invalid Quoting' being flagged during multipart parsing of the Content-Disposition's 'name' or 'filename'.

The following will no longer result in 'Invalid Quoting':
```
name="ab'cd"
```

The following will continue to result in 'Invalid Quoting':
```
name='abcd'
name=ab'cd
```

This change matches recent updates done in v2, see that pull request for more detail:
https://github.com/SpiderLabs/ModSecurity/pull/2660
