### PR TITLE
Prevent LMDB related segfault for #2755

### DIFF
--- a/src/collection/backend/lmdb.h
+++ b/src/collection/backend/lmdb.h
@@ -83,10 +83,13 @@ class MDBEnvProvider {
     }
     MDB_env* GetEnv();
     MDB_dbi* GetDBI();
+    bool isValid();
+
     ~MDBEnvProvider();
  private:
     MDB_env *m_env;
     MDB_dbi m_dbi;
+    bool valid;
 
     MDBEnvProvider();
 };


### PR DESCRIPTION
Make transactions no-op if the file handle is invalid (due to permissions, or other reasons like lmdb library mismatch).