### PR TITLE
V2/redundancy

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1029,8 +1029,10 @@ msre_action *msre_create_action(msre_engine *engine, apr_pool_t *mp, const char 
     return action;
 }
 
-// Return 1 if "name=value" is present in table
-static int apr_table_exists_(apr_pool_t* p, const apr_table_t* vartable, const char* expected, const char* name, const char* value) {
+// Return 1 if "name=value" is present in table (for supplied action)
+static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* action, const char* name, const char* value) {
+    if (strcmp(name, action) != 0) return 0;
+
     const char* vars = apr_table_getm(p, vartable, name);
     if (!vars) return 0;
 
@@ -1043,10 +1045,22 @@ static int apr_table_exists_(apr_pool_t* p, const apr_table_t* vartable, const c
     return !pcre_exec(regex, NULL, vars, strlen(vars), 0, 0, 0, 0);
 }
 
-// Return 1 if "name=value" is present in table for tags & logdata
+// Return 1 if "name=value" is present in table for tags, logdata (and others)
 static int action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* name, const char* value) {
-    if (strcmp(name, "logdata") == 0 && apr_table_exists_(p, vartable, "logdata", name, value)) return 1;
-    if (strcmp(name, "tag")     == 0 && apr_table_exists_(p, vartable, "tag",     name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "capture",    name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "chain",      name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "initcol",    name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "logdata",    name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "tag",        name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "tsetuidag",              name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "setrsc",                 name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "setsid",               name, value)) return 1;
     return 0;
 }
 

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1047,21 +1047,20 @@ static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, c
 
 // Return 1 if "name=value" is present in table for tags, logdata (and others)
 static int action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* name, const char* value) {
-    if (apr_table_action_exists(p, vartable, "capture",    name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "chain",      name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "initcol",    name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "logdata",    name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "tag",        name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "tsetuidag",              name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "setrsc",                 name, value)) return 1;
-    if (apr_table_action_exists(p, vartable, "setsid",               name, value)) return 1;
-    return 0;
+if (apr_table_action_exists(p, vartable, "capture", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "chain", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "initcol", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "logdata", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setrsc", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setsid", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setuid", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "tag", name, value)) return 1;    return 0;
 }
 
 /**


### PR DESCRIPTION
This adds a little check before adding tags and logdata to the actions, to ensure this is not already present in the table.
In case of redundant (thus exactly identical) tags, it avoids the tag being logged multiple times. Same for logdata.
This redundancy is common when using macros that adds some tags/logdata at different places.

Remark 1: This avoids duplicates in the ruleset table which is allocated in the ruleset pool that stays for the whole process life. This frees thus some memory.
Therefore, I also added other actions that have no mean to be redundant and cannot be "undone" by another action. This memory optimization is not so minor as the ruleset is duplicated in each sub-location.

Remark 2: We could also free memory for all the actions that can only have one value, like severity, by applying the opposite rule: removing everything but the last action. This could also be achieved by a cleanup process, instead of "inline" like my test. But that's another story ...