### PR TITLE
Removing getentropy dependency for wasm build

### DIFF
--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -163,8 +163,9 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, void *logCbData)
     m_logCbData(logCbData),
     TransactionAnchoredVariables(this) {
     m_id = std::unique_ptr<std::string>( new std::string(
-        std::to_string(m_timeStamp)
-        + std::to_string(modsecurity::utils::generate_transaction_unique_id())));
+        std::to_string(m_timeStamp)));
+        //+ std::to_string(modsecurity::utils::generate_transaction_unique_id())));
+        // Wasm VM does not support the random generation that involves a file system operation
 
     m_variableUrlEncodedError.set("0", 0);
 


### PR DESCRIPTION
This PR reverts https://github.com/SpiderLabs/ModSecurity/pull/2758/commits/14c94e2eb2b32709a1b97c41de65ca4580b87b7e. Wasm VM does not support the random generation that involves a file system operation, therefore it leads to a runtime error of libmodsecurity built for wasm.
Error:
```
[1943897][error][wasm] [source/extensions/common/wasm/wasm_vm.cc:38] Failed to load Wasm module due to a missing import: env.getentropy
[1943897][error][wasm] [source/extensions/common/wasm/wasm.cc:109] Wasm VM failed Failed to initialize Wasm code
```
I opened it as a draft PR in order to further think about it and see thoughts about possible alternative implementations/inclusions of the missing dependency.

Open to any discussion about it!