### PR TITLE
Feature request: adding severity in ModSecurityIntervention

### DIFF
--- a/headers/modsecurity/intervention.h
+++ b/headers/modsecurity/intervention.h
@@ -26,6 +26,7 @@ typedef struct ModSecurityIntervention_t {
     char *url;
     char *log;
     int disruptive;
+    int severity;
 } ModSecurityIntervention;
 
 #ifdef __cplusplus
@@ -34,6 +35,7 @@ namespace intervention {
         i->status = 200;
         i->pause = 0;
         i->disruptive = 0;
+        i->severity = 0;
     }
 
     static void clean(ModSecurityIntervention_t *i) {

--- a/src/actions/disruptive/allow.cc
+++ b/src/actions/disruptive/allow.cc
@@ -55,6 +55,9 @@ bool Allow::evaluate(RuleWithActions *rule, Transaction *transaction) {
         + allowTypeToName(m_allowType));
 
     transaction->m_allowType = m_allowType;
+    if (rule->hasSeverity()) {
+        transaction->m_it.severity = rule->severity();
+    }
 
     return true;
 }

--- a/src/actions/disruptive/deny.cc
+++ b/src/actions/disruptive/deny.cc
@@ -41,6 +41,9 @@ bool Deny::evaluate(RuleWithActions *rule, Transaction *transaction,
     rm->m_isDisruptive = true;
     transaction->m_it.log = strdup(
         rm->log(RuleMessage::LogMessageInfo::ClientLogMessageInfo).c_str());
+    if (rule->hasSeverity()) {
+        transaction->m_it.severity = rule->severity();
+    }
 
     return true;
 }

--- a/src/actions/disruptive/drop.cc
+++ b/src/actions/disruptive/drop.cc
@@ -46,6 +46,9 @@ bool Drop::evaluate(RuleWithActions *rule, Transaction *transaction,
     rm->m_isDisruptive = true;
     transaction->m_it.log = strdup(
         rm->log(RuleMessage::LogMessageInfo::ClientLogMessageInfo).c_str());
+    if (rule->hasSeverity()) {
+        transaction->m_it.severity = rule->severity();
+    }
 
     return true;
 }

--- a/src/actions/disruptive/pass.cc
+++ b/src/actions/disruptive/pass.cc
@@ -35,6 +35,9 @@ bool Pass::evaluate(RuleWithActions *rule, Transaction *transaction,
     intervention::reset(&transaction->m_it);
 
     ms_dbg_a(transaction, 8, "Running action pass");
+    if (rule->hasSeverity()) {
+        transaction->m_it.severity = rule->severity();
+    }
 
     return true;
 }

--- a/src/actions/disruptive/redirect.cc
+++ b/src/actions/disruptive/redirect.cc
@@ -50,6 +50,9 @@ bool Redirect::evaluate(RuleWithActions *rule, Transaction *transaction,
     rm->m_isDisruptive = true;
     transaction->m_it.log = strdup(
         rm->log(RuleMessage::LogMessageInfo::ClientLogMessageInfo).c_str());
+    if (rule->hasSeverity()) {
+        transaction->m_it.severity = rule->severity();
+    }
 
     return true;
 }

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1066,6 +1066,7 @@ int Transaction::appendRequestBody(const unsigned char *buf, size_t len) {
                             "reject the request");
                     m_it.status = 403;
                     m_it.disruptive = true;
+                    m_it.severity = 0;
                 } else {
                     ms_dbg(5, "Not rejecting the request as the engine is " \
                         "not Enabled");
@@ -1325,6 +1326,7 @@ int Transaction::appendResponseBody(const unsigned char *buf, size_t len) {
                         "the request");
                     m_it.status = 403;
                     m_it.disruptive = true;
+                    m_it.severity = 0;
                 } else {
                     ms_dbg(5, "Not rejecting the request as the engine is " \
                         "not Enabled");
@@ -1474,6 +1476,7 @@ bool Transaction::intervention(ModSecurityIntervention *it) {
         }
         it->disruptive = m_it.disruptive;
         it->status = m_it.status;
+        it->severity = m_it.severity;
 
         if (m_it.log != NULL) {
             std::string log("");

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1476,7 +1476,6 @@ bool Transaction::intervention(ModSecurityIntervention *it) {
         }
         it->disruptive = m_it.disruptive;
         it->status = m_it.status;
-        it->severity = m_it.severity;
 
         if (m_it.log != NULL) {
             std::string log("");
@@ -1487,6 +1486,7 @@ bool Transaction::intervention(ModSecurityIntervention *it) {
         }
         intervention::reset(&m_it);
     }
+    it->severity = m_it.severity;
 
     return it->disruptive;
 }


### PR DESCRIPTION
Hi, I think would be very useful adding in `ModSecurityIntervention` a `severity` field populated by disruptives `evaluate` function.  
In this way a connector can use the `intervention.log` based the `severity` of the log.  

For example https://github.com/SpiderLabs/ModSecurity-nginx/issues/274