### PR TITLE
Fix: negative usec on log line when data type long is 32b

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Fix: negative usec on log line when data type long is 32b
+   [Issue #2753 - @ABrauer-CPT, @martinhsv]
  * mlogc log-line parsing fails due to enhanced timestamp
    [Issue #2682 - @bozhinov, @ABrauer-CPT, @martinhsv]
  * Allow no-key, single-value JSON body

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -1134,7 +1134,7 @@ char *current_logtime(apr_pool_t *mp) {
 
     apr_strftime(tstr, &len, 80, "%d/%b/%Y:%H:%M:%S.", &t);
     apr_snprintf(tstr + strlen(tstr), 80 - strlen(tstr), "%06ld %c%.2d%.2d",
-            ((long)now) % 1000000L,
+            (long)apr_time_usec(now),
             t.tm_gmtoff < 0 ? '-' : '+',
             t.tm_gmtoff / (60 * 60), (t.tm_gmtoff / 60) % 60);
     return apr_pstrdup(mp, tstr);


### PR DESCRIPTION
In environments where the data type 'long' is only 32 bits, the milliseconds portion of the timestamp in a log line may appear as a negative number.