### PR TITLE
Support PCRE2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Support PCRE2
+    [Issue #2668 - @martinhsv]
   - Support SecRequestBodyNoFilesLimit
     [Issue #2670 - @airween, @martinhsv]
   - Fix misuses of LMDB API

--- a/build/pcre2.m4
+++ b/build/pcre2.m4
@@ -1,0 +1,183 @@
+dnl Check for PCRE2 Libraries
+dnl CHECK_PCRE2(ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND])
+
+AC_DEFUN([PROG_PCRE2], [
+
+# Possible names for the pcre2 library/package (pkg-config)
+PCRE2_POSSIBLE_LIB_NAMES="pcre2 pcre2-8"
+
+# Possible extensions for the library
+PCRE2_POSSIBLE_EXTENSIONS="so so0 la sl dll dylib so.0.0.0"
+
+# Possible paths (if pkg-config was not found, proceed with the file lookup)
+PCRE2_POSSIBLE_PATHS="/usr/lib /usr/local/lib /usr/local/libpcre2-8 /usr/local/pcre2 /usr/local /opt/libpcre2-8 /opt/pcre2 /opt /usr /usr/lib64 /opt/local"
+
+# Variables to be set by this very own script.
+PCRE2_VERSION=""
+PCRE2_CFLAGS=""
+PCRE2_CPPFLAGS=""
+PCRE2_LDADD=""
+PCRE2_LDFLAGS=""
+
+AC_ARG_WITH(
+    pcre2,
+    AC_HELP_STRING(
+      [--with-pcre2=PATH],
+      [Path to pcre2 prefix or config script]
+    )
+)
+
+if test "x${with_pcre2}" == "xno"; then
+    AC_DEFINE(HAVE_PCRE2, 0, [Support for PCRE2 was disabled by the utilization of --without-pcre2 or --with-pcre2=no])
+    AC_MSG_NOTICE([Support for PCRE2 was disabled by the utilization of --without-pcre2 or --with-pcre2=no])
+    PCRE2_DISABLED=yes
+else
+    if test "x${with_pcre2}" == "xyes"; then
+        PCRE2_MANDATORY=yes
+        AC_MSG_NOTICE([PCRE2 support was marked as mandatory by the utilization of --with-pcre2=yes])
+    fi
+#        for x in ${PCRE2_POSSIBLE_LIB_NAMES}; do
+#            CHECK_FOR_PCRE2_AT(${x})
+#            if test -n "${PCRE2_VERSION}"; then
+#                break
+#            fi
+#        done
+
+#    if test "x${with_pcre2}" != "xyes" or test "x${with_pcre2}" == "xyes"; then
+        if test "x${with_pcre2}" == "x" || test "x${with_pcre2}" == "xyes"; then
+            # Nothing about PCRE2 was informed, using the pkg-config to figure things out.
+            if test -n "${PKG_CONFIG}"; then
+                PCRE2_PKG_NAME=""
+                for x in ${PCRE2_POSSIBLE_LIB_NAMES}; do
+                    if ${PKG_CONFIG} --exists ${x}; then
+                        PCRE2_PKG_NAME="$x"
+                        break
+                    fi
+                done
+            fi
+            AC_MSG_NOTICE([Nothing about PCRE2 was informed during the configure phase. Trying to detect it on the platform...])
+            if test -n "${PCRE2_PKG_NAME}"; then
+                # Package was found using the pkg-config scripts
+                PCRE2_VERSION="`${PKG_CONFIG} ${PCRE2_PKG_NAME} --modversion`"
+                PCRE2_CFLAGS="`${PKG_CONFIG} ${PCRE2_PKG_NAME} --cflags`"
+                PCRE2_LDADD="`${PKG_CONFIG} ${PCRE2_PKG_NAME} --libs-only-l`"
+                PCRE2_LDFLAGS="`${PKG_CONFIG} ${PCRE2_PKG_NAME} --libs-only-L --libs-only-other`"
+                PCRE2_DISPLAY="${PCRE2_LDADD}, ${PCRE2_CFLAGS}"
+            else
+                # If pkg-config did not find anything useful, go over file lookup.
+                for x in ${PCRE2_POSSIBLE_PATHS}; do
+                    CHECK_FOR_PCRE2_AT(${x})
+                    if test -n "${PCRE2_VERSION}"; then
+                        break
+                    fi
+                done
+            fi
+        fi
+        if test "x${with_pcre2}" != "x"; then
+            # An specific path was informed, lets check.
+            PCRE2_MANDATORY=yes
+            CHECK_FOR_PCRE2_AT(${with_pcre2})
+        fi
+#    fi
+fi
+
+if test -z "${PCRE2_LDADD}"; then
+    if test -z "${PCRE2_MANDATORY}"; then
+        if test -z "${PCRE2_DISABLED}"; then
+            AC_MSG_NOTICE([PCRE2 library was not found])
+            PCRE2_FOUND=0
+        else
+            PCRE2_FOUND=2
+        fi
+    else
+        AC_MSG_ERROR([PCRE2 was explicitly referenced but it was not found])
+        PCRE2_FOUND=-1
+    fi
+else
+    if test -z "${PCRE2_MANDATORY}"; then
+        PCRE2_FOUND=2
+        AC_MSG_NOTICE([PCRE2 is disabled by default.])
+    else
+        PCRE2_FOUND=1
+        AC_MSG_NOTICE([using PCRE2 v${PCRE2_VERSION}])
+        PCRE2_CFLAGS="-DWITH_PCRE2 ${PCRE2_CFLAGS}"
+        PCRE2_DISPLAY="${PCRE2_LDADD}, ${PCRE2_CFLAGS}"
+        AC_SUBST(PCRE2_VERSION)
+        AC_SUBST(PCRE2_LDADD)
+        AC_SUBST(PCRE2_LIBS)
+        AC_SUBST(PCRE2_LDFLAGS)
+        AC_SUBST(PCRE2_CFLAGS)
+        AC_SUBST(PCRE2_DISPLAY)
+    fi
+fi
+
+
+AC_SUBST(PCRE2_FOUND)
+
+]) # AC_DEFUN [PROG_PCRE2]
+
+
+AC_DEFUN([CHECK_FOR_PCRE2_AT], [
+    path=$1
+    echo "*** LOOKING AT PATH: " ${path}
+    for y in ${PCRE2_POSSIBLE_EXTENSIONS}; do
+        for z in ${PCRE2_POSSIBLE_LIB_NAMES}; do
+           if test -e "${path}/${z}.${y}"; then
+               pcre2_lib_path="${path}/"
+               pcre2_lib_name="${z}"
+               pcre2_lib_file="${pcre2_lib_path}/${z}.${y}"
+               break
+           fi
+           if test -e "${path}/lib${z}.${y}"; then
+               pcre2_lib_path="${path}/"
+               pcre2_lib_name="${z}"
+               pcre2_lib_file="${pcre2_lib_path}/lib${z}.${y}"
+               break
+           fi
+           if test -e "${path}/lib/lib${z}.${y}"; then
+               pcre2_lib_path="${path}/lib/"
+               pcre2_lib_name="${z}"
+               pcre2_lib_file="${pcre2_lib_path}/lib${z}.${y}"
+               break
+           fi
+           if test -e "${path}/lib/x86_64-linux-gnu/lib${z}.${y}"; then
+               pcre2_lib_path="${path}/lib/x86_64-linux-gnu/"
+               pcre2_lib_name="${z}"
+               pcre2_lib_file="${pcre2_lib_path}/lib${z}.${y}"
+               break
+           fi
+           if test -e "${path}/lib/i386-linux-gnu/lib${z}.${y}"; then
+               pcre2_lib_path="${path}/lib/i386-linux-gnu/"
+               pcre2_lib_name="${z}"
+               pcre2_lib_file="${pcre2_lib_path}/lib${z}.${y}"
+               break
+           fi
+       done
+       if test -n "$pcre2_lib_path"; then
+           break
+       fi
+    done
+    if test -e "${path}/include/pcre2.h"; then
+        pcre2_inc_path="${path}/include"
+    elif test -e "${path}/pcre2.h"; then
+        pcre2_inc_path="${path}"
+    elif test -e "${path}/include/pcre2/pcre2.h"; then
+        pcre2_inc_path="${path}/include"
+    fi
+
+    if test -n "${pcre2_lib_path}"; then
+        AC_MSG_NOTICE([PCRE2 library found at: ${pcre2_lib_file}])
+    fi
+
+    if test -n "${pcre2_inc_path}"; then
+        AC_MSG_NOTICE([PCRE2 headers found at: ${pcre2_inc_path}])
+    fi
+
+    if test -n "${pcre2_lib_path}" -a -n "${pcre2_inc_path}"; then
+        # TODO: Compile a piece of code to check the version.
+        PCRE2_CFLAGS="-I${pcre2_inc_path}"
+        PCRE2_LDADD="-l${pcre2_lib_name}"
+        PCRE2_LDFLAGS="-L${pcre2_lib_path}"
+        PCRE2_DISPLAY="${pcre2_lib_file}, ${pcre2_inc_path}"
+    fi
+]) # AC_DEFUN [CHECK_FOR_PCRE2_AT]

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,13 @@ CHECK_LIBXML2
 CHECK_PCRE
 
 
+#
+# Check for pcre2
+#
+PROG_PCRE2
+AM_CONDITIONAL([PCRE2_CFLAGS], [test "PCRE2_CFLAGS" != ""])
+
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([string])
@@ -554,6 +561,23 @@ if test "x$LUA_FOUND" = "x2"; then
     echo "   + LUA                                           ....disabled"
 fi
 
+
+## PCRE2
+if test "x$PCRE2_FOUND" = "x0"; then
+    echo "   + PCRE2                                          ....not found"
+fi
+if test "x$PCRE2_FOUND" = "x1"; then
+    echo -n "   + PCRE2                                          ....found "
+    if ! test "x$PCRE2_VERSION" = "x"; then
+        echo "v${PCRE2_VERSION}"
+    else
+        echo ""
+    fi
+    echo "      ${PCRE2_DISPLAY}"
+fi
+if test "x$PCRE2_FOUND" = "x2"; then
+    echo "   + PCRE2                                          ....disabled"
+fi
 
 echo " "
 echo " Other Options"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -324,6 +324,7 @@ libmodsecurity_la_CPPFLAGS = \
 	$(YAJL_CFLAGS) \
 	$(LMDB_CFLAGS) \
 	$(PCRE_CFLAGS) \
+	$(PCRE2_CFLAGS) \
 	$(SSDEEP_CFLAGS) \
 	$(MAXMIND_CFLAGS) \
 	$(LUA_CFLAGS) \
@@ -339,6 +340,7 @@ libmodsecurity_la_LDFLAGS = \
 	$(LMDB_LDFLAGS) \
 	$(LUA_LDFLAGS) \
 	$(PCRE_LDFLAGS) \
+	$(PCRE2_LDFLAGS) \
 	$(SSDEEP_LDFLAGS) \
 	$(MAXMIND_LDFLAGS) \
 	$(YAJL_LDFLAGS) \
@@ -355,6 +357,7 @@ libmodsecurity_la_LIBADD = \
 	../others/libinjection.la \
 	../others/libmbedtls.la \
 	$(PCRE_LDADD) \
+	$(PCRE2_LDADD) \
 	$(MAXMIND_LDADD) \
 	$(SSDEEP_LDADD) \
 	$(YAJL_LDADD)

--- a/src/operators/verify_cc.h
+++ b/src/operators/verify_cc.h
@@ -16,7 +16,14 @@
 #ifndef SRC_OPERATORS_VERIFY_CC_H_
 #define SRC_OPERATORS_VERIFY_CC_H_
 
+#if WITH_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#else
 #include <pcre.h>
+#endif
+
+
 #include <string>
 #include <memory>
 #include <utility>
@@ -32,7 +39,11 @@ class VerifyCC : public Operator {
     explicit VerifyCC(std::unique_ptr<RunTimeString> param)
         : Operator("VerifyCC", std::move(param)),
         m_pc(NULL),
+#if WITH_PCRE2
+        m_match_data(NULL) { }
+#else
         m_pce(NULL) { }
+#endif
     ~VerifyCC();
 
     bool evaluate(Transaction *t, RuleWithActions *rule,
@@ -40,8 +51,13 @@ class VerifyCC : public Operator {
         std::shared_ptr<RuleMessage> ruleMessage)  override;
     bool init(const std::string &param, std::string *error) override;
  private:
+#if WITH_PCRE2
+    pcre2_code *m_pc;
+    pcre2_match_data *m_match_data;
+#else
     pcre *m_pc;
     pcre_extra *m_pce;
+#endif
     static int luhnVerify(const char *ccnumber, int len);
 };
 

--- a/src/utils/regex.h
+++ b/src/utils/regex.h
@@ -12,8 +12,12 @@
  * directly using the email address security@modsecurity.org.
  *
  */
-
+#if WITH_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#else
 #include <pcre.h>
+#endif
 
 #include <iostream>
 #include <fstream>
@@ -76,8 +80,13 @@ class Regex {
 
     const std::string pattern;
  private:
+#if WITH_PCRE2
+    pcre2_code *m_pc;
+    pcre2_match_data *m_match_data;
+#else
     pcre *m_pc = NULL;
     pcre_extra *m_pce = NULL;
+#endif
 };
 
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -50,6 +50,7 @@ unit_tests_LDADD = \
 	$(LMDB_LDADD) \
 	$(LUA_LDADD) \
 	$(PCRE_LDADD) \
+	$(PCRE2_LDADD) \
 	$(SSDEEP_LDADD) \
 	$(YAJL_LDADD)
 
@@ -81,6 +82,7 @@ unit_tests_CPPFLAGS = \
 	$(GLOBAL_CPPFLAGS) \
 	$(LMDB_CFLAGS) \
 	$(PCRE_CFLAGS) \
+	$(PCRE2_CFLAGS) \
 	$(YAJL_CFLAGS) \
 	$(LUA_CFLAGS) \
 	$(SSDEEP_CFLAGS) \
@@ -104,6 +106,7 @@ regression_tests_LDADD = \
 	$(LMDB_LDADD) \
 	$(LUA_LDADD) \
 	$(PCRE_LDADD) \
+	$(PCRE2_LDADD) \
 	$(SSDEEP_LDADD) \
 	$(YAJL_LDADD)
 
@@ -137,6 +140,7 @@ regression_tests_CPPFLAGS = \
 	$(LUA_CFLAGS) \
 	$(SSDEEP_CFLAGS) \
 	$(PCRE_CFLAGS) \
+	$(PCRE2_CFLAGS) \
 	$(YAJL_CFLAGS) \
 	$(LIBXML2_CFLAGS)
 
@@ -157,6 +161,7 @@ rules_optimization_LDADD = \
 	$(LMDB_LDADD) \
 	$(LUA_LDADD) \
 	$(PCRE_LDADD) \
+	$(PCRE2_LDADD) \
 	$(SSDEEP_LDADD) \
 	$(YAJL_LDADD)
 
@@ -188,6 +193,7 @@ rules_optimization_CPPFLAGS = \
 	$(LUA_CFLAGS) \
 	$(SSDEEP_CFLAGS) \
 	$(PCRE_CFLAGS) \
+	$(PCRE2_CFLAGS) \
 	$(YAJL_CFLAGS) \
 	$(LIBXML2_CFLAGS)
 


### PR DESCRIPTION
This pull request provides initial support for PCRE2 on an experimental basis. (Closes #2668 )

To use PCRE2 with nginx and ModSecurity you need to:
- use a version of nginx that supports it (e.g. nginx v1.21.5 or 1.21.6)
- use a version of the connector (ModSecurity-nginx) at or later than https://github.com/SpiderLabs/ModSecurity-nginx/commit/1c32794046c9e0065d4ad58f949fabb538c44222
- include the ```--with-pcre2``` option when running ModSecurity's ```./configure```
