### PR TITLE
Tolerate other parameters after boundary in multipart C-T

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Tolerate other parameters after boundary in multipart C-T
+    [Issue #1900 - @martinhsv]
   - Add DebugLog message for bad pattern in rx operator
     [Issue #2723 - @martinhsv]
   - Support PCRE2

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -1375,6 +1375,16 @@ bool Multipart::init(std::string *error) {
             return false;
         }
 
+        /* Some frameworks are known to incorrectly include a charset= parameter */
+        /* after the boundary. Doing so is not RFC-compliant, but we will tolerate it.*/
+        if (boundary_characters_valid(m_boundary.c_str()) != 1) {
+            size_t semicolon_after_boundary = m_boundary.find(';');
+            if (semicolon_after_boundary != std::string::npos) {
+                ms_dbg_a(m_transaction, 3,
+                    "Multipart: Invalid parameter after boundary in C-T (tolerated).");
+                m_boundary = m_boundary.substr(0, semicolon_after_boundary);
+            }
+        }
         /* Validate the characters used in the boundary. */
         if (boundary_characters_valid(m_boundary.c_str()) != 1) {
             m_flag_error = 1;

--- a/test/test-cases/regression/request-body-parser-multipart.json
+++ b/test/test-cases/regression/request-body-parser-multipart.json
@@ -3239,5 +3239,60 @@
         "SecRuleEngine On",
         "SecRule MULTIPART_UNMATCHED_BOUNDARY \"@eq 1\" \"phase:2,deny,id:500095\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"multipart parser (C-T parm after boundary -- invalid but tolerated)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"145",
+        "Content-Type":"multipart/form-data; boundary=00000000; charset=UTF-8",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+                "--00000000\r",
+                "Content-Disposition: form-data; name=\"namea\"\r",
+                "\r",
+                "111\r",
+                "--00000000\r",
+                "Content-Disposition: form-data; name=\"nameb\"\r",
+                "\r",
+                "222\r",
+                "--00000000--\r"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403,
+      "debug_log":"Multipart: Invalid parameter after boundary in C-T \\(tolerated\\).*Added data"
+    },
+    "rules":[
+        "SecRuleEngine On",
+        "SecRequestBodyAccess On",
+        "SecRule ARGS:namea \"@streq 111\" \"phase:2,deny,id:500096\""
+    ]
   }
 ]


### PR DESCRIPTION
This pull request supports permissively handling a Content-Type header for a multipart request, where the header incorrectly has additional parameters after the boundary. A debug log message is produced for this use case, but processing can otherwise continue as if the extra parameter(s) had not been present.
