### PR TITLE
Fix logging for Apache 2.4 (again)

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -25,12 +25,6 @@
 #include "apr_optional.h"
 #include "mod_log_config.h"
 
-/*
- * #ifdef APLOG_USE_MODULE
- * APLOG_USE_MODULE(security2);
- * #endif
- */
-
 #include "msc_logging.h"
 #include "msc_util.h"
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -145,6 +145,9 @@ extern DSOLOCAL char *real_server_signature;
 extern DSOLOCAL char *chroot_dir;
 
 extern module AP_MODULE_DECLARE_DATA security2_module;
+#ifdef APLOG_USE_MODULE
+    APLOG_USE_MODULE(security2);
+#endif
 
 extern DSOLOCAL const command_rec module_directives[];
 


### PR DESCRIPTION
There was a fix for Apache 2.4 logging in https://github.com/SpiderLabs/ModSecurity/commit/f813365f, which was partly reverted by https://github.com/SpiderLabs/ModSecurity/commit/da995bb6. 

Unfortunately, this reversion also removed the APLOG_USE_MODULE macro , which most likely wasn't causing any issues but is needed for Apache log messages to be correctly marked as belonging to mod_security2 module (i.e. `%m` token in https://httpd.apache.org/docs/2.4/mod/core.html#errorlogformat).

This pull request restores the APLOG_USE_MODULE, also adds it globally so all `ap_log_error` messages in all files are marked as belonging to mod_security2 module.