### PR TITLE
Fix memory leak in streams

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Fix memory leak in streams
+   [Issue #2208 - @marcstern, @vloup, @JamesColeman-LW]
  * mlogc log-line parsing fails due to enhanced timestamp
    [Issue #2682 - @bozhinov, @ABrauer-CPT, @martinhsv]
  * Allow no-key, single-value JSON body

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -325,6 +325,21 @@ static apr_status_t modsecurity_tx_cleanup(void *data) {
     #endif
 #endif
 
+    /* Streams cleanup. */
+    if (msr->stream_input_data != NULL) {
+        free(msr->stream_input_data);
+        msr->stream_input_data = NULL;
+        msr->stream_input_length = 0;
+#ifdef MSC_LARGE_STREAM_INPUT
+        msr->stream_input_allocated_length = 0;
+#endif
+    }
+    if (msr->stream_output_data != NULL) {
+        free(msr->stream_output_data);
+        msr->stream_output_data = NULL;
+        msr->stream_output_length = 0;
+    }
+
     return APR_SUCCESS;
 }
 


### PR DESCRIPTION
As suggested by @JamesColeman-LW, here is a PR that fixes #2208.

All the credits goes to @marcstern for finding the root cause of the memory leak, I just did share my memory graph and added an extra ifdef.