### PR TITLE
MULTIPART_UNMATCHED_BOUNDARY=1 functionality is broken

### DIFF
--- a/test/test-cases/regression/variable-MULTIPART_UNMATCHED_BOUNDARY.json
+++ b/test/test-cases/regression/variable-MULTIPART_UNMATCHED_BOUNDARY.json
@@ -57,5 +57,206 @@
       "SecRuleEngine On",
       "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@contains small_text_file.txt\" \"id:1,phase:3,pass,t:trim\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_UNMATCHED_BOUNDARY - 2nd unmatched",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"a\"",
+        "",
+        "1",
+        "----------------------------wrong-unmatched",
+        "Content-Disposition: form-data; name=\"b\"",
+        "",
+        "2",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"c\"",
+        "",
+        "3",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"d\"",
+        "",
+        "4",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"e\"",
+        "",
+        "5",
+        "----------------------------756b6d74fa1a8ee2--",
+        ""
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"Target value: \"1\" \\(Variable: MULTIPART_UNMATCHED_BOUNDARY\\)",
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@eq 1\" \"id:1,phase:2,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_UNMATCHED_BOUNDARY - 3rd unmatched",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"a\"",
+        "",
+        "1",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"b\"",
+        "",
+        "2",
+        "----------------------------wrong-unmatched",
+        "Content-Disposition: form-data; name=\"c\"",
+        "",
+        "3",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"d\"",
+        "",
+        "4",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"e\"",
+        "",
+        "5",
+        "----------------------------756b6d74fa1a8ee2--",
+        ""
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"Target value: \"1\" \\(Variable: MULTIPART_UNMATCHED_BOUNDARY\\)",
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@eq 1\" \"id:1,phase:2,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MULTIPART_UNMATCHED_BOUNDARY - 4th unmatched",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"a\"",
+        "",
+        "1",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"b\"",
+        "",
+        "2",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"c\"",
+        "",
+        "3",
+        "----------------------------wrong-unmatched",
+        "Content-Disposition: form-data; name=\"d\"",
+        "",
+        "4",
+        "----------------------------756b6d74fa1a8ee2",
+        "Content-Disposition: form-data; name=\"e\"",
+        "",
+        "5",
+        "----------------------------756b6d74fa1a8ee2--",
+        ""
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"Target value: \"1\" \\(Variable: MULTIPART_UNMATCHED_BOUNDARY\\)",
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@eq 1\" \"id:1,phase:2,deny,status:403\""
+    ]
   }
 ]


### PR DESCRIPTION
This pull request is not intended for near-term merging, but rather, to illustrate one of the problems with current v3 functionality for MULTIPART_UNMATCHED_BOUNDARY.

(This pull request is not intended to illustrate cases where either a) the value should be set to '2' but is not or b) the value is incorrectly set to '2' when it should be '0'.)

Rule 200004 as provided in modsecurity.conf-recommended tests:
```
SecRule MULTIPART_UNMATCHED_BOUNDARY "@eq 1" ...
```

In current v3/master, if there are 'n' apparent boundaries (basically lines beginning with '--'), then if any of the 2nd through n-2-th are non-matches, they will fail to result in MULTIPART_UNMATCHED_BOUNDARY=1.

E.g. if there are a total of 10 apparent boundaries, if any of the 2nd, 3rd, 4th, 5h, 6th, 7th or 8th of them should signal as 'unmatched', MULTIPART_UNMATCHED_BOUNDARY will not get set to 1.

This is illustrated in the 3 new tests in this file. They all fail in current v3/master but they all pass in v3/master as at June 7,2018.
