### PR TITLE
Fix build errors with multiple Lua libraries

### DIFF
--- a/build/lua.m4
+++ b/build/lua.m4
@@ -6,7 +6,7 @@ AC_DEFUN([CHECK_LUA],
 [dnl
 
 # Possible names for the lua library/package (pkg-config)
-LUA_POSSIBLE_LIB_NAMES="lua54 lua5.4 lua-5.4 lua53 lua5.3 lua-5.3 lua52 lua5.2 lua-5.2 lua51 lua5.1 lua-5.1 lua"
+LUA_POSSIBLE_LIB_NAMES="lua54 lua5.4 lua-5.4 lua53 lua5.3 lua-5.3 lua52 lua5.2 lua-5.2 lua51 lua5.1 lua-5.1 luajit-5.1 luajit lua"
 
 # Possible extensions for the library
 LUA_POSSIBLE_EXTENSIONS="so la sl dll dylib"
@@ -40,41 +40,41 @@ else
     else
         LUA_MANDATORY=no
     fi
-    for x in ${LUA_POSSIBLE_PATHS}; do
-        CHECK_FOR_LUA_AT(${x})
-        if test -n "${LUA_CFLAGS}"; then
-            break
-        fi
-    done
+    # Trying to figure out the version using pkg-config...
+    if test -n "${PKG_CONFIG}"; then
+        LUA_PKG_NAME=""
+        for x in ${LUA_POSSIBLE_LIB_NAMES}; do
+            if ${PKG_CONFIG} --exists ${x}; then
+                LUA_PKG_NAME="$x"
+                LUA_PKG_VERSION="`${PKG_CONFIG} ${LUA_PKG_NAME} --modversion`"
+                break
+            fi
+        done
+    fi
+    if test -n "${LUA_PKG_NAME}"; then
+        # Package was found using the pkg-config scripts
+        LUA_PKG_VERSION="`${PKG_CONFIG} ${LUA_PKG_NAME} --modversion`"
+        LUA_CFLAGS="`${PKG_CONFIG} ${LUA_PKG_NAME} --cflags`"
+        LUA_LDADD="`${PKG_CONFIG} ${LUA_PKG_NAME} --libs-only-l`"
+        LUA_LDFLAGS="`${PKG_CONFIG} ${LUA_PKG_NAME} --libs-only-L --libs-only-other`"
+        LUA_DISPLAY="${LUA_LDADD}, ${LUA_CFLAGS}"
+    case $LUA_PKG_VERSION in
+        (5.4*) LUA_CFLAGS="-DWITH_LUA_5_4 ${LUA_CFLAGS}" ; lua_5_4=1 ;;
+        (5.3*) LUA_CFLAGS="-DWITH_LUA_5_3 ${LUA_CFLAGS}" ; lua_5_3=1 ;;
+        (5.2*) LUA_CFLAGS="-DWITH_LUA_5_2 ${LUA_CFLAGS}" ; lua_5_2=1 ;;
+        (5.1*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
+        (2.0*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
+        (2.1*) LUA_CFLAGS="-DWITH_LUA_5_1 -DWITH_LUA_JIT_2_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
+    esac
+        AC_MSG_NOTICE([LUA pkg-config version: ${LUA_PKG_VERSION}])
+    fi
     if test -z "${LUA_CFLAGS}"; then
-     #Trying to figure out the version using pkg-config...
-        if test -n "${PKG_CONFIG}"; then
-            LUA_PKG_NAME=""
-            for x in ${LUA_POSSIBLE_LIB_NAMES}; do
-                if ${PKG_CONFIG} --exists ${x}; then
-                    LUA_PKG_NAME="$x"
-                    LUA_PKG_VERSION="`${PKG_CONFIG} ${LUA_PKG_NAME} --modversion`"
-                    break
-                fi
-            done
-        fi
-        if test -n "${LUA_PKG_NAME}"; then
-           # Package was found using the pkg-config scripts
-           LUA_PKG_VERSION="`${PKG_CONFIG} ${LUA_PKG_NAME} --modversion`"
-           LUA_CFLAGS="`${PKG_CONFIG} ${LUA_PKG_NAME} --cflags`"
-           LUA_LDADD="`${PKG_CONFIG} ${LUA_PKG_NAME} --libs-only-l`"
-           LUA_LDFLAGS="`${PKG_CONFIG} ${LUA_PKG_NAME} --libs-only-L --libs-only-other`"
-           LUA_DISPLAY="${LUA_LDADD}, ${LUA_CFLAGS}"
-        case $LUA_PKG_VERSION in
-           (5.1*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
-           (5.2*) LUA_CFLAGS="-DWITH_LUA_5_2 ${LUA_CFLAGS}" ; lua_5_2=1 ;;
-           (5.3*) LUA_CFLAGS="-DWITH_LUA_5_3 ${LUA_CFLAGS}" ; lua_5_3=1 ;;
-           (5.4*) LUA_CFLAGS="-DWITH_LUA_5_4 ${LUA_CFLAGS}" ; lua_5_4=1 ;;
-           (2.0*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
-           (2.1*) LUA_CFLAGS="-DWITH_LUA_5_1 -DWITH_LUA_JIT_2_1 ${LUA_CFLAGS}" ; lua_5_1=1 ;;
-        esac
-           AC_MSG_NOTICE([LUA pkg-config version: ${LUA_PKG_VERSION}])
-        fi
+        for x in ${LUA_POSSIBLE_PATHS}; do
+            CHECK_FOR_LUA_AT(${x})
+            if test -n "${LUA_CFLAGS}"; then
+                break
+            fi
+        done
     fi
 fi
 


### PR DESCRIPTION
This commit fixes two items:

1. Previously `configure` would search for Lua in known paths, but
this could cause the Makefile to use inconsistent header and library
paths. For example, if luajit were installed in `/usr/local/include`
but lua 5.1 were installed in `/usr/lib/liblua-5.1.so`, the build
would attempt to use the luajit headers but link against the lua 5.1
library.

To fix this, we switch the order of the search:

* First attempt to find an installed LUA library with `pkg-config`. 
* If we cannot find a library that way, fall back to the known-path
scan.

This is actually what is already documented in `LUA_POSSIBLE_PATHS`.

Note that `PKG_CONFIG_PATH` can be specified in `configure` to look in the right path:

```shell
PKG_CONFIG_PATH=/usr/local/pkgconfig ./configure
```

2. Add luajit back into `LUA_POSSIBLE_LIB_NAMES`. This was added in
0ac23a47 but quietly reverted in fe98ce4c. The changes in the first
item also ensure the `CFLAGS` are set properly for luajit.

This should fix the issues raised in #1909.