### PR TITLE
Add SecArgumentsLimit to modsecurity.conf-recommended

### DIFF
--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -57,6 +57,16 @@ SecRequestBodyLimitAction Reject
 #
 SecRequestBodyJsonDepthLimit 512
 
+# Maximum number of args allowed per request. You want to keep this
+# value as low as practical. The value should match that in rule 200007.
+SecArgumentsLimit 1000
+
+# If SecArgumentsLimit has been set, you probably want to reject any
+# request body that has only been partly parsed. The value used in this
+# rule should match what was used with SecArgumentsLimit
+SecRule &ARGS "@ge 1000" \
+"id:'200007', phase:2,t:none,log,deny,status:400,msg:'Failed to fully parse request body due to large argument count',severity:2"
+
 # Verify that we've correctly processed the request body.
 # As a rule of thumb, when failing to process a request body
 # you should reject the request (when deployed in blocking mode)


### PR DESCRIPTION
As of v3.0.5, libModSecurity has included (via #2234) a configuration directive called SecArgumentsLimit that can help protect against certain performance impacts. There is no default value, so if the configuration item is not specified, the limit is not used.

This pull request does not add any new functionality. It only supplies a default value in modsecurity.conf-recommended, along with a new rule to also reject requests that exceed the limit.

The goal here is merely to make it simpler for users (especially new users) to produce a usable and safe configuration.

Community input is welcome, particularly if:
- you think including this is a bad idea in general
- you think the default value of 1000 is too low for a substantial percentage of deployments

(The current plan is to include this in v3.0.7, which is likely to be published within 2 weeks or less.)
