### PR TITLE
[dev/Wasm] Removing unsupported try catch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "string": "cpp",
+        "charconv": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "string": "cpp",
-        "charconv": "cpp"
-    }
-}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+The latest versions of both v2.9.x and v3.0.x are supported.
+
+## Reporting a Vulnerability
+
+For information on how to report a security issue, please see https://github.com/SpiderLabs/ModSecurity#security-issue

--- a/src/actions/accuracy.cc
+++ b/src/actions/accuracy.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <charconv>
 
 #include "modsecurity/actions/action.h"
 #include "modsecurity/transaction.h"
@@ -28,9 +29,8 @@ namespace actions {
 
 
 bool Accuracy::init(std::string *error) {
-    try {
-        m_accuracy = std::stoi(m_parser_payload);
-    }  catch (...) {
+    const auto conv_res = std::from_chars(m_parser_payload.data(), m_parser_payload.data() + m_parser_payload.size(), m_accuracy);
+    if (conv_res.ec == std::errc::invalid_argument) {
         error->assign("Accuracy: The input \"" + m_parser_payload + "\" is " \
             "not a number.");
         return false;

--- a/src/actions/ctl/rule_remove_target_by_id.cc
+++ b/src/actions/ctl/rule_remove_target_by_id.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <charconv>
 
 #include "modsecurity/transaction.h"
 #include "src/utils/string.h"
@@ -38,9 +39,8 @@ bool RuleRemoveTargetById::init(std::string *error) {
         return false;
     }
 
-    try {
-        m_id = std::stoi(param[0]);
-    } catch(...) {
+    const auto conv_res = std::from_chars(param[0].data(), param[0].data() + param[0].size(), m_id);
+    if (conv_res.ec == std::errc::invalid_argument) {
         error->assign("Not able to convert '" + param[0] +
             "' into a number");
         return false;

--- a/src/actions/data/status.cc
+++ b/src/actions/data/status.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <charconv>
 
 #include "modsecurity/transaction.h"
 
@@ -27,9 +28,8 @@ namespace actions {
 namespace data {
 
 bool Status::init(std::string *error) {
-    try {
-        m_status = std::stoi(m_parser_payload);
-    } catch (...) {
+    const auto conv_res = std::from_chars(m_parser_payload.data(), m_parser_payload.data() + m_parser_payload.size(), m_status);
+    if (conv_res.ec == std::errc::invalid_argument) {
         error->assign("Not a valid number: " + m_parser_payload);
         return false;
     }

--- a/src/actions/maturity.cc
+++ b/src/actions/maturity.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <charconv>
 
 #include "modsecurity/actions/action.h"
 #include "modsecurity/transaction.h"
@@ -28,9 +29,10 @@ namespace actions {
 
 
 bool Maturity::init(std::string *error) {
-    try {
-        m_maturity = std::stoi(m_parser_payload);
-    }  catch (...) {
+
+    const auto conv_res = std::from_chars(m_parser_payload.data(), m_parser_payload.data() + m_parser_payload.size(), m_maturity);
+    if (conv_res.ec == std::errc::invalid_argument) {
+        // Conversion error
         error->assign("Maturity: The input \"" + m_parser_payload + "\" is " \
             "not a number.");
         return false;

--- a/src/actions/rule_id.cc
+++ b/src/actions/rule_id.cc
@@ -40,15 +40,6 @@ bool RuleId::init(std::string *error) {
         return false;
     }
 
-    // try {
-    //     m_ruleId = std::stod(a);
-    // } catch (...) {
-    //     m_ruleId = 0;
-    //     error->assign("The input \"" + a + "\" does not " \
-    //         "seems to be a valid rule id.");
-    //     return false;
-    // }
-
     std::ostringstream oss;
     oss << std::setprecision(40) << m_ruleId;
     if (a != oss.str() || m_ruleId < 0) {

--- a/src/actions/rule_id.cc
+++ b/src/actions/rule_id.cc
@@ -17,7 +17,7 @@
 
 #include <iostream>
 #include <string>
-#include <charconv>
+#include <sstream>
 
 #include "modsecurity/transaction.h"
 #include "modsecurity/rule.h"
@@ -28,11 +28,12 @@ namespace actions {
 
 bool RuleId::init(std::string *error) {
     std::string a = m_parser_payload;
-
-    const auto format = std::chars_format::fixed;
-    const auto conv_res = std::from_chars(a.data(), a.data() + a.size(), m_ruleId, format);
-    if (conv_res.ec == std::errc::invalid_argument || conv_res.ec == std::errc::result_out_of_range) {
-        // Conversion error
+    
+    std::stringstream ss;
+    ss<<a;
+    ss>>m_ruleId;
+    if (ss.fail()) {
+        ss.clear();
         m_ruleId = 0;
         error->assign("The input \"" + a + "\" does not " \
             "seems to be a valid rule id.");

--- a/src/actions/rule_id.cc
+++ b/src/actions/rule_id.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <charconv>
 
 #include "modsecurity/transaction.h"
 #include "modsecurity/rule.h"
@@ -28,14 +29,24 @@ namespace actions {
 bool RuleId::init(std::string *error) {
     std::string a = m_parser_payload;
 
-    try {
-        m_ruleId = std::stod(a);
-    } catch (...) {
+    const auto format = std::chars_format::fixed;
+    const auto conv_res = std::from_chars(a.data(), a.data() + a.size(), m_ruleId, format);
+    if (conv_res.ec == std::errc::invalid_argument || conv_res.ec == std::errc::result_out_of_range) {
+        // Conversion error
         m_ruleId = 0;
         error->assign("The input \"" + a + "\" does not " \
             "seems to be a valid rule id.");
         return false;
     }
+
+    // try {
+    //     m_ruleId = std::stod(a);
+    // } catch (...) {
+    //     m_ruleId = 0;
+    //     error->assign("The input \"" + a + "\" does not " \
+    //         "seems to be a valid rule id.");
+    //     return false;
+    // }
 
     std::ostringstream oss;
     oss << std::setprecision(40) << m_ruleId;

--- a/src/actions/severity.cc
+++ b/src/actions/severity.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <charconv>
 
 #include "modsecurity/rules_set.h"
 #include "modsecurity/actions/action.h"
@@ -58,15 +59,14 @@ bool Severity::init(std::string *error) {
         m_severity = 7;
         return true;
     } else {
-        try {
-            m_severity = std::stoi(a);
-            return true;
-        }  catch (...) {
+        const auto conv_res = std::from_chars(a.data(), a.data() + a.size(), m_severity);
+        if (conv_res.ec == std::errc::invalid_argument) {
             error->assign("Severity: The input \"" + a + "\" is " \
                 "not a number.");
+        } else {
+            return true;
         }
     }
-
     return false;
 }
 

--- a/src/actions/skip.cc
+++ b/src/actions/skip.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <charconv>
 
 #include "modsecurity/rules_set.h"
 #include "modsecurity/actions/action.h"
@@ -27,9 +28,8 @@ namespace actions {
 
 
 bool Skip::init(std::string *error) {
-    try {
-        m_skip_next = std::stoi(m_parser_payload);
-    }  catch (...) {
+    const auto conv_res = std::from_chars(m_parser_payload.data(), m_parser_payload.data() + m_parser_payload.size(), m_skip_next);
+    if (conv_res.ec == std::errc::invalid_argument) {
         error->assign("Skip: The input \"" + m_parser_payload + "\" is " \
             "not a number.");
         return false;

--- a/src/operators/eq.cc
+++ b/src/operators/eq.cc
@@ -16,6 +16,7 @@
 #include "src/operators/eq.h"
 
 #include <string>
+#include <charconv>
 
 #include "src/operators/operator.h"
 
@@ -29,14 +30,12 @@ bool Eq::evaluate(Transaction *transaction, const std::string &input) {
     int i = 0;
     std::string pt(m_string->evaluate(transaction));
 
-    try {
-        p = std::stoi(pt);
-    } catch (...) {
+    const auto conv_res = std::from_chars(pt.data(), pt.data() + pt.size(), p);
+    if (conv_res.ec == std::errc::invalid_argument) {
         p = 0;
     }
-    try {
-        i = std::stoi(input);
-    } catch (...) {
+    const auto conv_res2 = std::from_chars(input.data(), input.data() + input.size(), i);
+    if (conv_res2.ec == std::errc::invalid_argument) {
         i = 0;
     }
 

--- a/src/operators/fuzzy_hash.cc
+++ b/src/operators/fuzzy_hash.cc
@@ -38,9 +38,8 @@ bool FuzzyHash::init(const std::string &param2, std::string *error) {
     }
     digit.append(std::string(m_param, pos+1));
     file.append(std::string(m_param, 0, pos));
-    try {
-        m_threshold = std::stoi(digit);
-    } catch (...) {
+    const auto conv_res = std::from_chars(digit.data(), digit.data() + digit.size(), m_threshold);
+    if (conv_res.ec == std::errc::invalid_argument) {
         error->assign("Expecting a digit, got: " + digit);
         return false;
     }

--- a/src/operators/validate_byte_range.cc
+++ b/src/operators/validate_byte_range.cc
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <memory>
+#include <charconv>
 
 #include "src/operators/operator.h"
 
@@ -29,34 +30,29 @@ bool ValidateByteRange::getRange(const std::string &rangeRepresentation,
     int start;
     int end;
 
-    if (pos == std::string::npos) {
-        try {
-            start = std::stoi(rangeRepresentation);
-        } catch(...) {
+    if (pos == std::string::npos) {  
+        const auto conv_res = std::from_chars(rangeRepresentation.data(), rangeRepresentation.data() + rangeRepresentation.size(), start);
+        if (conv_res.ec == std::errc::invalid_argument) {
             error->assign("Not able to convert '" + rangeRepresentation +
                 "' into a number");
             return false;
         }
+
         table[start >> 3] = (table[start >> 3] | (1 << (start & 0x7)));
         return true;
     }
 
-    try {
-        start = std::stoi(std::string(rangeRepresentation, 0, pos));
-    } catch (...) {
-        error->assign("Not able to convert '" +
-            std::string(rangeRepresentation, 0, pos) +
-            "' into a number");
+    std::string to_be_converted(rangeRepresentation, 0, pos);
+    const auto conv_res2 = std::from_chars(to_be_converted.data(), to_be_converted.data() + to_be_converted.size(), start);
+    if (conv_res2.ec == std::errc::invalid_argument) {
+        error->assign("Not able to convert '" + to_be_converted + "' into a number");
         return false;
     }
 
-    try {
-        end = std::stoi(std::string(rangeRepresentation, pos + 1,
-            rangeRepresentation.length() - (pos + 1)));
-    } catch (...) {
-        error->assign("Not able to convert '" + std::string(rangeRepresentation,
-            pos + 1, rangeRepresentation.length() - (pos + 1)) +
-            "' into a number");
+    std::string to_be_converted2(rangeRepresentation, pos + 1, rangeRepresentation.length() - (pos + 1));
+    const auto conv_res3 = std::from_chars(to_be_converted2.data(), to_be_converted2.data() + to_be_converted2.size(), end);
+    if (conv_res3.ec == std::errc::invalid_argument) {
+        error->assign("Not able to convert '" + to_be_converted2 + "' into a number");
         return false;
     }
 

--- a/src/parser/location.hh
+++ b/src/parser/location.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.7.2.
+// A Bison parser, made by GNU Bison 3.8.2.
 
 // Locations for Bison parsers in C++
 
-// Copyright (C) 2002-2015, 2018-2020 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015, 2018-2021 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // As a special exception, you may create a larger work that contains
 // part or all of the Bison parser skeleton and distribute that work

--- a/src/parser/position.hh
+++ b/src/parser/position.hh
@@ -1,4 +1,4 @@
-// A Bison parser, made by GNU Bison 3.7.2.
+// A Bison parser, made by GNU Bison 3.8.2.
 
 // Starting with Bison 3.2, this file is useless: the structure it
 // used to define is now defined in "location.hh".

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.7.2.
+// A Bison parser, made by GNU Bison 3.8.2.
 
 // Skeleton implementation for Bison LALR(1) parsers in C++
 
-// Copyright (C) 2002-2015, 2018-2020 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015, 2018-2021 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // As a special exception, you may create a larger work that contains
 // part or all of the Bison parser skeleton and distribute that work
@@ -123,7 +123,7 @@
 #else // !YYDEBUG
 
 # define YYCDEBUG if (false) std::cerr
-# define YY_SYMBOL_PRINT(Title, Symbol)  YYUSE (Symbol)
+# define YY_SYMBOL_PRINT(Title, Symbol)  YY_USE (Symbol)
 # define YY_REDUCE_PRINT(Rule)           static_cast<void> (0)
 # define YY_STACK_PRINT()                static_cast<void> (0)
 
@@ -157,9 +157,9 @@ namespace yy {
   seclang_parser::syntax_error::~syntax_error () YY_NOEXCEPT YY_NOTHROW
   {}
 
-  /*---------------.
-  | symbol kinds.  |
-  `---------------*/
+  /*---------.
+  | symbol.  |
+  `---------*/
 
 
 
@@ -1195,7 +1195,7 @@ namespace yy {
   seclang_parser::yy_print_ (std::ostream& yyo, const basic_symbol<Base>& yysym) const
   {
     std::ostream& yyoutput = yyo;
-    YYUSE (yyoutput);
+    YY_USE (yyoutput);
     if (yysym.empty ())
       yyo << "empty symbol";
     else
@@ -1204,7 +1204,7 @@ namespace yy {
         yyo << (yykind < YYNTOKENS ? "token" : "nterm")
             << ' ' << yysym.name () << " ("
             << yysym.location << ": ";
-        YYUSE (yykind);
+        YY_USE (yykind);
         yyo << ')';
       }
   }
@@ -1230,7 +1230,7 @@ namespace yy {
   }
 
   void
-  seclang_parser::yypop_ (int n)
+  seclang_parser::yypop_ (int n) YY_NOEXCEPT
   {
     yystack_.pop (n);
   }
@@ -1273,13 +1273,13 @@ namespace yy {
   }
 
   bool
-  seclang_parser::yy_pact_value_is_default_ (int yyvalue)
+  seclang_parser::yy_pact_value_is_default_ (int yyvalue) YY_NOEXCEPT
   {
     return yyvalue == yypact_ninf_;
   }
 
   bool
-  seclang_parser::yy_table_value_is_error_ (int yyvalue)
+  seclang_parser::yy_table_value_is_error_ (int yyvalue) YY_NOEXCEPT
   {
     return yyvalue == yytable_ninf_;
   }
@@ -2874,9 +2874,11 @@ namespace yy {
       {
         std::string error;
         double ruleId;
-        try {
-            ruleId = std::stod(yystack_[1].value.as < std::string > ());
-        } catch (...) {
+        std::stringstream ss_conv;
+        ss_conv<<yystack_[1].value.as < std::string > ();
+        ss_conv>>ruleId;
+        if (ss_conv.fail()) {
+            ss_conv.clear();
             std::stringstream ss;
             ss << "SecRuleUpdateTargetById: failed to load:";
             ss << "The input \"" + yystack_[1].value.as < std::string > () + "\" does not ";
@@ -2896,17 +2898,19 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2900 "seclang-parser.cc"
+#line 2902 "seclang-parser.cc"
     break;
 
   case 124: // expression: "CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID" actions
-#line 1496 "seclang-parser.yy"
+#line 1498 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
-        try {
-            ruleId = std::stod(yystack_[1].value.as < std::string > ());
-        } catch (...) {
+        std::stringstream ss_conv;
+        ss_conv<<yystack_[1].value.as < std::string > ();
+        ss_conv>>ruleId;
+        if (ss_conv.fail()) {
+            ss_conv.clear();
             std::stringstream ss;
             ss << "SecRuleUpdateActionById: failed to load:";
             ss << "The input \"" + yystack_[1].value.as < std::string > () + "\" does not ";
@@ -2927,11 +2931,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2931 "seclang-parser.cc"
+#line 2935 "seclang-parser.cc"
     break;
 
   case 125: // expression: "CONFIG_DIR_DEBUG_LVL"
-#line 1524 "seclang-parser.yy"
+#line 1528 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as < std::string > ().c_str()));
@@ -2943,11 +2947,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2947 "seclang-parser.cc"
+#line 2951 "seclang-parser.cc"
     break;
 
   case 126: // expression: "CONFIG_DIR_DEBUG_LOG"
-#line 1536 "seclang-parser.yy"
+#line 1540 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -2966,11 +2970,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2970 "seclang-parser.cc"
+#line 2974 "seclang-parser.cc"
     break;
 
   case 127: // expression: "CONFIG_DIR_GEO_DB"
-#line 1556 "seclang-parser.yy"
+#line 1560 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
@@ -2997,47 +3001,47 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 3001 "seclang-parser.cc"
+#line 3005 "seclang-parser.cc"
     break;
 
   case 128: // expression: "CONFIG_DIR_ARGS_LIMIT"
-#line 1583 "seclang-parser.yy"
+#line 1587 "seclang-parser.yy"
       {
         driver.m_argumentsLimit.m_set = true;
         driver.m_argumentsLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3010 "seclang-parser.cc"
+#line 3014 "seclang-parser.cc"
     break;
 
   case 129: // expression: "CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT"
-#line 1588 "seclang-parser.yy"
+#line 1592 "seclang-parser.yy"
       {
         driver.m_requestBodyJsonDepthLimit.m_set = true;
         driver.m_requestBodyJsonDepthLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3019 "seclang-parser.cc"
+#line 3023 "seclang-parser.cc"
     break;
 
   case 130: // expression: "CONFIG_DIR_REQ_BODY_LIMIT"
-#line 1594 "seclang-parser.yy"
+#line 1598 "seclang-parser.yy"
       {
         driver.m_requestBodyLimit.m_set = true;
         driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3028 "seclang-parser.cc"
+#line 3032 "seclang-parser.cc"
     break;
 
   case 131: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
-#line 1599 "seclang-parser.yy"
+#line 1603 "seclang-parser.yy"
       {
         driver.m_requestBodyNoFilesLimit.m_set = true;
         driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3037 "seclang-parser.cc"
+#line 3041 "seclang-parser.cc"
     break;
 
   case 132: // expression: "CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT"
-#line 1604 "seclang-parser.yy"
+#line 1608 "seclang-parser.yy"
       {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -3046,68 +3050,68 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 3050 "seclang-parser.cc"
+#line 3054 "seclang-parser.cc"
     break;
 
   case 133: // expression: "CONFIG_DIR_RES_BODY_LIMIT"
-#line 1613 "seclang-parser.yy"
+#line 1617 "seclang-parser.yy"
       {
         driver.m_responseBodyLimit.m_set = true;
         driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3059 "seclang-parser.cc"
+#line 3063 "seclang-parser.cc"
     break;
 
   case 134: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1618 "seclang-parser.yy"
+#line 1622 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3067 "seclang-parser.cc"
+#line 3071 "seclang-parser.cc"
     break;
 
   case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1622 "seclang-parser.yy"
+#line 1626 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3075 "seclang-parser.cc"
+#line 3079 "seclang-parser.cc"
     break;
 
   case 136: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1626 "seclang-parser.yy"
+#line 1630 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3083 "seclang-parser.cc"
+#line 3087 "seclang-parser.cc"
     break;
 
   case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1630 "seclang-parser.yy"
+#line 1634 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3091 "seclang-parser.cc"
+#line 3095 "seclang-parser.cc"
     break;
 
   case 138: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
-#line 1634 "seclang-parser.yy"
+#line 1638 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 3099 "seclang-parser.cc"
+#line 3103 "seclang-parser.cc"
     break;
 
   case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
-#line 1638 "seclang-parser.yy"
+#line 1642 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 3107 "seclang-parser.cc"
+#line 3111 "seclang-parser.cc"
     break;
 
   case 142: // expression: "CONGIG_DIR_RESPONSE_BODY_MP"
-#line 1652 "seclang-parser.yy"
+#line 1656 "seclang-parser.yy"
       {
         std::istringstream buf(yystack_[0].value.as < std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -3119,37 +3123,37 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 3123 "seclang-parser.cc"
+#line 3127 "seclang-parser.cc"
     break;
 
   case 143: // expression: "CONGIG_DIR_RESPONSE_BODY_MP_CLEAR"
-#line 1664 "seclang-parser.yy"
+#line 1668 "seclang-parser.yy"
       {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 3133 "seclang-parser.cc"
+#line 3137 "seclang-parser.cc"
     break;
 
   case 144: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
-#line 1670 "seclang-parser.yy"
+#line 1674 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 3141 "seclang-parser.cc"
+#line 3145 "seclang-parser.cc"
     break;
 
   case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
-#line 1674 "seclang-parser.yy"
+#line 1678 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 3149 "seclang-parser.cc"
+#line 3153 "seclang-parser.cc"
     break;
 
   case 146: // expression: "CONGIG_DIR_SEC_TMP_DIR"
-#line 1678 "seclang-parser.yy"
+#line 1682 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
         std::stringstream ss;
@@ -3160,31 +3164,31 @@ namespace yy {
         YYERROR;
 */
       }
-#line 3164 "seclang-parser.cc"
+#line 3168 "seclang-parser.cc"
     break;
 
   case 149: // expression: "CONGIG_DIR_SEC_COOKIE_FORMAT"
-#line 1699 "seclang-parser.yy"
+#line 1703 "seclang-parser.yy"
       {
         if (atoi(yystack_[0].value.as < std::string > ().c_str()) == 1) {
           driver.error(yystack_[1].location, "SecCookieFormat 1 is not yet supported.");
           YYERROR;
         }
       }
-#line 3175 "seclang-parser.cc"
+#line 3179 "seclang-parser.cc"
     break;
 
   case 150: // expression: "CONFIG_SEC_COOKIEV0_SEPARATOR"
-#line 1706 "seclang-parser.yy"
+#line 1710 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCookieV0Separator is not yet supported.");
         YYERROR;
       }
-#line 3184 "seclang-parser.cc"
+#line 3188 "seclang-parser.cc"
     break;
 
   case 152: // expression: "CONFIG_DIR_UNICODE_MAP_FILE"
-#line 1716 "seclang-parser.yy"
+#line 1720 "seclang-parser.yy"
       {
         std::string error;
         std::vector<std::string> param;
@@ -3201,9 +3205,11 @@ namespace yy {
             YYERROR;
         }
 
-        try {
-            num = std::stod(param.back());
-        } catch (...) {
+        std::stringstream ss_conv;
+        ss_conv<<param.back();
+        ss_conv>>num;
+        if (ss_conv.fail()) {
+            ss_conv.clear();
             std::stringstream ss;
             ss << "Failed to process unicode map, last parameter is ";
             ss << "expected to be a number: " << param.back() << " ";
@@ -3238,31 +3244,31 @@ namespace yy {
         }
 
       }
-#line 3242 "seclang-parser.cc"
+#line 3248 "seclang-parser.cc"
     break;
 
   case 153: // expression: "CONFIG_SEC_COLLECTION_TIMEOUT"
-#line 1770 "seclang-parser.yy"
+#line 1776 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default CRS installations with crs-setup.conf-recommended
         driver.error(@0, "SecCollectionTimeout is not yet supported.");
         YYERROR;
 */
       }
-#line 3253 "seclang-parser.cc"
+#line 3259 "seclang-parser.cc"
     break;
 
   case 154: // expression: "CONFIG_SEC_HTTP_BLKEY"
-#line 1777 "seclang-parser.yy"
+#line 1783 "seclang-parser.yy"
       {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 3262 "seclang-parser.cc"
+#line 3268 "seclang-parser.cc"
     break;
 
   case 155: // variables: variables_pre_process
-#line 1785 "seclang-parser.yy"
+#line 1791 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable> > > originalList = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> newList(new std::vector<std::unique_ptr<Variable>>());
@@ -3296,2362 +3302,2362 @@ namespace yy {
         }
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(newNewList);
       }
-#line 3300 "seclang-parser.cc"
+#line 3306 "seclang-parser.cc"
     break;
 
   case 156: // variables_pre_process: variables_may_be_quoted
-#line 1822 "seclang-parser.yy"
+#line 1828 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3308 "seclang-parser.cc"
+#line 3314 "seclang-parser.cc"
     break;
 
   case 157: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
-#line 1826 "seclang-parser.yy"
+#line 1832 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3316 "seclang-parser.cc"
+#line 3322 "seclang-parser.cc"
     break;
 
   case 158: // variables_may_be_quoted: variables_may_be_quoted PIPE var
-#line 1833 "seclang-parser.yy"
+#line 1839 "seclang-parser.yy"
       {
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3325 "seclang-parser.cc"
+#line 3331 "seclang-parser.cc"
     break;
 
   case 159: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_EXCLUSION var
-#line 1838 "seclang-parser.yy"
+#line 1844 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3335 "seclang-parser.cc"
+#line 3341 "seclang-parser.cc"
     break;
 
   case 160: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_COUNT var
-#line 1844 "seclang-parser.yy"
+#line 1850 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3345 "seclang-parser.cc"
+#line 3351 "seclang-parser.cc"
     break;
 
   case 161: // variables_may_be_quoted: var
-#line 1850 "seclang-parser.yy"
+#line 1856 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3355 "seclang-parser.cc"
+#line 3361 "seclang-parser.cc"
     break;
 
   case 162: // variables_may_be_quoted: VAR_EXCLUSION var
-#line 1856 "seclang-parser.yy"
+#line 1862 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3366 "seclang-parser.cc"
+#line 3372 "seclang-parser.cc"
     break;
 
   case 163: // variables_may_be_quoted: VAR_COUNT var
-#line 1863 "seclang-parser.yy"
+#line 1869 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3377 "seclang-parser.cc"
+#line 3383 "seclang-parser.cc"
     break;
 
   case 164: // var: VARIABLE_ARGS "Dictionary element"
-#line 1873 "seclang-parser.yy"
+#line 1879 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3385 "seclang-parser.cc"
+#line 3391 "seclang-parser.cc"
     break;
 
   case 165: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
-#line 1877 "seclang-parser.yy"
+#line 1883 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3393 "seclang-parser.cc"
+#line 3399 "seclang-parser.cc"
     break;
 
   case 166: // var: VARIABLE_ARGS
-#line 1881 "seclang-parser.yy"
+#line 1887 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
       }
-#line 3401 "seclang-parser.cc"
+#line 3407 "seclang-parser.cc"
     break;
 
   case 167: // var: VARIABLE_ARGS_POST "Dictionary element"
-#line 1885 "seclang-parser.yy"
+#line 1891 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3409 "seclang-parser.cc"
+#line 3415 "seclang-parser.cc"
     break;
 
   case 168: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
-#line 1889 "seclang-parser.yy"
+#line 1895 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3417 "seclang-parser.cc"
+#line 3423 "seclang-parser.cc"
     break;
 
   case 169: // var: VARIABLE_ARGS_POST
-#line 1893 "seclang-parser.yy"
+#line 1899 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
       }
-#line 3425 "seclang-parser.cc"
+#line 3431 "seclang-parser.cc"
     break;
 
   case 170: // var: VARIABLE_ARGS_GET "Dictionary element"
-#line 1897 "seclang-parser.yy"
+#line 1903 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3433 "seclang-parser.cc"
+#line 3439 "seclang-parser.cc"
     break;
 
   case 171: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
-#line 1901 "seclang-parser.yy"
+#line 1907 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3441 "seclang-parser.cc"
+#line 3447 "seclang-parser.cc"
     break;
 
   case 172: // var: VARIABLE_ARGS_GET
-#line 1905 "seclang-parser.yy"
+#line 1911 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
       }
-#line 3449 "seclang-parser.cc"
+#line 3455 "seclang-parser.cc"
     break;
 
   case 173: // var: VARIABLE_FILES_SIZES "Dictionary element"
-#line 1909 "seclang-parser.yy"
+#line 1915 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3457 "seclang-parser.cc"
+#line 3463 "seclang-parser.cc"
     break;
 
   case 174: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
-#line 1913 "seclang-parser.yy"
+#line 1919 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3465 "seclang-parser.cc"
+#line 3471 "seclang-parser.cc"
     break;
 
   case 175: // var: VARIABLE_FILES_SIZES
-#line 1917 "seclang-parser.yy"
+#line 1923 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
       }
-#line 3473 "seclang-parser.cc"
+#line 3479 "seclang-parser.cc"
     break;
 
   case 176: // var: VARIABLE_FILES_NAMES "Dictionary element"
-#line 1921 "seclang-parser.yy"
+#line 1927 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3481 "seclang-parser.cc"
+#line 3487 "seclang-parser.cc"
     break;
 
   case 177: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
-#line 1925 "seclang-parser.yy"
+#line 1931 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3489 "seclang-parser.cc"
+#line 3495 "seclang-parser.cc"
     break;
 
   case 178: // var: VARIABLE_FILES_NAMES
-#line 1929 "seclang-parser.yy"
+#line 1935 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
       }
-#line 3497 "seclang-parser.cc"
+#line 3503 "seclang-parser.cc"
     break;
 
   case 179: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
-#line 1933 "seclang-parser.yy"
+#line 1939 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3505 "seclang-parser.cc"
+#line 3511 "seclang-parser.cc"
     break;
 
   case 180: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
-#line 1937 "seclang-parser.yy"
+#line 1943 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3513 "seclang-parser.cc"
+#line 3519 "seclang-parser.cc"
     break;
 
   case 181: // var: VARIABLE_FILES_TMP_CONTENT
-#line 1941 "seclang-parser.yy"
+#line 1947 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
       }
-#line 3521 "seclang-parser.cc"
+#line 3527 "seclang-parser.cc"
     break;
 
   case 182: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
-#line 1945 "seclang-parser.yy"
+#line 1951 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3529 "seclang-parser.cc"
+#line 3535 "seclang-parser.cc"
     break;
 
   case 183: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
-#line 1949 "seclang-parser.yy"
+#line 1955 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3537 "seclang-parser.cc"
+#line 3543 "seclang-parser.cc"
     break;
 
   case 184: // var: VARIABLE_MULTIPART_FILENAME
-#line 1953 "seclang-parser.yy"
+#line 1959 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
       }
-#line 3545 "seclang-parser.cc"
+#line 3551 "seclang-parser.cc"
     break;
 
   case 185: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
-#line 1957 "seclang-parser.yy"
+#line 1963 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3553 "seclang-parser.cc"
+#line 3559 "seclang-parser.cc"
     break;
 
   case 186: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
-#line 1961 "seclang-parser.yy"
+#line 1967 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3561 "seclang-parser.cc"
+#line 3567 "seclang-parser.cc"
     break;
 
   case 187: // var: VARIABLE_MULTIPART_NAME
-#line 1965 "seclang-parser.yy"
+#line 1971 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
       }
-#line 3569 "seclang-parser.cc"
+#line 3575 "seclang-parser.cc"
     break;
 
   case 188: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
-#line 1969 "seclang-parser.yy"
+#line 1975 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3577 "seclang-parser.cc"
+#line 3583 "seclang-parser.cc"
     break;
 
   case 189: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
-#line 1973 "seclang-parser.yy"
+#line 1979 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3585 "seclang-parser.cc"
+#line 3591 "seclang-parser.cc"
     break;
 
   case 190: // var: VARIABLE_MATCHED_VARS_NAMES
-#line 1977 "seclang-parser.yy"
+#line 1983 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
       }
-#line 3593 "seclang-parser.cc"
+#line 3599 "seclang-parser.cc"
     break;
 
   case 191: // var: VARIABLE_MATCHED_VARS "Dictionary element"
-#line 1981 "seclang-parser.yy"
+#line 1987 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3601 "seclang-parser.cc"
+#line 3607 "seclang-parser.cc"
     break;
 
   case 192: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
-#line 1985 "seclang-parser.yy"
+#line 1991 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3609 "seclang-parser.cc"
+#line 3615 "seclang-parser.cc"
     break;
 
   case 193: // var: VARIABLE_MATCHED_VARS
-#line 1989 "seclang-parser.yy"
+#line 1995 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
       }
-#line 3617 "seclang-parser.cc"
+#line 3623 "seclang-parser.cc"
     break;
 
   case 194: // var: VARIABLE_FILES "Dictionary element"
-#line 1993 "seclang-parser.yy"
+#line 1999 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3625 "seclang-parser.cc"
+#line 3631 "seclang-parser.cc"
     break;
 
   case 195: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
-#line 1997 "seclang-parser.yy"
+#line 2003 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3633 "seclang-parser.cc"
+#line 3639 "seclang-parser.cc"
     break;
 
   case 196: // var: VARIABLE_FILES
-#line 2001 "seclang-parser.yy"
+#line 2007 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
       }
-#line 3641 "seclang-parser.cc"
+#line 3647 "seclang-parser.cc"
     break;
 
   case 197: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
-#line 2005 "seclang-parser.yy"
+#line 2011 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3649 "seclang-parser.cc"
+#line 3655 "seclang-parser.cc"
     break;
 
   case 198: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
-#line 2009 "seclang-parser.yy"
+#line 2015 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3657 "seclang-parser.cc"
+#line 3663 "seclang-parser.cc"
     break;
 
   case 199: // var: VARIABLE_REQUEST_COOKIES
-#line 2013 "seclang-parser.yy"
+#line 2019 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
       }
-#line 3665 "seclang-parser.cc"
+#line 3671 "seclang-parser.cc"
     break;
 
   case 200: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
-#line 2017 "seclang-parser.yy"
+#line 2023 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3673 "seclang-parser.cc"
+#line 3679 "seclang-parser.cc"
     break;
 
   case 201: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
-#line 2021 "seclang-parser.yy"
+#line 2027 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3681 "seclang-parser.cc"
+#line 3687 "seclang-parser.cc"
     break;
 
   case 202: // var: VARIABLE_REQUEST_HEADERS
-#line 2025 "seclang-parser.yy"
+#line 2031 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
       }
-#line 3689 "seclang-parser.cc"
+#line 3695 "seclang-parser.cc"
     break;
 
   case 203: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
-#line 2029 "seclang-parser.yy"
+#line 2035 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3697 "seclang-parser.cc"
+#line 3703 "seclang-parser.cc"
     break;
 
   case 204: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
-#line 2033 "seclang-parser.yy"
+#line 2039 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3705 "seclang-parser.cc"
+#line 3711 "seclang-parser.cc"
     break;
 
   case 205: // var: VARIABLE_RESPONSE_HEADERS
-#line 2037 "seclang-parser.yy"
+#line 2043 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
       }
-#line 3713 "seclang-parser.cc"
+#line 3719 "seclang-parser.cc"
     break;
 
   case 206: // var: VARIABLE_GEO "Dictionary element"
-#line 2041 "seclang-parser.yy"
+#line 2047 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3721 "seclang-parser.cc"
+#line 3727 "seclang-parser.cc"
     break;
 
   case 207: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
-#line 2045 "seclang-parser.yy"
+#line 2051 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3729 "seclang-parser.cc"
+#line 3735 "seclang-parser.cc"
     break;
 
   case 208: // var: VARIABLE_GEO
-#line 2049 "seclang-parser.yy"
+#line 2055 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
       }
-#line 3737 "seclang-parser.cc"
+#line 3743 "seclang-parser.cc"
     break;
 
   case 209: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
-#line 2053 "seclang-parser.yy"
+#line 2059 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3745 "seclang-parser.cc"
+#line 3751 "seclang-parser.cc"
     break;
 
   case 210: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
-#line 2057 "seclang-parser.yy"
+#line 2063 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3753 "seclang-parser.cc"
+#line 3759 "seclang-parser.cc"
     break;
 
   case 211: // var: VARIABLE_REQUEST_COOKIES_NAMES
-#line 2061 "seclang-parser.yy"
+#line 2067 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
       }
-#line 3761 "seclang-parser.cc"
+#line 3767 "seclang-parser.cc"
     break;
 
   case 212: // var: VARIABLE_RULE "Dictionary element"
-#line 2065 "seclang-parser.yy"
+#line 2071 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3769 "seclang-parser.cc"
+#line 3775 "seclang-parser.cc"
     break;
 
   case 213: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
-#line 2069 "seclang-parser.yy"
+#line 2075 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3777 "seclang-parser.cc"
+#line 3783 "seclang-parser.cc"
     break;
 
   case 214: // var: VARIABLE_RULE
-#line 2073 "seclang-parser.yy"
+#line 2079 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
       }
-#line 3785 "seclang-parser.cc"
+#line 3791 "seclang-parser.cc"
     break;
 
   case 215: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
-#line 2077 "seclang-parser.yy"
+#line 2083 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3793 "seclang-parser.cc"
+#line 3799 "seclang-parser.cc"
     break;
 
   case 216: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
-#line 2081 "seclang-parser.yy"
+#line 2087 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3801 "seclang-parser.cc"
+#line 3807 "seclang-parser.cc"
     break;
 
   case 217: // var: "RUN_TIME_VAR_ENV"
-#line 2085 "seclang-parser.yy"
+#line 2091 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
       }
-#line 3809 "seclang-parser.cc"
+#line 3815 "seclang-parser.cc"
     break;
 
   case 218: // var: "RUN_TIME_VAR_XML" "Dictionary element"
-#line 2089 "seclang-parser.yy"
+#line 2095 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3817 "seclang-parser.cc"
+#line 3823 "seclang-parser.cc"
     break;
 
   case 219: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
-#line 2093 "seclang-parser.yy"
+#line 2099 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3825 "seclang-parser.cc"
+#line 3831 "seclang-parser.cc"
     break;
 
   case 220: // var: "RUN_TIME_VAR_XML"
-#line 2097 "seclang-parser.yy"
+#line 2103 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
       }
-#line 3833 "seclang-parser.cc"
+#line 3839 "seclang-parser.cc"
     break;
 
   case 221: // var: "FILES_TMPNAMES" "Dictionary element"
-#line 2101 "seclang-parser.yy"
+#line 2107 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3841 "seclang-parser.cc"
+#line 3847 "seclang-parser.cc"
     break;
 
   case 222: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
-#line 2105 "seclang-parser.yy"
+#line 2111 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3849 "seclang-parser.cc"
+#line 3855 "seclang-parser.cc"
     break;
 
   case 223: // var: "FILES_TMPNAMES"
-#line 2109 "seclang-parser.yy"
+#line 2115 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
       }
-#line 3857 "seclang-parser.cc"
+#line 3863 "seclang-parser.cc"
     break;
 
   case 224: // var: "RESOURCE" run_time_string
-#line 2113 "seclang-parser.yy"
+#line 2119 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3865 "seclang-parser.cc"
+#line 3871 "seclang-parser.cc"
     break;
 
   case 225: // var: "RESOURCE" "Dictionary element"
-#line 2117 "seclang-parser.yy"
+#line 2123 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3873 "seclang-parser.cc"
+#line 3879 "seclang-parser.cc"
     break;
 
   case 226: // var: "RESOURCE" "Dictionary element, selected by regexp"
-#line 2121 "seclang-parser.yy"
+#line 2127 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3881 "seclang-parser.cc"
+#line 3887 "seclang-parser.cc"
     break;
 
   case 227: // var: "RESOURCE"
-#line 2125 "seclang-parser.yy"
+#line 2131 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
       }
-#line 3889 "seclang-parser.cc"
+#line 3895 "seclang-parser.cc"
     break;
 
   case 228: // var: "VARIABLE_IP" run_time_string
-#line 2129 "seclang-parser.yy"
+#line 2135 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3897 "seclang-parser.cc"
+#line 3903 "seclang-parser.cc"
     break;
 
   case 229: // var: "VARIABLE_IP" "Dictionary element"
-#line 2133 "seclang-parser.yy"
+#line 2139 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3905 "seclang-parser.cc"
+#line 3911 "seclang-parser.cc"
     break;
 
   case 230: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
-#line 2137 "seclang-parser.yy"
+#line 2143 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3913 "seclang-parser.cc"
+#line 3919 "seclang-parser.cc"
     break;
 
   case 231: // var: "VARIABLE_IP"
-#line 2141 "seclang-parser.yy"
+#line 2147 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
       }
-#line 3921 "seclang-parser.cc"
+#line 3927 "seclang-parser.cc"
     break;
 
   case 232: // var: "VARIABLE_GLOBAL" run_time_string
-#line 2145 "seclang-parser.yy"
+#line 2151 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3929 "seclang-parser.cc"
+#line 3935 "seclang-parser.cc"
     break;
 
   case 233: // var: "VARIABLE_GLOBAL" "Dictionary element"
-#line 2149 "seclang-parser.yy"
+#line 2155 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3937 "seclang-parser.cc"
+#line 3943 "seclang-parser.cc"
     break;
 
   case 234: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
-#line 2153 "seclang-parser.yy"
+#line 2159 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3945 "seclang-parser.cc"
+#line 3951 "seclang-parser.cc"
     break;
 
   case 235: // var: "VARIABLE_GLOBAL"
-#line 2157 "seclang-parser.yy"
+#line 2163 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
       }
-#line 3953 "seclang-parser.cc"
+#line 3959 "seclang-parser.cc"
     break;
 
   case 236: // var: "VARIABLE_USER" run_time_string
-#line 2161 "seclang-parser.yy"
+#line 2167 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3961 "seclang-parser.cc"
+#line 3967 "seclang-parser.cc"
     break;
 
   case 237: // var: "VARIABLE_USER" "Dictionary element"
-#line 2165 "seclang-parser.yy"
+#line 2171 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3969 "seclang-parser.cc"
+#line 3975 "seclang-parser.cc"
     break;
 
   case 238: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
-#line 2169 "seclang-parser.yy"
+#line 2175 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3977 "seclang-parser.cc"
+#line 3983 "seclang-parser.cc"
     break;
 
   case 239: // var: "VARIABLE_USER"
-#line 2173 "seclang-parser.yy"
+#line 2179 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
       }
-#line 3985 "seclang-parser.cc"
+#line 3991 "seclang-parser.cc"
     break;
 
   case 240: // var: "VARIABLE_TX" run_time_string
-#line 2177 "seclang-parser.yy"
+#line 2183 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3993 "seclang-parser.cc"
+#line 3999 "seclang-parser.cc"
     break;
 
   case 241: // var: "VARIABLE_TX" "Dictionary element"
-#line 2181 "seclang-parser.yy"
+#line 2187 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4001 "seclang-parser.cc"
+#line 4007 "seclang-parser.cc"
     break;
 
   case 242: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
-#line 2185 "seclang-parser.yy"
+#line 2191 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4009 "seclang-parser.cc"
+#line 4015 "seclang-parser.cc"
     break;
 
   case 243: // var: "VARIABLE_TX"
-#line 2189 "seclang-parser.yy"
+#line 2195 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
       }
-#line 4017 "seclang-parser.cc"
+#line 4023 "seclang-parser.cc"
     break;
 
   case 244: // var: "VARIABLE_SESSION" run_time_string
-#line 2193 "seclang-parser.yy"
+#line 2199 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4025 "seclang-parser.cc"
+#line 4031 "seclang-parser.cc"
     break;
 
   case 245: // var: "VARIABLE_SESSION" "Dictionary element"
-#line 2197 "seclang-parser.yy"
+#line 2203 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4033 "seclang-parser.cc"
+#line 4039 "seclang-parser.cc"
     break;
 
   case 246: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
-#line 2201 "seclang-parser.yy"
+#line 2207 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4041 "seclang-parser.cc"
+#line 4047 "seclang-parser.cc"
     break;
 
   case 247: // var: "VARIABLE_SESSION"
-#line 2205 "seclang-parser.yy"
+#line 2211 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
       }
-#line 4049 "seclang-parser.cc"
+#line 4055 "seclang-parser.cc"
     break;
 
   case 248: // var: "Variable ARGS_NAMES" "Dictionary element"
-#line 2209 "seclang-parser.yy"
+#line 2215 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4057 "seclang-parser.cc"
+#line 4063 "seclang-parser.cc"
     break;
 
   case 249: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
-#line 2213 "seclang-parser.yy"
+#line 2219 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4065 "seclang-parser.cc"
+#line 4071 "seclang-parser.cc"
     break;
 
   case 250: // var: "Variable ARGS_NAMES"
-#line 2217 "seclang-parser.yy"
+#line 2223 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
       }
-#line 4073 "seclang-parser.cc"
+#line 4079 "seclang-parser.cc"
     break;
 
   case 251: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
-#line 2221 "seclang-parser.yy"
+#line 2227 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4081 "seclang-parser.cc"
+#line 4087 "seclang-parser.cc"
     break;
 
   case 252: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
-#line 2225 "seclang-parser.yy"
+#line 2231 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4089 "seclang-parser.cc"
+#line 4095 "seclang-parser.cc"
     break;
 
   case 253: // var: VARIABLE_ARGS_GET_NAMES
-#line 2229 "seclang-parser.yy"
+#line 2235 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
       }
-#line 4097 "seclang-parser.cc"
+#line 4103 "seclang-parser.cc"
     break;
 
   case 254: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
-#line 2234 "seclang-parser.yy"
+#line 2240 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4105 "seclang-parser.cc"
+#line 4111 "seclang-parser.cc"
     break;
 
   case 255: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
-#line 2238 "seclang-parser.yy"
+#line 2244 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4113 "seclang-parser.cc"
+#line 4119 "seclang-parser.cc"
     break;
 
   case 256: // var: VARIABLE_ARGS_POST_NAMES
-#line 2242 "seclang-parser.yy"
+#line 2248 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
       }
-#line 4121 "seclang-parser.cc"
+#line 4127 "seclang-parser.cc"
     break;
 
   case 257: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
-#line 2247 "seclang-parser.yy"
+#line 2253 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4129 "seclang-parser.cc"
+#line 4135 "seclang-parser.cc"
     break;
 
   case 258: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2251 "seclang-parser.yy"
+#line 2257 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4137 "seclang-parser.cc"
+#line 4143 "seclang-parser.cc"
     break;
 
   case 259: // var: VARIABLE_REQUEST_HEADERS_NAMES
-#line 2255 "seclang-parser.yy"
+#line 2261 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
       }
-#line 4145 "seclang-parser.cc"
+#line 4151 "seclang-parser.cc"
     break;
 
   case 260: // var: VARIABLE_RESPONSE_CONTENT_TYPE
-#line 2260 "seclang-parser.yy"
+#line 2266 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
       }
-#line 4153 "seclang-parser.cc"
+#line 4159 "seclang-parser.cc"
     break;
 
   case 261: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
-#line 2265 "seclang-parser.yy"
+#line 2271 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4161 "seclang-parser.cc"
+#line 4167 "seclang-parser.cc"
     break;
 
   case 262: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2269 "seclang-parser.yy"
+#line 2275 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4169 "seclang-parser.cc"
+#line 4175 "seclang-parser.cc"
     break;
 
   case 263: // var: VARIABLE_RESPONSE_HEADERS_NAMES
-#line 2273 "seclang-parser.yy"
+#line 2279 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
       }
-#line 4177 "seclang-parser.cc"
+#line 4183 "seclang-parser.cc"
     break;
 
   case 264: // var: VARIABLE_ARGS_COMBINED_SIZE
-#line 2277 "seclang-parser.yy"
+#line 2283 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
       }
-#line 4185 "seclang-parser.cc"
+#line 4191 "seclang-parser.cc"
     break;
 
   case 265: // var: "AUTH_TYPE"
-#line 2281 "seclang-parser.yy"
+#line 2287 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
       }
-#line 4193 "seclang-parser.cc"
+#line 4199 "seclang-parser.cc"
     break;
 
   case 266: // var: "FILES_COMBINED_SIZE"
-#line 2285 "seclang-parser.yy"
+#line 2291 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
       }
-#line 4201 "seclang-parser.cc"
+#line 4207 "seclang-parser.cc"
     break;
 
   case 267: // var: "FULL_REQUEST"
-#line 2289 "seclang-parser.yy"
+#line 2295 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
       }
-#line 4209 "seclang-parser.cc"
+#line 4215 "seclang-parser.cc"
     break;
 
   case 268: // var: "FULL_REQUEST_LENGTH"
-#line 2293 "seclang-parser.yy"
+#line 2299 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
       }
-#line 4217 "seclang-parser.cc"
+#line 4223 "seclang-parser.cc"
     break;
 
   case 269: // var: "INBOUND_DATA_ERROR"
-#line 2297 "seclang-parser.yy"
+#line 2303 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
       }
-#line 4225 "seclang-parser.cc"
+#line 4231 "seclang-parser.cc"
     break;
 
   case 270: // var: "MATCHED_VAR"
-#line 2301 "seclang-parser.yy"
+#line 2307 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
       }
-#line 4233 "seclang-parser.cc"
+#line 4239 "seclang-parser.cc"
     break;
 
   case 271: // var: "MATCHED_VAR_NAME"
-#line 2305 "seclang-parser.yy"
+#line 2311 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
       }
-#line 4241 "seclang-parser.cc"
+#line 4247 "seclang-parser.cc"
     break;
 
   case 272: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
-#line 2309 "seclang-parser.yy"
+#line 2315 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
       }
-#line 4249 "seclang-parser.cc"
+#line 4255 "seclang-parser.cc"
     break;
 
   case 273: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
-#line 2313 "seclang-parser.yy"
+#line 2319 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
       }
-#line 4257 "seclang-parser.cc"
+#line 4263 "seclang-parser.cc"
     break;
 
   case 274: // var: "MULTIPART_CRLF_LF_LINES"
-#line 2317 "seclang-parser.yy"
+#line 2323 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
       }
-#line 4265 "seclang-parser.cc"
+#line 4271 "seclang-parser.cc"
     break;
 
   case 275: // var: "MULTIPART_DATA_AFTER"
-#line 2321 "seclang-parser.yy"
+#line 2327 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
       }
-#line 4273 "seclang-parser.cc"
+#line 4279 "seclang-parser.cc"
     break;
 
   case 276: // var: VARIABLE_MULTIPART_DATA_BEFORE
-#line 2325 "seclang-parser.yy"
+#line 2331 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
       }
-#line 4281 "seclang-parser.cc"
+#line 4287 "seclang-parser.cc"
     break;
 
   case 277: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
-#line 2329 "seclang-parser.yy"
+#line 2335 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
       }
-#line 4289 "seclang-parser.cc"
+#line 4295 "seclang-parser.cc"
     break;
 
   case 278: // var: "MULTIPART_HEADER_FOLDING"
-#line 2333 "seclang-parser.yy"
+#line 2339 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
       }
-#line 4297 "seclang-parser.cc"
+#line 4303 "seclang-parser.cc"
     break;
 
   case 279: // var: "MULTIPART_INVALID_HEADER_FOLDING"
-#line 2337 "seclang-parser.yy"
+#line 2343 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
       }
-#line 4305 "seclang-parser.cc"
+#line 4311 "seclang-parser.cc"
     break;
 
   case 280: // var: VARIABLE_MULTIPART_INVALID_PART
-#line 2341 "seclang-parser.yy"
+#line 2347 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
       }
-#line 4313 "seclang-parser.cc"
+#line 4319 "seclang-parser.cc"
     break;
 
   case 281: // var: "MULTIPART_INVALID_QUOTING"
-#line 2345 "seclang-parser.yy"
+#line 2351 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
       }
-#line 4321 "seclang-parser.cc"
+#line 4327 "seclang-parser.cc"
     break;
 
   case 282: // var: VARIABLE_MULTIPART_LF_LINE
-#line 2349 "seclang-parser.yy"
+#line 2355 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
       }
-#line 4329 "seclang-parser.cc"
+#line 4335 "seclang-parser.cc"
     break;
 
   case 283: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
-#line 2353 "seclang-parser.yy"
+#line 2359 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4337 "seclang-parser.cc"
+#line 4343 "seclang-parser.cc"
     break;
 
   case 284: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
-#line 2357 "seclang-parser.yy"
+#line 2363 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4345 "seclang-parser.cc"
+#line 4351 "seclang-parser.cc"
     break;
 
   case 285: // var: "MULTIPART_STRICT_ERROR"
-#line 2361 "seclang-parser.yy"
+#line 2367 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
       }
-#line 4353 "seclang-parser.cc"
+#line 4359 "seclang-parser.cc"
     break;
 
   case 286: // var: "MULTIPART_UNMATCHED_BOUNDARY"
-#line 2365 "seclang-parser.yy"
+#line 2371 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
       }
-#line 4361 "seclang-parser.cc"
+#line 4367 "seclang-parser.cc"
     break;
 
   case 287: // var: "OUTBOUND_DATA_ERROR"
-#line 2369 "seclang-parser.yy"
+#line 2375 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
       }
-#line 4369 "seclang-parser.cc"
+#line 4375 "seclang-parser.cc"
     break;
 
   case 288: // var: "PATH_INFO"
-#line 2373 "seclang-parser.yy"
+#line 2379 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
       }
-#line 4377 "seclang-parser.cc"
+#line 4383 "seclang-parser.cc"
     break;
 
   case 289: // var: "QUERY_STRING"
-#line 2377 "seclang-parser.yy"
+#line 2383 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
       }
-#line 4385 "seclang-parser.cc"
+#line 4391 "seclang-parser.cc"
     break;
 
   case 290: // var: "REMOTE_ADDR"
-#line 2381 "seclang-parser.yy"
+#line 2387 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
       }
-#line 4393 "seclang-parser.cc"
+#line 4399 "seclang-parser.cc"
     break;
 
   case 291: // var: "REMOTE_HOST"
-#line 2385 "seclang-parser.yy"
+#line 2391 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
       }
-#line 4401 "seclang-parser.cc"
+#line 4407 "seclang-parser.cc"
     break;
 
   case 292: // var: "REMOTE_PORT"
-#line 2389 "seclang-parser.yy"
+#line 2395 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
       }
-#line 4409 "seclang-parser.cc"
+#line 4415 "seclang-parser.cc"
     break;
 
   case 293: // var: "REQBODY_ERROR"
-#line 2393 "seclang-parser.yy"
+#line 2399 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
       }
-#line 4417 "seclang-parser.cc"
+#line 4423 "seclang-parser.cc"
     break;
 
   case 294: // var: "REQBODY_ERROR_MSG"
-#line 2397 "seclang-parser.yy"
+#line 2403 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
       }
-#line 4425 "seclang-parser.cc"
+#line 4431 "seclang-parser.cc"
     break;
 
   case 295: // var: "REQBODY_PROCESSOR"
-#line 2401 "seclang-parser.yy"
+#line 2407 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
       }
-#line 4433 "seclang-parser.cc"
+#line 4439 "seclang-parser.cc"
     break;
 
   case 296: // var: "REQBODY_PROCESSOR_ERROR"
-#line 2405 "seclang-parser.yy"
+#line 2411 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
       }
-#line 4441 "seclang-parser.cc"
+#line 4447 "seclang-parser.cc"
     break;
 
   case 297: // var: "REQBODY_PROCESSOR_ERROR_MSG"
-#line 2409 "seclang-parser.yy"
+#line 2415 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
       }
-#line 4449 "seclang-parser.cc"
+#line 4455 "seclang-parser.cc"
     break;
 
   case 298: // var: "REQUEST_BASENAME"
-#line 2413 "seclang-parser.yy"
+#line 2419 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
       }
-#line 4457 "seclang-parser.cc"
+#line 4463 "seclang-parser.cc"
     break;
 
   case 299: // var: "REQUEST_BODY"
-#line 2417 "seclang-parser.yy"
+#line 2423 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
       }
-#line 4465 "seclang-parser.cc"
+#line 4471 "seclang-parser.cc"
     break;
 
   case 300: // var: "REQUEST_BODY_LENGTH"
-#line 2421 "seclang-parser.yy"
+#line 2427 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
       }
-#line 4473 "seclang-parser.cc"
+#line 4479 "seclang-parser.cc"
     break;
 
   case 301: // var: "REQUEST_FILENAME"
-#line 2425 "seclang-parser.yy"
+#line 2431 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
       }
-#line 4481 "seclang-parser.cc"
+#line 4487 "seclang-parser.cc"
     break;
 
   case 302: // var: "REQUEST_LINE"
-#line 2429 "seclang-parser.yy"
+#line 2435 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
       }
-#line 4489 "seclang-parser.cc"
+#line 4495 "seclang-parser.cc"
     break;
 
   case 303: // var: "REQUEST_METHOD"
-#line 2433 "seclang-parser.yy"
+#line 2439 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
       }
-#line 4497 "seclang-parser.cc"
+#line 4503 "seclang-parser.cc"
     break;
 
   case 304: // var: "REQUEST_PROTOCOL"
-#line 2437 "seclang-parser.yy"
+#line 2443 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
       }
-#line 4505 "seclang-parser.cc"
+#line 4511 "seclang-parser.cc"
     break;
 
   case 305: // var: "REQUEST_URI"
-#line 2441 "seclang-parser.yy"
+#line 2447 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
       }
-#line 4513 "seclang-parser.cc"
+#line 4519 "seclang-parser.cc"
     break;
 
   case 306: // var: "REQUEST_URI_RAW"
-#line 2445 "seclang-parser.yy"
+#line 2451 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
       }
-#line 4521 "seclang-parser.cc"
+#line 4527 "seclang-parser.cc"
     break;
 
   case 307: // var: "RESPONSE_BODY"
-#line 2449 "seclang-parser.yy"
+#line 2455 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
       }
-#line 4529 "seclang-parser.cc"
+#line 4535 "seclang-parser.cc"
     break;
 
   case 308: // var: "RESPONSE_CONTENT_LENGTH"
-#line 2453 "seclang-parser.yy"
+#line 2459 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
       }
-#line 4537 "seclang-parser.cc"
+#line 4543 "seclang-parser.cc"
     break;
 
   case 309: // var: "RESPONSE_PROTOCOL"
-#line 2457 "seclang-parser.yy"
+#line 2463 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
       }
-#line 4545 "seclang-parser.cc"
+#line 4551 "seclang-parser.cc"
     break;
 
   case 310: // var: "RESPONSE_STATUS"
-#line 2461 "seclang-parser.yy"
+#line 2467 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
       }
-#line 4553 "seclang-parser.cc"
+#line 4559 "seclang-parser.cc"
     break;
 
   case 311: // var: "SERVER_ADDR"
-#line 2465 "seclang-parser.yy"
+#line 2471 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
       }
-#line 4561 "seclang-parser.cc"
+#line 4567 "seclang-parser.cc"
     break;
 
   case 312: // var: "SERVER_NAME"
-#line 2469 "seclang-parser.yy"
+#line 2475 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
       }
-#line 4569 "seclang-parser.cc"
+#line 4575 "seclang-parser.cc"
     break;
 
   case 313: // var: "SERVER_PORT"
-#line 2473 "seclang-parser.yy"
+#line 2479 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
       }
-#line 4577 "seclang-parser.cc"
+#line 4583 "seclang-parser.cc"
     break;
 
   case 314: // var: "SESSIONID"
-#line 2477 "seclang-parser.yy"
+#line 2483 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
       }
-#line 4585 "seclang-parser.cc"
+#line 4591 "seclang-parser.cc"
     break;
 
   case 315: // var: "UNIQUE_ID"
-#line 2481 "seclang-parser.yy"
+#line 2487 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
       }
-#line 4593 "seclang-parser.cc"
+#line 4599 "seclang-parser.cc"
     break;
 
   case 316: // var: "URLENCODED_ERROR"
-#line 2485 "seclang-parser.yy"
+#line 2491 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
       }
-#line 4601 "seclang-parser.cc"
+#line 4607 "seclang-parser.cc"
     break;
 
   case 317: // var: "USERID"
-#line 2489 "seclang-parser.yy"
+#line 2495 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
       }
-#line 4609 "seclang-parser.cc"
+#line 4615 "seclang-parser.cc"
     break;
 
   case 318: // var: "VARIABLE_STATUS"
-#line 2493 "seclang-parser.yy"
+#line 2499 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4617 "seclang-parser.cc"
+#line 4623 "seclang-parser.cc"
     break;
 
   case 319: // var: "VARIABLE_STATUS_LINE"
-#line 2497 "seclang-parser.yy"
+#line 2503 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4625 "seclang-parser.cc"
+#line 4631 "seclang-parser.cc"
     break;
 
   case 320: // var: "WEBAPPID"
-#line 2501 "seclang-parser.yy"
+#line 2507 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
       }
-#line 4633 "seclang-parser.cc"
+#line 4639 "seclang-parser.cc"
     break;
 
   case 321: // var: "RUN_TIME_VAR_DUR"
-#line 2505 "seclang-parser.yy"
+#line 2511 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4644 "seclang-parser.cc"
+#line 4650 "seclang-parser.cc"
     break;
 
   case 322: // var: "RUN_TIME_VAR_BLD"
-#line 2513 "seclang-parser.yy"
+#line 2519 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4655 "seclang-parser.cc"
+#line 4661 "seclang-parser.cc"
     break;
 
   case 323: // var: "RUN_TIME_VAR_HSV"
-#line 2520 "seclang-parser.yy"
+#line 2526 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4666 "seclang-parser.cc"
+#line 4672 "seclang-parser.cc"
     break;
 
   case 324: // var: "RUN_TIME_VAR_REMOTE_USER"
-#line 2527 "seclang-parser.yy"
+#line 2533 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4677 "seclang-parser.cc"
+#line 4683 "seclang-parser.cc"
     break;
 
   case 325: // var: "RUN_TIME_VAR_TIME"
-#line 2534 "seclang-parser.yy"
+#line 2540 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4688 "seclang-parser.cc"
+#line 4694 "seclang-parser.cc"
     break;
 
   case 326: // var: "RUN_TIME_VAR_TIME_DAY"
-#line 2541 "seclang-parser.yy"
+#line 2547 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4699 "seclang-parser.cc"
+#line 4705 "seclang-parser.cc"
     break;
 
   case 327: // var: "RUN_TIME_VAR_TIME_EPOCH"
-#line 2548 "seclang-parser.yy"
+#line 2554 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4710 "seclang-parser.cc"
+#line 4716 "seclang-parser.cc"
     break;
 
   case 328: // var: "RUN_TIME_VAR_TIME_HOUR"
-#line 2555 "seclang-parser.yy"
+#line 2561 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4721 "seclang-parser.cc"
+#line 4727 "seclang-parser.cc"
     break;
 
   case 329: // var: "RUN_TIME_VAR_TIME_MIN"
-#line 2562 "seclang-parser.yy"
+#line 2568 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4732 "seclang-parser.cc"
+#line 4738 "seclang-parser.cc"
     break;
 
   case 330: // var: "RUN_TIME_VAR_TIME_MON"
-#line 2569 "seclang-parser.yy"
+#line 2575 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4743 "seclang-parser.cc"
+#line 4749 "seclang-parser.cc"
     break;
 
   case 331: // var: "RUN_TIME_VAR_TIME_SEC"
-#line 2576 "seclang-parser.yy"
+#line 2582 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4754 "seclang-parser.cc"
+#line 4760 "seclang-parser.cc"
     break;
 
   case 332: // var: "RUN_TIME_VAR_TIME_WDAY"
-#line 2583 "seclang-parser.yy"
+#line 2589 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4765 "seclang-parser.cc"
+#line 4771 "seclang-parser.cc"
     break;
 
   case 333: // var: "RUN_TIME_VAR_TIME_YEAR"
-#line 2590 "seclang-parser.yy"
+#line 2596 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4776 "seclang-parser.cc"
+#line 4782 "seclang-parser.cc"
     break;
 
   case 334: // act: "Accuracy"
-#line 2600 "seclang-parser.yy"
+#line 2606 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
       }
-#line 4784 "seclang-parser.cc"
+#line 4790 "seclang-parser.cc"
     break;
 
   case 335: // act: "Allow"
-#line 2604 "seclang-parser.yy"
+#line 2610 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
       }
-#line 4792 "seclang-parser.cc"
+#line 4798 "seclang-parser.cc"
     break;
 
   case 336: // act: "Append"
-#line 2608 "seclang-parser.yy"
+#line 2614 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 4800 "seclang-parser.cc"
+#line 4806 "seclang-parser.cc"
     break;
 
   case 337: // act: "AuditLog"
-#line 2612 "seclang-parser.yy"
+#line 2618 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 4808 "seclang-parser.cc"
+#line 4814 "seclang-parser.cc"
     break;
 
   case 338: // act: "Block"
-#line 2616 "seclang-parser.yy"
+#line 2622 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
       }
-#line 4816 "seclang-parser.cc"
+#line 4822 "seclang-parser.cc"
     break;
 
   case 339: // act: "Capture"
-#line 2620 "seclang-parser.yy"
+#line 2626 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
       }
-#line 4824 "seclang-parser.cc"
+#line 4830 "seclang-parser.cc"
     break;
 
   case 340: // act: "Chain"
-#line 2624 "seclang-parser.yy"
+#line 2630 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
       }
-#line 4832 "seclang-parser.cc"
+#line 4838 "seclang-parser.cc"
     break;
 
   case 341: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_ON"
-#line 2628 "seclang-parser.yy"
+#line 2634 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=on"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4841 "seclang-parser.cc"
+#line 4847 "seclang-parser.cc"
     break;
 
   case 342: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
-#line 2633 "seclang-parser.yy"
+#line 2639 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
       }
-#line 4849 "seclang-parser.cc"
+#line 4855 "seclang-parser.cc"
     break;
 
   case 343: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 2637 "seclang-parser.yy"
+#line 2643 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=relevantonly"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4858 "seclang-parser.cc"
+#line 4864 "seclang-parser.cc"
     break;
 
   case 344: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
-#line 2642 "seclang-parser.yy"
+#line 2648 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
       }
-#line 4866 "seclang-parser.cc"
+#line 4872 "seclang-parser.cc"
     break;
 
   case 345: // act: "ACTION_CTL_BDY_JSON"
-#line 2646 "seclang-parser.yy"
+#line 2652 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
       }
-#line 4874 "seclang-parser.cc"
+#line 4880 "seclang-parser.cc"
     break;
 
   case 346: // act: "ACTION_CTL_BDY_XML"
-#line 2650 "seclang-parser.yy"
+#line 2656 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
       }
-#line 4882 "seclang-parser.cc"
+#line 4888 "seclang-parser.cc"
     break;
 
   case 347: // act: "ACTION_CTL_BDY_URLENCODED"
-#line 2654 "seclang-parser.yy"
+#line 2660 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
       }
-#line 4890 "seclang-parser.cc"
+#line 4896 "seclang-parser.cc"
     break;
 
   case 348: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
-#line 2658 "seclang-parser.yy"
+#line 2664 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4899 "seclang-parser.cc"
+#line 4905 "seclang-parser.cc"
     break;
 
   case 349: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
-#line 2663 "seclang-parser.yy"
+#line 2669 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4908 "seclang-parser.cc"
+#line 4914 "seclang-parser.cc"
     break;
 
   case 350: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
-#line 2668 "seclang-parser.yy"
+#line 2674 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
       }
-#line 4916 "seclang-parser.cc"
+#line 4922 "seclang-parser.cc"
     break;
 
   case 351: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
-#line 2672 "seclang-parser.yy"
+#line 2678 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
       }
-#line 4924 "seclang-parser.cc"
+#line 4930 "seclang-parser.cc"
     break;
 
   case 352: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
-#line 2676 "seclang-parser.yy"
+#line 2682 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 4932 "seclang-parser.cc"
+#line 4938 "seclang-parser.cc"
     break;
 
   case 353: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
-#line 2680 "seclang-parser.yy"
+#line 2686 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 4940 "seclang-parser.cc"
+#line 4946 "seclang-parser.cc"
     break;
 
   case 354: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
-#line 2684 "seclang-parser.yy"
+#line 2690 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 4948 "seclang-parser.cc"
+#line 4954 "seclang-parser.cc"
     break;
 
   case 355: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
-#line 2688 "seclang-parser.yy"
+#line 2694 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
       }
-#line 4956 "seclang-parser.cc"
+#line 4962 "seclang-parser.cc"
     break;
 
   case 356: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
-#line 2692 "seclang-parser.yy"
+#line 2698 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 4964 "seclang-parser.cc"
+#line 4970 "seclang-parser.cc"
     break;
 
   case 357: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
-#line 2696 "seclang-parser.yy"
+#line 2702 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
       }
-#line 4972 "seclang-parser.cc"
+#line 4978 "seclang-parser.cc"
     break;
 
   case 358: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
-#line 2700 "seclang-parser.yy"
+#line 2706 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 4980 "seclang-parser.cc"
+#line 4986 "seclang-parser.cc"
     break;
 
   case 359: // act: "Deny"
-#line 2704 "seclang-parser.yy"
+#line 2710 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
       }
-#line 4988 "seclang-parser.cc"
+#line 4994 "seclang-parser.cc"
     break;
 
   case 360: // act: "DeprecateVar"
-#line 2708 "seclang-parser.yy"
+#line 2714 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 4996 "seclang-parser.cc"
+#line 5002 "seclang-parser.cc"
     break;
 
   case 361: // act: "Drop"
-#line 2712 "seclang-parser.yy"
+#line 2718 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
       }
-#line 5004 "seclang-parser.cc"
+#line 5010 "seclang-parser.cc"
     break;
 
   case 362: // act: "Exec"
-#line 2716 "seclang-parser.yy"
+#line 2722 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
       }
-#line 5012 "seclang-parser.cc"
+#line 5018 "seclang-parser.cc"
     break;
 
   case 363: // act: "ExpireVar"
-#line 2720 "seclang-parser.yy"
+#line 2726 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("ExpireVar", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[0].value.as < std::string > ()));
       }
-#line 5021 "seclang-parser.cc"
+#line 5027 "seclang-parser.cc"
     break;
 
   case 364: // act: "Id"
-#line 2725 "seclang-parser.yy"
+#line 2731 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
       }
-#line 5029 "seclang-parser.cc"
+#line 5035 "seclang-parser.cc"
     break;
 
   case 365: // act: "InitCol" run_time_string
-#line 2729 "seclang-parser.yy"
+#line 2735 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5037 "seclang-parser.cc"
+#line 5043 "seclang-parser.cc"
     break;
 
   case 366: // act: "LogData" run_time_string
-#line 2733 "seclang-parser.yy"
+#line 2739 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5045 "seclang-parser.cc"
+#line 5051 "seclang-parser.cc"
     break;
 
   case 367: // act: "Log"
-#line 2737 "seclang-parser.yy"
+#line 2743 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
       }
-#line 5053 "seclang-parser.cc"
+#line 5059 "seclang-parser.cc"
     break;
 
   case 368: // act: "Maturity"
-#line 2741 "seclang-parser.yy"
+#line 2747 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
       }
-#line 5061 "seclang-parser.cc"
+#line 5067 "seclang-parser.cc"
     break;
 
   case 369: // act: "Msg" run_time_string
-#line 2745 "seclang-parser.yy"
+#line 2751 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5069 "seclang-parser.cc"
+#line 5075 "seclang-parser.cc"
     break;
 
   case 370: // act: "MultiMatch"
-#line 2749 "seclang-parser.yy"
+#line 2755 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
       }
-#line 5077 "seclang-parser.cc"
+#line 5083 "seclang-parser.cc"
     break;
 
   case 371: // act: "NoAuditLog"
-#line 2753 "seclang-parser.yy"
+#line 2759 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5085 "seclang-parser.cc"
+#line 5091 "seclang-parser.cc"
     break;
 
   case 372: // act: "NoLog"
-#line 2757 "seclang-parser.yy"
+#line 2763 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5093 "seclang-parser.cc"
+#line 5099 "seclang-parser.cc"
     break;
 
   case 373: // act: "Pass"
-#line 2761 "seclang-parser.yy"
+#line 2767 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
       }
-#line 5101 "seclang-parser.cc"
+#line 5107 "seclang-parser.cc"
     break;
 
   case 374: // act: "Pause"
-#line 2765 "seclang-parser.yy"
+#line 2771 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 5109 "seclang-parser.cc"
+#line 5115 "seclang-parser.cc"
     break;
 
   case 375: // act: "Phase"
-#line 2769 "seclang-parser.yy"
+#line 2775 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
       }
-#line 5117 "seclang-parser.cc"
+#line 5123 "seclang-parser.cc"
     break;
 
   case 376: // act: "Prepend"
-#line 2773 "seclang-parser.yy"
+#line 2779 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 5125 "seclang-parser.cc"
+#line 5131 "seclang-parser.cc"
     break;
 
   case 377: // act: "Proxy"
-#line 2777 "seclang-parser.yy"
+#line 2783 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 5133 "seclang-parser.cc"
+#line 5139 "seclang-parser.cc"
     break;
 
   case 378: // act: "Redirect" run_time_string
-#line 2781 "seclang-parser.yy"
+#line 2787 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5141 "seclang-parser.cc"
+#line 5147 "seclang-parser.cc"
     break;
 
   case 379: // act: "Rev"
-#line 2785 "seclang-parser.yy"
+#line 2791 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
       }
-#line 5149 "seclang-parser.cc"
+#line 5155 "seclang-parser.cc"
     break;
 
   case 380: // act: "SanitiseArg"
-#line 2789 "seclang-parser.yy"
+#line 2795 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
       }
-#line 5157 "seclang-parser.cc"
+#line 5163 "seclang-parser.cc"
     break;
 
   case 381: // act: "SanitiseMatched"
-#line 2793 "seclang-parser.yy"
+#line 2799 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
       }
-#line 5165 "seclang-parser.cc"
+#line 5171 "seclang-parser.cc"
     break;
 
   case 382: // act: "SanitiseMatchedBytes"
-#line 2797 "seclang-parser.yy"
+#line 2803 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
       }
-#line 5173 "seclang-parser.cc"
+#line 5179 "seclang-parser.cc"
     break;
 
   case 383: // act: "SanitiseRequestHeader"
-#line 2801 "seclang-parser.yy"
+#line 2807 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
       }
-#line 5181 "seclang-parser.cc"
+#line 5187 "seclang-parser.cc"
     break;
 
   case 384: // act: "SanitiseResponseHeader"
-#line 2805 "seclang-parser.yy"
+#line 2811 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
       }
-#line 5189 "seclang-parser.cc"
+#line 5195 "seclang-parser.cc"
     break;
 
   case 385: // act: "SetEnv" run_time_string
-#line 2809 "seclang-parser.yy"
+#line 2815 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5197 "seclang-parser.cc"
+#line 5203 "seclang-parser.cc"
     break;
 
   case 386: // act: "SetRsc" run_time_string
-#line 2813 "seclang-parser.yy"
+#line 2819 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5205 "seclang-parser.cc"
+#line 5211 "seclang-parser.cc"
     break;
 
   case 387: // act: "SetSid" run_time_string
-#line 2817 "seclang-parser.yy"
+#line 2823 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5213 "seclang-parser.cc"
+#line 5219 "seclang-parser.cc"
     break;
 
   case 388: // act: "SetUID" run_time_string
-#line 2821 "seclang-parser.yy"
+#line 2827 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5221 "seclang-parser.cc"
+#line 5227 "seclang-parser.cc"
     break;
 
   case 389: // act: "SetVar" setvar_action
-#line 2825 "seclang-parser.yy"
+#line 2831 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
       }
-#line 5229 "seclang-parser.cc"
+#line 5235 "seclang-parser.cc"
     break;
 
   case 390: // act: "Severity"
-#line 2829 "seclang-parser.yy"
+#line 2835 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
       }
-#line 5237 "seclang-parser.cc"
+#line 5243 "seclang-parser.cc"
     break;
 
   case 391: // act: "Skip"
-#line 2833 "seclang-parser.yy"
+#line 2839 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
       }
-#line 5245 "seclang-parser.cc"
+#line 5251 "seclang-parser.cc"
     break;
 
   case 392: // act: "SkipAfter"
-#line 2837 "seclang-parser.yy"
+#line 2843 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
       }
-#line 5253 "seclang-parser.cc"
+#line 5259 "seclang-parser.cc"
     break;
 
   case 393: // act: "Status"
-#line 2841 "seclang-parser.yy"
+#line 2847 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
       }
-#line 5261 "seclang-parser.cc"
+#line 5267 "seclang-parser.cc"
     break;
 
   case 394: // act: "Tag" run_time_string
-#line 2845 "seclang-parser.yy"
+#line 2851 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5269 "seclang-parser.cc"
+#line 5275 "seclang-parser.cc"
     break;
 
   case 395: // act: "Ver"
-#line 2849 "seclang-parser.yy"
+#line 2855 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
       }
-#line 5277 "seclang-parser.cc"
+#line 5283 "seclang-parser.cc"
     break;
 
   case 396: // act: "xmlns"
-#line 2853 "seclang-parser.yy"
+#line 2859 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
       }
-#line 5285 "seclang-parser.cc"
+#line 5291 "seclang-parser.cc"
     break;
 
   case 397: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
-#line 2857 "seclang-parser.yy"
+#line 2863 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5293 "seclang-parser.cc"
+#line 5299 "seclang-parser.cc"
     break;
 
   case 398: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
-#line 2861 "seclang-parser.yy"
+#line 2867 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5301 "seclang-parser.cc"
+#line 5307 "seclang-parser.cc"
     break;
 
   case 399: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
-#line 2865 "seclang-parser.yy"
+#line 2871 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5309 "seclang-parser.cc"
+#line 5315 "seclang-parser.cc"
     break;
 
   case 400: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
-#line 2869 "seclang-parser.yy"
+#line 2875 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5317 "seclang-parser.cc"
+#line 5323 "seclang-parser.cc"
     break;
 
   case 401: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
-#line 2873 "seclang-parser.yy"
+#line 2879 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
       }
-#line 5325 "seclang-parser.cc"
+#line 5331 "seclang-parser.cc"
     break;
 
   case 402: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
-#line 2877 "seclang-parser.yy"
+#line 2883 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
       }
-#line 5333 "seclang-parser.cc"
+#line 5339 "seclang-parser.cc"
     break;
 
   case 403: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
-#line 2881 "seclang-parser.yy"
+#line 2887 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
       }
-#line 5341 "seclang-parser.cc"
+#line 5347 "seclang-parser.cc"
     break;
 
   case 404: // act: "ACTION_TRANSFORMATION_CMD_LINE"
-#line 2885 "seclang-parser.yy"
+#line 2891 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
       }
-#line 5349 "seclang-parser.cc"
+#line 5355 "seclang-parser.cc"
     break;
 
   case 405: // act: "ACTION_TRANSFORMATION_SHA1"
-#line 2889 "seclang-parser.yy"
+#line 2895 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
       }
-#line 5357 "seclang-parser.cc"
+#line 5363 "seclang-parser.cc"
     break;
 
   case 406: // act: "ACTION_TRANSFORMATION_MD5"
-#line 2893 "seclang-parser.yy"
+#line 2899 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
       }
-#line 5365 "seclang-parser.cc"
+#line 5371 "seclang-parser.cc"
     break;
 
   case 407: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
-#line 2897 "seclang-parser.yy"
+#line 2903 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5373 "seclang-parser.cc"
+#line 5379 "seclang-parser.cc"
     break;
 
   case 408: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
-#line 2901 "seclang-parser.yy"
+#line 2907 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5381 "seclang-parser.cc"
+#line 5387 "seclang-parser.cc"
     break;
 
   case 409: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
-#line 2905 "seclang-parser.yy"
+#line 2911 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5389 "seclang-parser.cc"
+#line 5395 "seclang-parser.cc"
     break;
 
   case 410: // act: "ACTION_TRANSFORMATION_LOWERCASE"
-#line 2909 "seclang-parser.yy"
+#line 2915 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5397 "seclang-parser.cc"
+#line 5403 "seclang-parser.cc"
     break;
 
   case 411: // act: "ACTION_TRANSFORMATION_UPPERCASE"
-#line 2913 "seclang-parser.yy"
+#line 2919 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5405 "seclang-parser.cc"
+#line 5411 "seclang-parser.cc"
     break;
 
   case 412: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
-#line 2917 "seclang-parser.yy"
+#line 2923 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
       }
-#line 5413 "seclang-parser.cc"
+#line 5419 "seclang-parser.cc"
     break;
 
   case 413: // act: "ACTION_TRANSFORMATION_URL_DECODE"
-#line 2921 "seclang-parser.yy"
+#line 2927 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5421 "seclang-parser.cc"
+#line 5427 "seclang-parser.cc"
     break;
 
   case 414: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
-#line 2925 "seclang-parser.yy"
+#line 2931 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5429 "seclang-parser.cc"
+#line 5435 "seclang-parser.cc"
     break;
 
   case 415: // act: "ACTION_TRANSFORMATION_NONE"
-#line 2929 "seclang-parser.yy"
+#line 2935 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
       }
-#line 5437 "seclang-parser.cc"
+#line 5443 "seclang-parser.cc"
     break;
 
   case 416: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
-#line 2933 "seclang-parser.yy"
+#line 2939 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5445 "seclang-parser.cc"
+#line 5451 "seclang-parser.cc"
     break;
 
   case 417: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
-#line 2937 "seclang-parser.yy"
+#line 2943 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5453 "seclang-parser.cc"
+#line 5459 "seclang-parser.cc"
     break;
 
   case 418: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
-#line 2941 "seclang-parser.yy"
+#line 2947 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5461 "seclang-parser.cc"
+#line 5467 "seclang-parser.cc"
     break;
 
   case 419: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
-#line 2945 "seclang-parser.yy"
+#line 2951 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5469 "seclang-parser.cc"
+#line 5475 "seclang-parser.cc"
     break;
 
   case 420: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
-#line 2949 "seclang-parser.yy"
+#line 2955 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5477 "seclang-parser.cc"
+#line 5483 "seclang-parser.cc"
     break;
 
   case 421: // act: "ACTION_TRANSFORMATION_JS_DECODE"
-#line 2953 "seclang-parser.yy"
+#line 2959 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5485 "seclang-parser.cc"
+#line 5491 "seclang-parser.cc"
     break;
 
   case 422: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
-#line 2957 "seclang-parser.yy"
+#line 2963 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5493 "seclang-parser.cc"
+#line 5499 "seclang-parser.cc"
     break;
 
   case 423: // act: "ACTION_TRANSFORMATION_TRIM"
-#line 2961 "seclang-parser.yy"
+#line 2967 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
       }
-#line 5501 "seclang-parser.cc"
+#line 5507 "seclang-parser.cc"
     break;
 
   case 424: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
-#line 2965 "seclang-parser.yy"
+#line 2971 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
       }
-#line 5509 "seclang-parser.cc"
+#line 5515 "seclang-parser.cc"
     break;
 
   case 425: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
-#line 2969 "seclang-parser.yy"
+#line 2975 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
       }
-#line 5517 "seclang-parser.cc"
+#line 5523 "seclang-parser.cc"
     break;
 
   case 426: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
-#line 2973 "seclang-parser.yy"
+#line 2979 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
       }
-#line 5525 "seclang-parser.cc"
+#line 5531 "seclang-parser.cc"
     break;
 
   case 427: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
-#line 2977 "seclang-parser.yy"
+#line 2983 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
       }
-#line 5533 "seclang-parser.cc"
+#line 5539 "seclang-parser.cc"
     break;
 
   case 428: // act: "ACTION_TRANSFORMATION_LENGTH"
-#line 2981 "seclang-parser.yy"
+#line 2987 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
       }
-#line 5541 "seclang-parser.cc"
+#line 5547 "seclang-parser.cc"
     break;
 
   case 429: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
-#line 2985 "seclang-parser.yy"
+#line 2991 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
       }
-#line 5549 "seclang-parser.cc"
+#line 5555 "seclang-parser.cc"
     break;
 
   case 430: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
-#line 2989 "seclang-parser.yy"
+#line 2995 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
       }
-#line 5557 "seclang-parser.cc"
+#line 5563 "seclang-parser.cc"
     break;
 
   case 431: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
-#line 2993 "seclang-parser.yy"
+#line 2999 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5565 "seclang-parser.cc"
+#line 5571 "seclang-parser.cc"
     break;
 
   case 432: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
-#line 2997 "seclang-parser.yy"
+#line 3003 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5573 "seclang-parser.cc"
+#line 5579 "seclang-parser.cc"
     break;
 
   case 433: // setvar_action: "NOT" var
-#line 3004 "seclang-parser.yy"
+#line 3010 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5581 "seclang-parser.cc"
+#line 5587 "seclang-parser.cc"
     break;
 
   case 434: // setvar_action: var
-#line 3008 "seclang-parser.yy"
+#line 3014 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5589 "seclang-parser.cc"
+#line 5595 "seclang-parser.cc"
     break;
 
   case 435: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
-#line 3012 "seclang-parser.yy"
+#line 3018 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5597 "seclang-parser.cc"
+#line 5603 "seclang-parser.cc"
     break;
 
   case 436: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
-#line 3016 "seclang-parser.yy"
+#line 3022 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5605 "seclang-parser.cc"
+#line 5611 "seclang-parser.cc"
     break;
 
   case 437: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
-#line 3020 "seclang-parser.yy"
+#line 3026 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5613 "seclang-parser.cc"
+#line 5619 "seclang-parser.cc"
     break;
 
   case 438: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3027 "seclang-parser.yy"
+#line 3033 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5622 "seclang-parser.cc"
+#line 5628 "seclang-parser.cc"
     break;
 
   case 439: // run_time_string: run_time_string var
-#line 3032 "seclang-parser.yy"
+#line 3038 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5631 "seclang-parser.cc"
+#line 5637 "seclang-parser.cc"
     break;
 
   case 440: // run_time_string: "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3037 "seclang-parser.yy"
+#line 3043 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5641 "seclang-parser.cc"
+#line 5647 "seclang-parser.cc"
     break;
 
   case 441: // run_time_string: var
-#line 3043 "seclang-parser.yy"
+#line 3049 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5651 "seclang-parser.cc"
+#line 5657 "seclang-parser.cc"
     break;
 
 
-#line 5655 "seclang-parser.cc"
+#line 5661 "seclang-parser.cc"
 
             default:
               break;
@@ -5889,16 +5895,16 @@ namespace yy {
     // Actual number of expected tokens
     int yycount = 0;
 
-    int yyn = yypact_[+yyparser_.yystack_[0].state];
+    const int yyn = yypact_[+yyparser_.yystack_[0].state];
     if (!yy_pact_value_is_default_ (yyn))
       {
         /* Start YYX at -YYN if negative to avoid negative indexes in
            YYCHECK.  In other words, skip the first -YYN actions for
            this state because they are default actions.  */
-        int yyxbegin = yyn < 0 ? -yyn : 0;
+        const int yyxbegin = yyn < 0 ? -yyn : 0;
         // Stay within bounds of both yycheck and yytname.
-        int yychecklim = yylast_ - yyn + 1;
-        int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+        const int yychecklim = yylast_ - yyn + 1;
+        const int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
         for (int yyx = yyxbegin; yyx < yyxend; ++yyx)
           if (yycheck_[yyx + yyn] == yyx && yyx != symbol_kind::S_YYerror
               && !yy_table_value_is_error_ (yytable_[yyx + yyn]))
@@ -5916,6 +5922,9 @@ namespace yy {
       yyarg[0] = symbol_kind::S_YYEMPTY;
     return yycount;
   }
+
+
+
 
 
 
@@ -6130,7 +6139,7 @@ namespace yy {
   const short
   seclang_parser::yydefgoto_[] =
   {
-      -1,    82,    83,    84,   209,   210,   476,   477,    85,   335,
+       0,    82,    83,    84,   209,   210,   476,   477,    85,   335,
      322,   323,   354,   211,   342,   355
   };
 
@@ -7159,39 +7168,39 @@ namespace yy {
     1276,  1281,  1284,  1289,  1294,  1299,  1304,  1307,  1312,  1315,
     1320,  1325,  1328,  1333,  1338,  1343,  1348,  1353,  1358,  1363,
     1366,  1371,  1376,  1381,  1386,  1389,  1394,  1399,  1404,  1417,
-    1430,  1443,  1456,  1469,  1495,  1523,  1535,  1555,  1582,  1587,
-    1593,  1598,  1603,  1612,  1617,  1621,  1625,  1629,  1633,  1637,
-    1641,  1646,  1651,  1663,  1669,  1673,  1677,  1688,  1697,  1698,
-    1705,  1710,  1715,  1769,  1776,  1784,  1821,  1825,  1832,  1837,
-    1843,  1849,  1855,  1862,  1872,  1876,  1880,  1884,  1888,  1892,
-    1896,  1900,  1904,  1908,  1912,  1916,  1920,  1924,  1928,  1932,
-    1936,  1940,  1944,  1948,  1952,  1956,  1960,  1964,  1968,  1972,
-    1976,  1980,  1984,  1988,  1992,  1996,  2000,  2004,  2008,  2012,
-    2016,  2020,  2024,  2028,  2032,  2036,  2040,  2044,  2048,  2052,
-    2056,  2060,  2064,  2068,  2072,  2076,  2080,  2084,  2088,  2092,
-    2096,  2100,  2104,  2108,  2112,  2116,  2120,  2124,  2128,  2132,
-    2136,  2140,  2144,  2148,  2152,  2156,  2160,  2164,  2168,  2172,
-    2176,  2180,  2184,  2188,  2192,  2196,  2200,  2204,  2208,  2212,
-    2216,  2220,  2224,  2228,  2233,  2237,  2241,  2246,  2250,  2254,
-    2259,  2264,  2268,  2272,  2276,  2280,  2284,  2288,  2292,  2296,
-    2300,  2304,  2308,  2312,  2316,  2320,  2324,  2328,  2332,  2336,
-    2340,  2344,  2348,  2352,  2356,  2360,  2364,  2368,  2372,  2376,
-    2380,  2384,  2388,  2392,  2396,  2400,  2404,  2408,  2412,  2416,
-    2420,  2424,  2428,  2432,  2436,  2440,  2444,  2448,  2452,  2456,
-    2460,  2464,  2468,  2472,  2476,  2480,  2484,  2488,  2492,  2496,
-    2500,  2504,  2512,  2519,  2526,  2533,  2540,  2547,  2554,  2561,
-    2568,  2575,  2582,  2589,  2599,  2603,  2607,  2611,  2615,  2619,
-    2623,  2627,  2632,  2636,  2641,  2645,  2649,  2653,  2657,  2662,
-    2667,  2671,  2675,  2679,  2683,  2687,  2691,  2695,  2699,  2703,
-    2707,  2711,  2715,  2719,  2724,  2728,  2732,  2736,  2740,  2744,
-    2748,  2752,  2756,  2760,  2764,  2768,  2772,  2776,  2780,  2784,
-    2788,  2792,  2796,  2800,  2804,  2808,  2812,  2816,  2820,  2824,
-    2828,  2832,  2836,  2840,  2844,  2848,  2852,  2856,  2860,  2864,
-    2868,  2872,  2876,  2880,  2884,  2888,  2892,  2896,  2900,  2904,
-    2908,  2912,  2916,  2920,  2924,  2928,  2932,  2936,  2940,  2944,
-    2948,  2952,  2956,  2960,  2964,  2968,  2972,  2976,  2980,  2984,
-    2988,  2992,  2996,  3003,  3007,  3011,  3015,  3019,  3026,  3031,
-    3036,  3042
+    1430,  1443,  1456,  1469,  1497,  1527,  1539,  1559,  1586,  1591,
+    1597,  1602,  1607,  1616,  1621,  1625,  1629,  1633,  1637,  1641,
+    1645,  1650,  1655,  1667,  1673,  1677,  1681,  1692,  1701,  1702,
+    1709,  1714,  1719,  1775,  1782,  1790,  1827,  1831,  1838,  1843,
+    1849,  1855,  1861,  1868,  1878,  1882,  1886,  1890,  1894,  1898,
+    1902,  1906,  1910,  1914,  1918,  1922,  1926,  1930,  1934,  1938,
+    1942,  1946,  1950,  1954,  1958,  1962,  1966,  1970,  1974,  1978,
+    1982,  1986,  1990,  1994,  1998,  2002,  2006,  2010,  2014,  2018,
+    2022,  2026,  2030,  2034,  2038,  2042,  2046,  2050,  2054,  2058,
+    2062,  2066,  2070,  2074,  2078,  2082,  2086,  2090,  2094,  2098,
+    2102,  2106,  2110,  2114,  2118,  2122,  2126,  2130,  2134,  2138,
+    2142,  2146,  2150,  2154,  2158,  2162,  2166,  2170,  2174,  2178,
+    2182,  2186,  2190,  2194,  2198,  2202,  2206,  2210,  2214,  2218,
+    2222,  2226,  2230,  2234,  2239,  2243,  2247,  2252,  2256,  2260,
+    2265,  2270,  2274,  2278,  2282,  2286,  2290,  2294,  2298,  2302,
+    2306,  2310,  2314,  2318,  2322,  2326,  2330,  2334,  2338,  2342,
+    2346,  2350,  2354,  2358,  2362,  2366,  2370,  2374,  2378,  2382,
+    2386,  2390,  2394,  2398,  2402,  2406,  2410,  2414,  2418,  2422,
+    2426,  2430,  2434,  2438,  2442,  2446,  2450,  2454,  2458,  2462,
+    2466,  2470,  2474,  2478,  2482,  2486,  2490,  2494,  2498,  2502,
+    2506,  2510,  2518,  2525,  2532,  2539,  2546,  2553,  2560,  2567,
+    2574,  2581,  2588,  2595,  2605,  2609,  2613,  2617,  2621,  2625,
+    2629,  2633,  2638,  2642,  2647,  2651,  2655,  2659,  2663,  2668,
+    2673,  2677,  2681,  2685,  2689,  2693,  2697,  2701,  2705,  2709,
+    2713,  2717,  2721,  2725,  2730,  2734,  2738,  2742,  2746,  2750,
+    2754,  2758,  2762,  2766,  2770,  2774,  2778,  2782,  2786,  2790,
+    2794,  2798,  2802,  2806,  2810,  2814,  2818,  2822,  2826,  2830,
+    2834,  2838,  2842,  2846,  2850,  2854,  2858,  2862,  2866,  2870,
+    2874,  2878,  2882,  2886,  2890,  2894,  2898,  2902,  2906,  2910,
+    2914,  2918,  2922,  2926,  2930,  2934,  2938,  2942,  2946,  2950,
+    2954,  2958,  2962,  2966,  2970,  2974,  2978,  2982,  2986,  2990,
+    2994,  2998,  3002,  3009,  3013,  3017,  3021,  3025,  3032,  3037,
+    3042,  3048
   };
 
   void
@@ -7223,9 +7232,9 @@ namespace yy {
 
 
 } // yy
-#line 7227 "seclang-parser.cc"
+#line 7236 "seclang-parser.cc"
 
-#line 3049 "seclang-parser.yy"
+#line 3055 "seclang-parser.yy"
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.hh
+++ b/src/parser/seclang-parser.hh
@@ -1,8 +1,8 @@
-// A Bison parser, made by GNU Bison 3.7.2.
+// A Bison parser, made by GNU Bison 3.8.2.
 
 // Skeleton interface for Bison LALR(1) parsers in C++
 
-// Copyright (C) 2002-2015, 2018-2020 Free Software Foundation, Inc.
+// Copyright (C) 2002-2015, 2018-2021 Free Software Foundation, Inc.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // As a special exception, you may create a larger work that contains
 // part or all of the Bison parser skeleton and distribute that work
@@ -32,7 +32,7 @@
 
 
 /**
- ** \file y.tab.h
+ ** \file seclang-parser.hh
  ** Define the yy::parser class.
  */
 
@@ -422,17 +422,23 @@ using namespace modsecurity::operators;
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(E) ((void) (E))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
     _Pragma ("GCC diagnostic push")                                     \
     _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
 # define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
@@ -485,7 +491,7 @@ using namespace modsecurity::operators;
 #endif
 
 namespace yy {
-#line 489 "seclang-parser.hh"
+#line 495 "seclang-parser.hh"
 
 
 
@@ -494,27 +500,32 @@ namespace yy {
   class seclang_parser
   {
   public:
-#ifndef YYSTYPE
+#ifdef YYSTYPE
+# ifdef __GNUC__
+#  pragma GCC message "bison: do not #define YYSTYPE in C++, use %define api.value.type"
+# endif
+    typedef YYSTYPE value_type;
+#else
   /// A buffer to store and retrieve objects.
   ///
   /// Sort of a variant, but does not keep track of the nature
   /// of the stored data, since that knowledge is available
   /// via the current parser state.
-  class semantic_type
+  class value_type
   {
   public:
     /// Type of *this.
-    typedef semantic_type self_type;
+    typedef value_type self_type;
 
     /// Empty construction.
-    semantic_type () YY_NOEXCEPT
-      : yybuffer_ ()
+    value_type () YY_NOEXCEPT
+      : yyraw_ ()
       , yytypeid_ (YY_NULLPTR)
     {}
 
     /// Construct and fill.
     template <typename T>
-    semantic_type (YY_RVREF (T) t)
+    value_type (YY_RVREF (T) t)
       : yytypeid_ (&typeid (T))
     {
       YY_ASSERT (sizeof (T) <= size);
@@ -523,13 +534,13 @@ namespace yy {
 
 #if 201103L <= YY_CPLUSPLUS
     /// Non copyable.
-    semantic_type (const self_type&) = delete;
+    value_type (const self_type&) = delete;
     /// Non copyable.
     self_type& operator= (const self_type&) = delete;
 #endif
 
     /// Destruction, allowed only if empty.
-    ~semantic_type () YY_NOEXCEPT
+    ~value_type () YY_NOEXCEPT
     {
       YY_ASSERT (!yytypeid_);
     }
@@ -565,7 +576,7 @@ namespace yy {
       YY_ASSERT (!yytypeid_);
       YY_ASSERT (sizeof (T) <= size);
       yytypeid_ = & typeid (T);
-      return *new (yyas_<T> ()) T (std::move((T&)t));
+      return *new (yyas_<T> ()) T (t);
     }
 # endif
 
@@ -673,7 +684,7 @@ namespace yy {
   private:
 #if YY_CPLUSPLUS < 201103L
     /// Non copyable.
-    semantic_type (const self_type&);
+    value_type (const self_type&);
     /// Non copyable.
     self_type& operator= (const self_type&);
 #endif
@@ -683,7 +694,7 @@ namespace yy {
     T*
     yyas_ () YY_NOEXCEPT
     {
-      void *yyp = yybuffer_.yyraw;
+      void *yyp = yyraw_;
       return static_cast<T*> (yyp);
      }
 
@@ -692,7 +703,7 @@ namespace yy {
     const T*
     yyas_ () const YY_NOEXCEPT
     {
-      const void *yyp = yybuffer_.yyraw;
+      const void *yyp = yyraw_;
       return static_cast<const T*> (yyp);
      }
 
@@ -930,18 +941,19 @@ namespace yy {
     union
     {
       /// Strongest alignment constraints.
-      long double yyalign_me;
+      long double yyalign_me_;
       /// A buffer large enough to store any of the semantic values.
-      char yyraw[size];
-    } yybuffer_;
+      char yyraw_[size];
+    };
 
     /// Whether the content is built: if defined, the name of the stored type.
     const std::type_info *yytypeid_;
   };
 
-#else
-    typedef YYSTYPE semantic_type;
 #endif
+    /// Backward compatibility (Bison 3.8).
+    typedef value_type semantic_type;
+
     /// Symbol locations.
     typedef location location_type;
 
@@ -1319,7 +1331,7 @@ namespace yy {
     };
 
     /// Token kind, as returned by yylex.
-    typedef token::yytokentype token_kind_type;
+    typedef token::token_kind_type token_kind_type;
 
     /// Backward compatibility alias (Bison 3.6).
     typedef token_kind_type token_type;
@@ -1713,7 +1725,7 @@ namespace yy {
       typedef Base super_type;
 
       /// Default constructor.
-      basic_symbol ()
+      basic_symbol () YY_NOEXCEPT
         : value ()
         , location ()
       {}
@@ -1967,7 +1979,7 @@ namespace yy {
       /// Copy constructor.
       basic_symbol (const basic_symbol& that);
 
-      /// Constructor for valueless symbols, and symbols from each type.
+      /// Constructors for typed symbols.
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, location_type&& l)
         : Base (t)
@@ -1979,6 +1991,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::string&& v, location_type&& l)
         : Base (t)
@@ -1992,6 +2005,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::unique_ptr<Operator>&& v, location_type&& l)
         : Base (t)
@@ -2005,6 +2019,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::unique_ptr<RunTimeString>&& v, location_type&& l)
         : Base (t)
@@ -2018,6 +2033,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::unique_ptr<Variable>&& v, location_type&& l)
         : Base (t)
@@ -2031,6 +2047,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::unique_ptr<actions::Action>&& v, location_type&& l)
         : Base (t)
@@ -2044,6 +2061,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::unique_ptr<std::vector<std::unique_ptr<Variable> > > && v, location_type&& l)
         : Base (t)
@@ -2057,6 +2075,7 @@ namespace yy {
         , location (l)
       {}
 #endif
+
 #if 201103L <= YY_CPLUSPLUS
       basic_symbol (typename Base::kind_type t, std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > > && v, location_type&& l)
         : Base (t)
@@ -2077,8 +2096,10 @@ namespace yy {
         clear ();
       }
 
+
+
       /// Destroy contents, and record that is empty.
-      void clear ()
+      void clear () YY_NOEXCEPT
       {
         // User destructor.
         symbol_kind_type yykind = this->kind ();
@@ -2346,7 +2367,7 @@ switch (yykind)
       void move (basic_symbol& s);
 
       /// The semantic value.
-      semantic_type value;
+      value_type value;
 
       /// The location.
       location_type location;
@@ -2361,25 +2382,27 @@ switch (yykind)
     /// Type access provider for token (enum) based symbols.
     struct by_kind
     {
-      /// Default constructor.
-      by_kind ();
-
-#if 201103L <= YY_CPLUSPLUS
-      /// Move constructor.
-      by_kind (by_kind&& that);
-#endif
-
-      /// Copy constructor.
-      by_kind (const by_kind& that);
-
       /// The symbol kind as needed by the constructor.
       typedef token_kind_type kind_type;
 
+      /// Default constructor.
+      by_kind () YY_NOEXCEPT;
+
+#if 201103L <= YY_CPLUSPLUS
+      /// Move constructor.
+      by_kind (by_kind&& that) YY_NOEXCEPT;
+#endif
+
+      /// Copy constructor.
+      by_kind (const by_kind& that) YY_NOEXCEPT;
+
       /// Constructor from (external) token numbers.
-      by_kind (kind_type t);
+      by_kind (kind_type t) YY_NOEXCEPT;
+
+
 
       /// Record that this symbol is empty.
-      void clear ();
+      void clear () YY_NOEXCEPT;
 
       /// Steal the symbol kind from \a that.
       void move (by_kind& that);
@@ -2406,35 +2429,34 @@ switch (yykind)
       typedef basic_symbol<by_kind> super_type;
 
       /// Empty symbol.
-      symbol_type () {}
+      symbol_type () YY_NOEXCEPT {}
 
       /// Constructor for valueless symbols, and symbols from each type.
 #if 201103L <= YY_CPLUSPLUS
       symbol_type (int tok, location_type l)
-        : super_type(token_type (tok), std::move (l))
-      {
-        YY_ASSERT (tok == token::TOK_END || tok == token::TOK_YYerror || tok == token::TOK_YYUNDEF || tok == token::TOK_COMMA || tok == token::TOK_CONFIG_CONTENT_INJECTION || tok == token::TOK_CONGIG_DIR_RESPONSE_BODY_MP_CLEAR || tok == token::TOK_PIPE || tok == token::TOK_NEW_LINE || tok == token::TOK_VAR_COUNT || tok == token::TOK_VAR_EXCLUSION || tok == token::TOK_VARIABLE_ARGS || tok == token::TOK_VARIABLE_ARGS_POST || tok == token::TOK_VARIABLE_ARGS_GET || tok == token::TOK_VARIABLE_FILES_SIZES || tok == token::TOK_VARIABLE_FILES_NAMES || tok == token::TOK_VARIABLE_FILES_TMP_CONTENT || tok == token::TOK_VARIABLE_MULTIPART_FILENAME || tok == token::TOK_VARIABLE_MULTIPART_NAME || tok == token::TOK_VARIABLE_MATCHED_VARS_NAMES || tok == token::TOK_VARIABLE_MATCHED_VARS || tok == token::TOK_VARIABLE_FILES || tok == token::TOK_VARIABLE_REQUEST_COOKIES || tok == token::TOK_VARIABLE_REQUEST_HEADERS || tok == token::TOK_VARIABLE_RESPONSE_HEADERS || tok == token::TOK_VARIABLE_GEO || tok == token::TOK_VARIABLE_REQUEST_COOKIES_NAMES || tok == token::TOK_VARIABLE_ARGS_COMBINED_SIZE || tok == token::TOK_VARIABLE_ARGS_GET_NAMES || tok == token::TOK_VARIABLE_RULE || tok == token::TOK_VARIABLE_ARGS_NAMES || tok == token::TOK_VARIABLE_ARGS_POST_NAMES || tok == token::TOK_VARIABLE_AUTH_TYPE || tok == token::TOK_VARIABLE_FILES_COMBINED_SIZE || tok == token::TOK_VARIABLE_FILES_TMP_NAMES || tok == token::TOK_VARIABLE_FULL_REQUEST || tok == token::TOK_VARIABLE_FULL_REQUEST_LENGTH || tok == token::TOK_VARIABLE_INBOUND_DATA_ERROR || tok == token::TOK_VARIABLE_MATCHED_VAR || tok == token::TOK_VARIABLE_MATCHED_VAR_NAME || tok == token::TOK_VARIABLE_MULTIPART_BOUNDARY_QUOTED || tok == token::TOK_VARIABLE_MULTIPART_BOUNDARY_WHITESPACE || tok == token::TOK_VARIABLE_MULTIPART_CRLF_LF_LINES || tok == token::TOK_VARIABLE_MULTIPART_DATA_AFTER || tok == token::TOK_VARIABLE_MULTIPART_DATA_BEFORE || tok == token::TOK_VARIABLE_MULTIPART_FILE_LIMIT_EXCEEDED || tok == token::TOK_VARIABLE_MULTIPART_HEADER_FOLDING || tok == token::TOK_VARIABLE_MULTIPART_INVALID_HEADER_FOLDING || tok == token::TOK_VARIABLE_MULTIPART_INVALID_PART || tok == token::TOK_VARIABLE_MULTIPART_INVALID_QUOTING || tok == token::TOK_VARIABLE_MULTIPART_LF_LINE || tok == token::TOK_VARIABLE_MULTIPART_MISSING_SEMICOLON || tok == token::TOK_VARIABLE_MULTIPART_SEMICOLON_MISSING || tok == token::TOK_VARIABLE_MULTIPART_STRICT_ERROR || tok == token::TOK_VARIABLE_MULTIPART_UNMATCHED_BOUNDARY || tok == token::TOK_VARIABLE_OUTBOUND_DATA_ERROR || tok == token::TOK_VARIABLE_PATH_INFO || tok == token::TOK_VARIABLE_QUERY_STRING || tok == token::TOK_VARIABLE_REMOTE_ADDR || tok == token::TOK_VARIABLE_REMOTE_HOST || tok == token::TOK_VARIABLE_REMOTE_PORT || tok == token::TOK_VARIABLE_REQBODY_ERROR_MSG || tok == token::TOK_VARIABLE_REQBODY_ERROR || tok == token::TOK_VARIABLE_REQBODY_PROCESSOR_ERROR_MSG || tok == token::TOK_VARIABLE_REQBODY_PROCESSOR_ERROR || tok == token::TOK_VARIABLE_REQBODY_PROCESSOR || tok == token::TOK_VARIABLE_REQUEST_BASENAME || tok == token::TOK_VARIABLE_REQUEST_BODY_LENGTH || tok == token::TOK_VARIABLE_REQUEST_BODY || tok == token::TOK_VARIABLE_REQUEST_FILE_NAME || tok == token::TOK_VARIABLE_REQUEST_HEADERS_NAMES || tok == token::TOK_VARIABLE_REQUEST_LINE || tok == token::TOK_VARIABLE_REQUEST_METHOD || tok == token::TOK_VARIABLE_REQUEST_PROTOCOL || tok == token::TOK_VARIABLE_REQUEST_URI_RAW || tok == token::TOK_VARIABLE_REQUEST_URI || tok == token::TOK_VARIABLE_RESOURCE || tok == token::TOK_VARIABLE_RESPONSE_BODY || tok == token::TOK_VARIABLE_RESPONSE_CONTENT_LENGTH || tok == token::TOK_VARIABLE_RESPONSE_CONTENT_TYPE || tok == token::TOK_VARIABLE_RESPONSE_HEADERS_NAMES || tok == token::TOK_VARIABLE_RESPONSE_PROTOCOL || tok == token::TOK_VARIABLE_RESPONSE_STATUS || tok == token::TOK_VARIABLE_SERVER_ADDR || tok == token::TOK_VARIABLE_SERVER_NAME || tok == token::TOK_VARIABLE_SERVER_PORT || tok == token::TOK_VARIABLE_SESSION_ID || tok == token::TOK_VARIABLE_UNIQUE_ID || tok == token::TOK_VARIABLE_URL_ENCODED_ERROR || tok == token::TOK_VARIABLE_USER_ID || tok == token::TOK_VARIABLE_WEB_APP_ID || tok == token::TOK_VARIABLE_STATUS || tok == token::TOK_VARIABLE_STATUS_LINE || tok == token::TOK_VARIABLE_IP || tok == token::TOK_VARIABLE_GLOBAL || tok == token::TOK_VARIABLE_TX || tok == token::TOK_VARIABLE_SESSION || tok == token::TOK_VARIABLE_USER || tok == token::TOK_RUN_TIME_VAR_ENV || tok == token::TOK_RUN_TIME_VAR_XML || tok == token::TOK_ACTION_SETVAR || tok == token::TOK_SETVAR_OPERATION_EQUALS || tok == token::TOK_SETVAR_OPERATION_EQUALS_PLUS || tok == token::TOK_SETVAR_OPERATION_EQUALS_MINUS || tok == token::TOK_NOT || tok == token::TOK_OPERATOR_BEGINS_WITH || tok == token::TOK_OPERATOR_CONTAINS || tok == token::TOK_OPERATOR_CONTAINS_WORD || tok == token::TOK_OPERATOR_DETECT_SQLI || tok == token::TOK_OPERATOR_DETECT_XSS || tok == token::TOK_OPERATOR_ENDS_WITH || tok == token::TOK_OPERATOR_EQ || tok == token::TOK_OPERATOR_FUZZY_HASH || tok == token::TOK_OPERATOR_GEOLOOKUP || tok == token::TOK_OPERATOR_GE || tok == token::TOK_OPERATOR_GSB_LOOKUP || tok == token::TOK_OPERATOR_GT || tok == token::TOK_OPERATOR_INSPECT_FILE || tok == token::TOK_OPERATOR_IP_MATCH_FROM_FILE || tok == token::TOK_OPERATOR_IP_MATCH || tok == token::TOK_OPERATOR_LE || tok == token::TOK_OPERATOR_LT || tok == token::TOK_OPERATOR_PM_FROM_FILE || tok == token::TOK_OPERATOR_PM || tok == token::TOK_OPERATOR_RBL || tok == token::TOK_OPERATOR_RSUB || tok == token::TOK_OPERATOR_RX_CONTENT_ONLY || tok == token::TOK_OPERATOR_RX || tok == token::TOK_OPERATOR_RX_GLOBAL || tok == token::TOK_OPERATOR_STR_EQ || tok == token::TOK_OPERATOR_STR_MATCH || tok == token::TOK_OPERATOR_UNCONDITIONAL_MATCH || tok == token::TOK_OPERATOR_VALIDATE_BYTE_RANGE || tok == token::TOK_OPERATOR_VALIDATE_DTD || tok == token::TOK_OPERATOR_VALIDATE_HASH || tok == token::TOK_OPERATOR_VALIDATE_SCHEMA || tok == token::TOK_OPERATOR_VALIDATE_URL_ENCODING || tok == token::TOK_OPERATOR_VALIDATE_UTF8_ENCODING || tok == token::TOK_OPERATOR_VERIFY_CC || tok == token::TOK_OPERATOR_VERIFY_CPF || tok == token::TOK_OPERATOR_VERIFY_SSN || tok == token::TOK_OPERATOR_VERIFY_SVNR || tok == token::TOK_OPERATOR_WITHIN || tok == token::TOK_CONFIG_DIR_AUDIT_LOG_FMT || tok == token::TOK_JSON || tok == token::TOK_NATIVE || tok == token::TOK_ACTION_CTL_RULE_ENGINE);
-      }
+        : super_type (token_kind_type (tok), std::move (l))
 #else
       symbol_type (int tok, const location_type& l)
-        : super_type(token_type (tok), l)
-      {
-        YY_ASSERT (tok == token::TOK_END || tok == token::TOK_YYerror || tok == token::TOK_YYUNDEF || tok == token::TOK_COMMA || tok == token::TOK_CONFIG_CONTENT_INJECTION || tok == token::TOK_CONGIG_DIR_RESPONSE_BODY_MP_CLEAR || tok == token::TOK_PIPE || tok == token::TOK_NEW_LINE || tok == token::TOK_VAR_COUNT || tok == token::TOK_VAR_EXCLUSION || tok == token::TOK_VARIABLE_ARGS || tok == token::TOK_VARIABLE_ARGS_POST || tok == token::TOK_VARIABLE_ARGS_GET || tok == token::TOK_VARIABLE_FILES_SIZES || tok == token::TOK_VARIABLE_FILES_NAMES || tok == token::TOK_VARIABLE_FILES_TMP_CONTENT || tok == token::TOK_VARIABLE_MULTIPART_FILENAME || tok == token::TOK_VARIABLE_MULTIPART_NAME || tok == token::TOK_VARIABLE_MATCHED_VARS_NAMES || tok == token::TOK_VARIABLE_MATCHED_VARS || tok == token::TOK_VARIABLE_FILES || tok == token::TOK_VARIABLE_REQUEST_COOKIES || tok == token::TOK_VARIABLE_REQUEST_HEADERS || tok == token::TOK_VARIABLE_RESPONSE_HEADERS || tok == token::TOK_VARIABLE_GEO || tok == token::TOK_VARIABLE_REQUEST_COOKIES_NAMES || tok == token::TOK_VARIABLE_ARGS_COMBINED_SIZE || tok == token::TOK_VARIABLE_ARGS_GET_NAMES || tok == token::TOK_VARIABLE_RULE || tok == token::TOK_VARIABLE_ARGS_NAMES || tok == token::TOK_VARIABLE_ARGS_POST_NAMES || tok == token::TOK_VARIABLE_AUTH_TYPE || tok == token::TOK_VARIABLE_FILES_COMBINED_SIZE || tok == token::TOK_VARIABLE_FILES_TMP_NAMES || tok == token::TOK_VARIABLE_FULL_REQUEST || tok == token::TOK_VARIABLE_FULL_REQUEST_LENGTH || tok == token::TOK_VARIABLE_INBOUND_DATA_ERROR || tok == token::TOK_VARIABLE_MATCHED_VAR || tok == token::TOK_VARIABLE_MATCHED_VAR_NAME || tok == token::TOK_VARIABLE_MULTIPART_BOUNDARY_QUOTED || tok == token::TOK_VARIABLE_MULTIPART_BOUNDARY_WHITESPACE || tok == token::TOK_VARIABLE_MULTIPART_CRLF_LF_LINES || tok == token::TOK_VARIABLE_MULTIPART_DATA_AFTER || tok == token::TOK_VARIABLE_MULTIPART_DATA_BEFORE || tok == token::TOK_VARIABLE_MULTIPART_FILE_LIMIT_EXCEEDED || tok == token::TOK_VARIABLE_MULTIPART_HEADER_FOLDING || tok == token::TOK_VARIABLE_MULTIPART_INVALID_HEADER_FOLDING || tok == token::TOK_VARIABLE_MULTIPART_INVALID_PART || tok == token::TOK_VARIABLE_MULTIPART_INVALID_QUOTING || tok == token::TOK_VARIABLE_MULTIPART_LF_LINE || tok == token::TOK_VARIABLE_MULTIPART_MISSING_SEMICOLON || tok == token::TOK_VARIABLE_MULTIPART_SEMICOLON_MISSING || tok == token::TOK_VARIABLE_MULTIPART_STRICT_ERROR || tok == token::TOK_VARIABLE_MULTIPART_UNMATCHED_BOUNDARY || tok == token::TOK_VARIABLE_OUTBOUND_DATA_ERROR || tok == token::TOK_VARIABLE_PATH_INFO || tok == token::TOK_VARIABLE_QUERY_STRING || tok == token::TOK_VARIABLE_REMOTE_ADDR || tok == token::TOK_VARIABLE_REMOTE_HOST || tok == token::TOK_VARIABLE_REMOTE_PORT || tok == token::TOK_VARIABLE_REQBODY_ERROR_MSG || tok == token::TOK_VARIABLE_REQBODY_ERROR || tok == token::TOK_VARIABLE_REQBODY_PROCESSOR_ERROR_MSG || tok == token::TOK_VARIABLE_REQBODY_PROCESSOR_ERROR || tok == token::TOK_VARIABLE_REQBODY_PROCESSOR || tok == token::TOK_VARIABLE_REQUEST_BASENAME || tok == token::TOK_VARIABLE_REQUEST_BODY_LENGTH || tok == token::TOK_VARIABLE_REQUEST_BODY || tok == token::TOK_VARIABLE_REQUEST_FILE_NAME || tok == token::TOK_VARIABLE_REQUEST_HEADERS_NAMES || tok == token::TOK_VARIABLE_REQUEST_LINE || tok == token::TOK_VARIABLE_REQUEST_METHOD || tok == token::TOK_VARIABLE_REQUEST_PROTOCOL || tok == token::TOK_VARIABLE_REQUEST_URI_RAW || tok == token::TOK_VARIABLE_REQUEST_URI || tok == token::TOK_VARIABLE_RESOURCE || tok == token::TOK_VARIABLE_RESPONSE_BODY || tok == token::TOK_VARIABLE_RESPONSE_CONTENT_LENGTH || tok == token::TOK_VARIABLE_RESPONSE_CONTENT_TYPE || tok == token::TOK_VARIABLE_RESPONSE_HEADERS_NAMES || tok == token::TOK_VARIABLE_RESPONSE_PROTOCOL || tok == token::TOK_VARIABLE_RESPONSE_STATUS || tok == token::TOK_VARIABLE_SERVER_ADDR || tok == token::TOK_VARIABLE_SERVER_NAME || tok == token::TOK_VARIABLE_SERVER_PORT || tok == token::TOK_VARIABLE_SESSION_ID || tok == token::TOK_VARIABLE_UNIQUE_ID || tok == token::TOK_VARIABLE_URL_ENCODED_ERROR || tok == token::TOK_VARIABLE_USER_ID || tok == token::TOK_VARIABLE_WEB_APP_ID || tok == token::TOK_VARIABLE_STATUS || tok == token::TOK_VARIABLE_STATUS_LINE || tok == token::TOK_VARIABLE_IP || tok == token::TOK_VARIABLE_GLOBAL || tok == token::TOK_VARIABLE_TX || tok == token::TOK_VARIABLE_SESSION || tok == token::TOK_VARIABLE_USER || tok == token::TOK_RUN_TIME_VAR_ENV || tok == token::TOK_RUN_TIME_VAR_XML || tok == token::TOK_ACTION_SETVAR || tok == token::TOK_SETVAR_OPERATION_EQUALS || tok == token::TOK_SETVAR_OPERATION_EQUALS_PLUS || tok == token::TOK_SETVAR_OPERATION_EQUALS_MINUS || tok == token::TOK_NOT || tok == token::TOK_OPERATOR_BEGINS_WITH || tok == token::TOK_OPERATOR_CONTAINS || tok == token::TOK_OPERATOR_CONTAINS_WORD || tok == token::TOK_OPERATOR_DETECT_SQLI || tok == token::TOK_OPERATOR_DETECT_XSS || tok == token::TOK_OPERATOR_ENDS_WITH || tok == token::TOK_OPERATOR_EQ || tok == token::TOK_OPERATOR_FUZZY_HASH || tok == token::TOK_OPERATOR_GEOLOOKUP || tok == token::TOK_OPERATOR_GE || tok == token::TOK_OPERATOR_GSB_LOOKUP || tok == token::TOK_OPERATOR_GT || tok == token::TOK_OPERATOR_INSPECT_FILE || tok == token::TOK_OPERATOR_IP_MATCH_FROM_FILE || tok == token::TOK_OPERATOR_IP_MATCH || tok == token::TOK_OPERATOR_LE || tok == token::TOK_OPERATOR_LT || tok == token::TOK_OPERATOR_PM_FROM_FILE || tok == token::TOK_OPERATOR_PM || tok == token::TOK_OPERATOR_RBL || tok == token::TOK_OPERATOR_RSUB || tok == token::TOK_OPERATOR_RX_CONTENT_ONLY || tok == token::TOK_OPERATOR_RX || tok == token::TOK_OPERATOR_RX_GLOBAL || tok == token::TOK_OPERATOR_STR_EQ || tok == token::TOK_OPERATOR_STR_MATCH || tok == token::TOK_OPERATOR_UNCONDITIONAL_MATCH || tok == token::TOK_OPERATOR_VALIDATE_BYTE_RANGE || tok == token::TOK_OPERATOR_VALIDATE_DTD || tok == token::TOK_OPERATOR_VALIDATE_HASH || tok == token::TOK_OPERATOR_VALIDATE_SCHEMA || tok == token::TOK_OPERATOR_VALIDATE_URL_ENCODING || tok == token::TOK_OPERATOR_VALIDATE_UTF8_ENCODING || tok == token::TOK_OPERATOR_VERIFY_CC || tok == token::TOK_OPERATOR_VERIFY_CPF || tok == token::TOK_OPERATOR_VERIFY_SSN || tok == token::TOK_OPERATOR_VERIFY_SVNR || tok == token::TOK_OPERATOR_WITHIN || tok == token::TOK_CONFIG_DIR_AUDIT_LOG_FMT || tok == token::TOK_JSON || tok == token::TOK_NATIVE || tok == token::TOK_ACTION_CTL_RULE_ENGINE);
-      }
+        : super_type (token_kind_type (tok), l)
 #endif
+      {
+#if !defined _MSC_VER || defined __clang__
+        YY_ASSERT (tok == token::TOK_END
+                   || (token::TOK_YYerror <= tok && tok <= token::TOK_ACTION_CTL_RULE_ENGINE));
+#endif
+      }
 #if 201103L <= YY_CPLUSPLUS
       symbol_type (int tok, std::string v, location_type l)
-        : super_type(token_type (tok), std::move (v), std::move (l))
-      {
-        YY_ASSERT (tok == token::TOK_ACTION_ACCURACY || tok == token::TOK_ACTION_ALLOW || tok == token::TOK_ACTION_APPEND || tok == token::TOK_ACTION_AUDIT_LOG || tok == token::TOK_ACTION_BLOCK || tok == token::TOK_ACTION_CAPTURE || tok == token::TOK_ACTION_CHAIN || tok == token::TOK_ACTION_CTL_AUDIT_ENGINE || tok == token::TOK_ACTION_CTL_AUDIT_LOG_PARTS || tok == token::TOK_ACTION_CTL_BDY_JSON || tok == token::TOK_ACTION_CTL_BDY_XML || tok == token::TOK_ACTION_CTL_BDY_URLENCODED || tok == token::TOK_ACTION_CTL_FORCE_REQ_BODY_VAR || tok == token::TOK_ACTION_CTL_REQUEST_BODY_ACCESS || tok == token::TOK_ACTION_CTL_RULE_REMOVE_BY_ID || tok == token::TOK_ACTION_CTL_RULE_REMOVE_BY_TAG || tok == token::TOK_ACTION_CTL_RULE_REMOVE_TARGET_BY_ID || tok == token::TOK_ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG || tok == token::TOK_ACTION_DENY || tok == token::TOK_ACTION_DEPRECATE_VAR || tok == token::TOK_ACTION_DROP || tok == token::TOK_ACTION_EXEC || tok == token::TOK_ACTION_EXPIRE_VAR || tok == token::TOK_ACTION_ID || tok == token::TOK_ACTION_INITCOL || tok == token::TOK_ACTION_LOG || tok == token::TOK_ACTION_LOG_DATA || tok == token::TOK_ACTION_MATURITY || tok == token::TOK_ACTION_MSG || tok == token::TOK_ACTION_MULTI_MATCH || tok == token::TOK_ACTION_NO_AUDIT_LOG || tok == token::TOK_ACTION_NO_LOG || tok == token::TOK_ACTION_PASS || tok == token::TOK_ACTION_PAUSE || tok == token::TOK_ACTION_PHASE || tok == token::TOK_ACTION_PREPEND || tok == token::TOK_ACTION_PROXY || tok == token::TOK_ACTION_REDIRECT || tok == token::TOK_ACTION_REV || tok == token::TOK_ACTION_SANITISE_ARG || tok == token::TOK_ACTION_SANITISE_MATCHED || tok == token::TOK_ACTION_SANITISE_MATCHED_BYTES || tok == token::TOK_ACTION_SANITISE_REQUEST_HEADER || tok == token::TOK_ACTION_SANITISE_RESPONSE_HEADER || tok == token::TOK_ACTION_SETENV || tok == token::TOK_ACTION_SETRSC || tok == token::TOK_ACTION_SETSID || tok == token::TOK_ACTION_SETUID || tok == token::TOK_ACTION_SEVERITY || tok == token::TOK_ACTION_SKIP || tok == token::TOK_ACTION_SKIP_AFTER || tok == token::TOK_ACTION_STATUS || tok == token::TOK_ACTION_TAG || tok == token::TOK_ACTION_TRANSFORMATION_BASE_64_ENCODE || tok == token::TOK_ACTION_TRANSFORMATION_BASE_64_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_BASE_64_DECODE_EXT || tok == token::TOK_ACTION_TRANSFORMATION_CMD_LINE || tok == token::TOK_ACTION_TRANSFORMATION_COMPRESS_WHITESPACE || tok == token::TOK_ACTION_TRANSFORMATION_CSS_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_HEX_ENCODE || tok == token::TOK_ACTION_TRANSFORMATION_HEX_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_HTML_ENTITY_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_JS_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_LENGTH || tok == token::TOK_ACTION_TRANSFORMATION_LOWERCASE || tok == token::TOK_ACTION_TRANSFORMATION_MD5 || tok == token::TOK_ACTION_TRANSFORMATION_NONE || tok == token::TOK_ACTION_TRANSFORMATION_NORMALISE_PATH || tok == token::TOK_ACTION_TRANSFORMATION_NORMALISE_PATH_WIN || tok == token::TOK_ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT || tok == token::TOK_ACTION_TRANSFORMATION_PARITY_ODD_7_BIT || tok == token::TOK_ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_COMMENTS || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_NULLS || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_WHITESPACE || tok == token::TOK_ACTION_TRANSFORMATION_REPLACE_COMMENTS || tok == token::TOK_ACTION_TRANSFORMATION_REPLACE_NULLS || tok == token::TOK_ACTION_TRANSFORMATION_SHA1 || tok == token::TOK_ACTION_TRANSFORMATION_SQL_HEX_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_TRIM || tok == token::TOK_ACTION_TRANSFORMATION_TRIM_LEFT || tok == token::TOK_ACTION_TRANSFORMATION_TRIM_RIGHT || tok == token::TOK_ACTION_TRANSFORMATION_UPPERCASE || tok == token::TOK_ACTION_TRANSFORMATION_URL_ENCODE || tok == token::TOK_ACTION_TRANSFORMATION_URL_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_URL_DECODE_UNI || tok == token::TOK_ACTION_TRANSFORMATION_UTF8_TO_UNICODE || tok == token::TOK_ACTION_VER || tok == token::TOK_ACTION_XMLNS || tok == token::TOK_CONFIG_COMPONENT_SIG || tok == token::TOK_CONFIG_CONN_ENGINE || tok == token::TOK_CONFIG_SEC_ARGUMENT_SEPARATOR || tok == token::TOK_CONFIG_SEC_WEB_APP_ID || tok == token::TOK_CONFIG_SEC_SERVER_SIG || tok == token::TOK_CONFIG_DIR_AUDIT_DIR || tok == token::TOK_CONFIG_DIR_AUDIT_DIR_MOD || tok == token::TOK_CONFIG_DIR_AUDIT_ENG || tok == token::TOK_CONFIG_DIR_AUDIT_FLE_MOD || tok == token::TOK_CONFIG_DIR_AUDIT_LOG || tok == token::TOK_CONFIG_DIR_AUDIT_LOG2 || tok == token::TOK_CONFIG_DIR_AUDIT_LOG_P || tok == token::TOK_CONFIG_DIR_AUDIT_STS || tok == token::TOK_CONFIG_DIR_AUDIT_TPE || tok == token::TOK_CONFIG_DIR_DEBUG_LOG || tok == token::TOK_CONFIG_DIR_DEBUG_LVL || tok == token::TOK_CONFIG_SEC_CACHE_TRANSFORMATIONS || tok == token::TOK_CONFIG_SEC_DISABLE_BACKEND_COMPRESS || tok == token::TOK_CONFIG_SEC_HASH_ENGINE || tok == token::TOK_CONFIG_SEC_HASH_KEY || tok == token::TOK_CONFIG_SEC_HASH_PARAM || tok == token::TOK_CONFIG_SEC_HASH_METHOD_RX || tok == token::TOK_CONFIG_SEC_HASH_METHOD_PM || tok == token::TOK_CONFIG_SEC_CHROOT_DIR || tok == token::TOK_CONFIG_DIR_GEO_DB || tok == token::TOK_CONFIG_DIR_GSB_DB || tok == token::TOK_CONFIG_SEC_GUARDIAN_LOG || tok == token::TOK_CONFIG_DIR_PCRE_MATCH_LIMIT || tok == token::TOK_CONFIG_DIR_PCRE_MATCH_LIMIT_RECURSION || tok == token::TOK_CONFIG_SEC_CONN_R_STATE_LIMIT || tok == token::TOK_CONFIG_SEC_CONN_W_STATE_LIMIT || tok == token::TOK_CONFIG_SEC_SENSOR_ID || tok == token::TOK_CONFIG_DIR_ARGS_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY || tok == token::TOK_CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY_LIMIT_ACTION || tok == token::TOK_CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT || tok == token::TOK_CONFIG_DIR_RES_BODY || tok == token::TOK_CONFIG_DIR_RES_BODY_LIMIT || tok == token::TOK_CONFIG_DIR_RES_BODY_LIMIT_ACTION || tok == token::TOK_CONFIG_SEC_RULE_INHERITANCE || tok == token::TOK_CONFIG_SEC_RULE_PERF_TIME || tok == token::TOK_CONFIG_DIR_RULE_ENG || tok == token::TOK_CONFIG_DIR_SEC_ACTION || tok == token::TOK_CONFIG_DIR_SEC_DEFAULT_ACTION || tok == token::TOK_CONFIG_DIR_SEC_MARKER || tok == token::TOK_CONFIG_DIR_UNICODE_MAP_FILE || tok == token::TOK_CONFIG_DIR_UNICODE_CODE_PAGE || tok == token::TOK_CONFIG_SEC_COLLECTION_TIMEOUT || tok == token::TOK_CONFIG_SEC_HTTP_BLKEY || tok == token::TOK_CONFIG_SEC_INTERCEPT_ON_ERROR || tok == token::TOK_CONFIG_SEC_REMOTE_RULES_FAIL_ACTION || tok == token::TOK_CONFIG_SEC_RULE_REMOVE_BY_ID || tok == token::TOK_CONFIG_SEC_RULE_REMOVE_BY_MSG || tok == token::TOK_CONFIG_SEC_RULE_REMOVE_BY_TAG || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_TARGET_BY_TAG || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_TARGET_BY_MSG || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID || tok == token::TOK_CONFIG_UPDLOAD_KEEP_FILES || tok == token::TOK_CONFIG_UPDLOAD_SAVE_TMP_FILES || tok == token::TOK_CONFIG_UPLOAD_DIR || tok == token::TOK_CONFIG_UPLOAD_FILE_LIMIT || tok == token::TOK_CONFIG_UPLOAD_FILE_MODE || tok == token::TOK_CONFIG_VALUE_ABORT || tok == token::TOK_CONFIG_VALUE_DETC || tok == token::TOK_CONFIG_VALUE_HTTPS || tok == token::TOK_CONFIG_VALUE_OFF || tok == token::TOK_CONFIG_VALUE_ON || tok == token::TOK_CONFIG_VALUE_PARALLEL || tok == token::TOK_CONFIG_VALUE_PROCESS_PARTIAL || tok == token::TOK_CONFIG_VALUE_REJECT || tok == token::TOK_CONFIG_VALUE_RELEVANT_ONLY || tok == token::TOK_CONFIG_VALUE_SERIAL || tok == token::TOK_CONFIG_VALUE_WARN || tok == token::TOK_CONFIG_XML_EXTERNAL_ENTITY || tok == token::TOK_CONGIG_DIR_RESPONSE_BODY_MP || tok == token::TOK_CONGIG_DIR_SEC_ARG_SEP || tok == token::TOK_CONGIG_DIR_SEC_COOKIE_FORMAT || tok == token::TOK_CONFIG_SEC_COOKIEV0_SEPARATOR || tok == token::TOK_CONGIG_DIR_SEC_DATA_DIR || tok == token::TOK_CONGIG_DIR_SEC_STATUS_ENGINE || tok == token::TOK_CONFIG_SEC_STREAM_IN_BODY_INSPECTION || tok == token::TOK_CONFIG_SEC_STREAM_OUT_BODY_INSPECTION || tok == token::TOK_CONGIG_DIR_SEC_TMP_DIR || tok == token::TOK_DIRECTIVE || tok == token::TOK_DIRECTIVE_SECRULESCRIPT || tok == token::TOK_FREE_TEXT_QUOTE_MACRO_EXPANSION || tok == token::TOK_QUOTATION_MARK || tok == token::TOK_RUN_TIME_VAR_BLD || tok == token::TOK_RUN_TIME_VAR_DUR || tok == token::TOK_RUN_TIME_VAR_HSV || tok == token::TOK_RUN_TIME_VAR_REMOTE_USER || tok == token::TOK_RUN_TIME_VAR_TIME || tok == token::TOK_RUN_TIME_VAR_TIME_DAY || tok == token::TOK_RUN_TIME_VAR_TIME_EPOCH || tok == token::TOK_RUN_TIME_VAR_TIME_HOUR || tok == token::TOK_RUN_TIME_VAR_TIME_MIN || tok == token::TOK_RUN_TIME_VAR_TIME_MON || tok == token::TOK_RUN_TIME_VAR_TIME_SEC || tok == token::TOK_RUN_TIME_VAR_TIME_WDAY || tok == token::TOK_RUN_TIME_VAR_TIME_YEAR || tok == token::TOK_VARIABLE || tok == token::TOK_DICT_ELEMENT || tok == token::TOK_DICT_ELEMENT_REGEXP);
-      }
+        : super_type (token_kind_type (tok), std::move (v), std::move (l))
 #else
       symbol_type (int tok, const std::string& v, const location_type& l)
-        : super_type(token_type (tok), v, l)
-      {
-        YY_ASSERT (tok == token::TOK_ACTION_ACCURACY || tok == token::TOK_ACTION_ALLOW || tok == token::TOK_ACTION_APPEND || tok == token::TOK_ACTION_AUDIT_LOG || tok == token::TOK_ACTION_BLOCK || tok == token::TOK_ACTION_CAPTURE || tok == token::TOK_ACTION_CHAIN || tok == token::TOK_ACTION_CTL_AUDIT_ENGINE || tok == token::TOK_ACTION_CTL_AUDIT_LOG_PARTS || tok == token::TOK_ACTION_CTL_BDY_JSON || tok == token::TOK_ACTION_CTL_BDY_XML || tok == token::TOK_ACTION_CTL_BDY_URLENCODED || tok == token::TOK_ACTION_CTL_FORCE_REQ_BODY_VAR || tok == token::TOK_ACTION_CTL_REQUEST_BODY_ACCESS || tok == token::TOK_ACTION_CTL_RULE_REMOVE_BY_ID || tok == token::TOK_ACTION_CTL_RULE_REMOVE_BY_TAG || tok == token::TOK_ACTION_CTL_RULE_REMOVE_TARGET_BY_ID || tok == token::TOK_ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG || tok == token::TOK_ACTION_DENY || tok == token::TOK_ACTION_DEPRECATE_VAR || tok == token::TOK_ACTION_DROP || tok == token::TOK_ACTION_EXEC || tok == token::TOK_ACTION_EXPIRE_VAR || tok == token::TOK_ACTION_ID || tok == token::TOK_ACTION_INITCOL || tok == token::TOK_ACTION_LOG || tok == token::TOK_ACTION_LOG_DATA || tok == token::TOK_ACTION_MATURITY || tok == token::TOK_ACTION_MSG || tok == token::TOK_ACTION_MULTI_MATCH || tok == token::TOK_ACTION_NO_AUDIT_LOG || tok == token::TOK_ACTION_NO_LOG || tok == token::TOK_ACTION_PASS || tok == token::TOK_ACTION_PAUSE || tok == token::TOK_ACTION_PHASE || tok == token::TOK_ACTION_PREPEND || tok == token::TOK_ACTION_PROXY || tok == token::TOK_ACTION_REDIRECT || tok == token::TOK_ACTION_REV || tok == token::TOK_ACTION_SANITISE_ARG || tok == token::TOK_ACTION_SANITISE_MATCHED || tok == token::TOK_ACTION_SANITISE_MATCHED_BYTES || tok == token::TOK_ACTION_SANITISE_REQUEST_HEADER || tok == token::TOK_ACTION_SANITISE_RESPONSE_HEADER || tok == token::TOK_ACTION_SETENV || tok == token::TOK_ACTION_SETRSC || tok == token::TOK_ACTION_SETSID || tok == token::TOK_ACTION_SETUID || tok == token::TOK_ACTION_SEVERITY || tok == token::TOK_ACTION_SKIP || tok == token::TOK_ACTION_SKIP_AFTER || tok == token::TOK_ACTION_STATUS || tok == token::TOK_ACTION_TAG || tok == token::TOK_ACTION_TRANSFORMATION_BASE_64_ENCODE || tok == token::TOK_ACTION_TRANSFORMATION_BASE_64_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_BASE_64_DECODE_EXT || tok == token::TOK_ACTION_TRANSFORMATION_CMD_LINE || tok == token::TOK_ACTION_TRANSFORMATION_COMPRESS_WHITESPACE || tok == token::TOK_ACTION_TRANSFORMATION_CSS_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_HEX_ENCODE || tok == token::TOK_ACTION_TRANSFORMATION_HEX_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_HTML_ENTITY_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_JS_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_LENGTH || tok == token::TOK_ACTION_TRANSFORMATION_LOWERCASE || tok == token::TOK_ACTION_TRANSFORMATION_MD5 || tok == token::TOK_ACTION_TRANSFORMATION_NONE || tok == token::TOK_ACTION_TRANSFORMATION_NORMALISE_PATH || tok == token::TOK_ACTION_TRANSFORMATION_NORMALISE_PATH_WIN || tok == token::TOK_ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT || tok == token::TOK_ACTION_TRANSFORMATION_PARITY_ODD_7_BIT || tok == token::TOK_ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_COMMENTS || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_NULLS || tok == token::TOK_ACTION_TRANSFORMATION_REMOVE_WHITESPACE || tok == token::TOK_ACTION_TRANSFORMATION_REPLACE_COMMENTS || tok == token::TOK_ACTION_TRANSFORMATION_REPLACE_NULLS || tok == token::TOK_ACTION_TRANSFORMATION_SHA1 || tok == token::TOK_ACTION_TRANSFORMATION_SQL_HEX_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_TRIM || tok == token::TOK_ACTION_TRANSFORMATION_TRIM_LEFT || tok == token::TOK_ACTION_TRANSFORMATION_TRIM_RIGHT || tok == token::TOK_ACTION_TRANSFORMATION_UPPERCASE || tok == token::TOK_ACTION_TRANSFORMATION_URL_ENCODE || tok == token::TOK_ACTION_TRANSFORMATION_URL_DECODE || tok == token::TOK_ACTION_TRANSFORMATION_URL_DECODE_UNI || tok == token::TOK_ACTION_TRANSFORMATION_UTF8_TO_UNICODE || tok == token::TOK_ACTION_VER || tok == token::TOK_ACTION_XMLNS || tok == token::TOK_CONFIG_COMPONENT_SIG || tok == token::TOK_CONFIG_CONN_ENGINE || tok == token::TOK_CONFIG_SEC_ARGUMENT_SEPARATOR || tok == token::TOK_CONFIG_SEC_WEB_APP_ID || tok == token::TOK_CONFIG_SEC_SERVER_SIG || tok == token::TOK_CONFIG_DIR_AUDIT_DIR || tok == token::TOK_CONFIG_DIR_AUDIT_DIR_MOD || tok == token::TOK_CONFIG_DIR_AUDIT_ENG || tok == token::TOK_CONFIG_DIR_AUDIT_FLE_MOD || tok == token::TOK_CONFIG_DIR_AUDIT_LOG || tok == token::TOK_CONFIG_DIR_AUDIT_LOG2 || tok == token::TOK_CONFIG_DIR_AUDIT_LOG_P || tok == token::TOK_CONFIG_DIR_AUDIT_STS || tok == token::TOK_CONFIG_DIR_AUDIT_TPE || tok == token::TOK_CONFIG_DIR_DEBUG_LOG || tok == token::TOK_CONFIG_DIR_DEBUG_LVL || tok == token::TOK_CONFIG_SEC_CACHE_TRANSFORMATIONS || tok == token::TOK_CONFIG_SEC_DISABLE_BACKEND_COMPRESS || tok == token::TOK_CONFIG_SEC_HASH_ENGINE || tok == token::TOK_CONFIG_SEC_HASH_KEY || tok == token::TOK_CONFIG_SEC_HASH_PARAM || tok == token::TOK_CONFIG_SEC_HASH_METHOD_RX || tok == token::TOK_CONFIG_SEC_HASH_METHOD_PM || tok == token::TOK_CONFIG_SEC_CHROOT_DIR || tok == token::TOK_CONFIG_DIR_GEO_DB || tok == token::TOK_CONFIG_DIR_GSB_DB || tok == token::TOK_CONFIG_SEC_GUARDIAN_LOG || tok == token::TOK_CONFIG_DIR_PCRE_MATCH_LIMIT || tok == token::TOK_CONFIG_DIR_PCRE_MATCH_LIMIT_RECURSION || tok == token::TOK_CONFIG_SEC_CONN_R_STATE_LIMIT || tok == token::TOK_CONFIG_SEC_CONN_W_STATE_LIMIT || tok == token::TOK_CONFIG_SEC_SENSOR_ID || tok == token::TOK_CONFIG_DIR_ARGS_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY || tok == token::TOK_CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY_LIMIT || tok == token::TOK_CONFIG_DIR_REQ_BODY_LIMIT_ACTION || tok == token::TOK_CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT || tok == token::TOK_CONFIG_DIR_RES_BODY || tok == token::TOK_CONFIG_DIR_RES_BODY_LIMIT || tok == token::TOK_CONFIG_DIR_RES_BODY_LIMIT_ACTION || tok == token::TOK_CONFIG_SEC_RULE_INHERITANCE || tok == token::TOK_CONFIG_SEC_RULE_PERF_TIME || tok == token::TOK_CONFIG_DIR_RULE_ENG || tok == token::TOK_CONFIG_DIR_SEC_ACTION || tok == token::TOK_CONFIG_DIR_SEC_DEFAULT_ACTION || tok == token::TOK_CONFIG_DIR_SEC_MARKER || tok == token::TOK_CONFIG_DIR_UNICODE_MAP_FILE || tok == token::TOK_CONFIG_DIR_UNICODE_CODE_PAGE || tok == token::TOK_CONFIG_SEC_COLLECTION_TIMEOUT || tok == token::TOK_CONFIG_SEC_HTTP_BLKEY || tok == token::TOK_CONFIG_SEC_INTERCEPT_ON_ERROR || tok == token::TOK_CONFIG_SEC_REMOTE_RULES_FAIL_ACTION || tok == token::TOK_CONFIG_SEC_RULE_REMOVE_BY_ID || tok == token::TOK_CONFIG_SEC_RULE_REMOVE_BY_MSG || tok == token::TOK_CONFIG_SEC_RULE_REMOVE_BY_TAG || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_TARGET_BY_TAG || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_TARGET_BY_MSG || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID || tok == token::TOK_CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID || tok == token::TOK_CONFIG_UPDLOAD_KEEP_FILES || tok == token::TOK_CONFIG_UPDLOAD_SAVE_TMP_FILES || tok == token::TOK_CONFIG_UPLOAD_DIR || tok == token::TOK_CONFIG_UPLOAD_FILE_LIMIT || tok == token::TOK_CONFIG_UPLOAD_FILE_MODE || tok == token::TOK_CONFIG_VALUE_ABORT || tok == token::TOK_CONFIG_VALUE_DETC || tok == token::TOK_CONFIG_VALUE_HTTPS || tok == token::TOK_CONFIG_VALUE_OFF || tok == token::TOK_CONFIG_VALUE_ON || tok == token::TOK_CONFIG_VALUE_PARALLEL || tok == token::TOK_CONFIG_VALUE_PROCESS_PARTIAL || tok == token::TOK_CONFIG_VALUE_REJECT || tok == token::TOK_CONFIG_VALUE_RELEVANT_ONLY || tok == token::TOK_CONFIG_VALUE_SERIAL || tok == token::TOK_CONFIG_VALUE_WARN || tok == token::TOK_CONFIG_XML_EXTERNAL_ENTITY || tok == token::TOK_CONGIG_DIR_RESPONSE_BODY_MP || tok == token::TOK_CONGIG_DIR_SEC_ARG_SEP || tok == token::TOK_CONGIG_DIR_SEC_COOKIE_FORMAT || tok == token::TOK_CONFIG_SEC_COOKIEV0_SEPARATOR || tok == token::TOK_CONGIG_DIR_SEC_DATA_DIR || tok == token::TOK_CONGIG_DIR_SEC_STATUS_ENGINE || tok == token::TOK_CONFIG_SEC_STREAM_IN_BODY_INSPECTION || tok == token::TOK_CONFIG_SEC_STREAM_OUT_BODY_INSPECTION || tok == token::TOK_CONGIG_DIR_SEC_TMP_DIR || tok == token::TOK_DIRECTIVE || tok == token::TOK_DIRECTIVE_SECRULESCRIPT || tok == token::TOK_FREE_TEXT_QUOTE_MACRO_EXPANSION || tok == token::TOK_QUOTATION_MARK || tok == token::TOK_RUN_TIME_VAR_BLD || tok == token::TOK_RUN_TIME_VAR_DUR || tok == token::TOK_RUN_TIME_VAR_HSV || tok == token::TOK_RUN_TIME_VAR_REMOTE_USER || tok == token::TOK_RUN_TIME_VAR_TIME || tok == token::TOK_RUN_TIME_VAR_TIME_DAY || tok == token::TOK_RUN_TIME_VAR_TIME_EPOCH || tok == token::TOK_RUN_TIME_VAR_TIME_HOUR || tok == token::TOK_RUN_TIME_VAR_TIME_MIN || tok == token::TOK_RUN_TIME_VAR_TIME_MON || tok == token::TOK_RUN_TIME_VAR_TIME_SEC || tok == token::TOK_RUN_TIME_VAR_TIME_WDAY || tok == token::TOK_RUN_TIME_VAR_TIME_YEAR || tok == token::TOK_VARIABLE || tok == token::TOK_DICT_ELEMENT || tok == token::TOK_DICT_ELEMENT_REGEXP);
-      }
+        : super_type (token_kind_type (tok), v, l)
 #endif
+      {
+#if !defined _MSC_VER || defined __clang__
+        YY_ASSERT ((token::TOK_ACTION_ACCURACY <= tok && tok <= token::TOK_DICT_ELEMENT_REGEXP));
+#endif
+      }
     };
 
     /// Build a parser object.
@@ -2482,7 +2504,7 @@ switch (yykind)
     /// YYSYMBOL.  No bounds checking.
     static std::string symbol_name (symbol_kind_type yysymbol);
 
-    // Implementation of make_symbol for each symbol type.
+    // Implementation of make_symbol for each token kind.
 #if 201103L <= YY_CPLUSPLUS
       static
       symbol_type
@@ -7649,9 +7671,9 @@ switch (yykind)
     {
     public:
       context (const seclang_parser& yyparser, const symbol_type& yyla);
-      const symbol_type& lookahead () const { return yyla_; }
-      symbol_kind_type token () const { return yyla_.kind (); }
-      const location_type& location () const { return yyla_.location; }
+      const symbol_type& lookahead () const YY_NOEXCEPT { return yyla_; }
+      symbol_kind_type token () const YY_NOEXCEPT { return yyla_.kind (); }
+      const location_type& location () const YY_NOEXCEPT { return yyla_.location; }
 
       /// Put in YYARG at most YYARGN of the expected tokens, and return the
       /// number of tokens stored in YYARG.  If YYARG is null, return the
@@ -7689,19 +7711,19 @@ switch (yykind)
 
     /// Whether the given \c yypact_ value indicates a defaulted state.
     /// \param yyvalue   the value to check
-    static bool yy_pact_value_is_default_ (int yyvalue);
+    static bool yy_pact_value_is_default_ (int yyvalue) YY_NOEXCEPT;
 
     /// Whether the given \c yytable_ value indicates a syntax error.
     /// \param yyvalue   the value to check
-    static bool yy_table_value_is_error_ (int yyvalue);
+    static bool yy_table_value_is_error_ (int yyvalue) YY_NOEXCEPT;
 
     static const short yypact_ninf_;
     static const signed char yytable_ninf_;
 
     /// Convert a scanner token kind \a t to a symbol kind.
     /// In theory \a t should be a token_kind_type, but character literals
-    /// are valid, yet not members of the token_type enum.
-    static symbol_kind_type yytranslate_ (int t);
+    /// are valid, yet not members of the token_kind_type enum.
+    static symbol_kind_type yytranslate_ (int t) YY_NOEXCEPT;
 
     /// Convert the symbol name \a n to a form suitable for a diagnostic.
     static std::string yytnamerr_ (const char *yystr);
@@ -7733,14 +7755,14 @@ switch (yykind)
 
     static const short yycheck_[];
 
-    // YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-    // symbol of state STATE-NUM.
+    // YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+    // state STATE-NUM.
     static const short yystos_[];
 
-    // YYR1[YYN] -- Symbol number of symbol that rule YYN derives.
+    // YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.
     static const short yyr1_[];
 
-    // YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.
+    // YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.
     static const signed char yyr2_[];
 
 
@@ -7839,7 +7861,7 @@ switch (yykind)
       typedef typename S::size_type size_type;
       typedef typename std::ptrdiff_t index_type;
 
-      stack (size_type n = 200)
+      stack (size_type n = 200) YY_NOEXCEPT
         : seq_ (n)
       {}
 
@@ -7918,7 +7940,7 @@ switch (yykind)
       class slice
       {
       public:
-        slice (const stack& stack, index_type range)
+        slice (const stack& stack, index_type range) YY_NOEXCEPT
           : stack_ (stack)
           , range_ (range)
         {}
@@ -7968,7 +7990,7 @@ switch (yykind)
     void yypush_ (const char* m, state_type s, YY_MOVE_REF (symbol_type) sym);
 
     /// Pop \a n symbols from the stack.
-    void yypop_ (int n = 1);
+    void yypop_ (int n = 1) YY_NOEXCEPT;
 
     /// Constants.
     enum
@@ -7986,7 +8008,7 @@ switch (yykind)
 
   inline
   seclang_parser::symbol_kind_type
-  seclang_parser::yytranslate_ (int t)
+  seclang_parser::yytranslate_ (int t) YY_NOEXCEPT
   {
     // YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to
     // TOKEN-NUM as returned by yylex.
@@ -8061,7 +8083,7 @@ switch (yykind)
     if (t <= 0)
       return symbol_kind::S_YYEOF;
     else if (t <= code_max)
-      return YY_CAST (symbol_kind_type, translate_table[t]);
+      return static_cast <symbol_kind_type> (translate_table[t]);
     else
       return symbol_kind::S_YYUNDEF;
   }
@@ -8313,12 +8335,14 @@ switch (yykind)
 
 
 
+
   template <typename Base>
   seclang_parser::symbol_kind_type
   seclang_parser::basic_symbol<Base>::type_get () const YY_NOEXCEPT
   {
     return this->kind ();
   }
+
 
   template <typename Base>
   bool
@@ -8573,13 +8597,13 @@ switch (yykind)
 
   // by_kind.
   inline
-  seclang_parser::by_kind::by_kind ()
+  seclang_parser::by_kind::by_kind () YY_NOEXCEPT
     : kind_ (symbol_kind::S_YYEMPTY)
   {}
 
 #if 201103L <= YY_CPLUSPLUS
   inline
-  seclang_parser::by_kind::by_kind (by_kind&& that)
+  seclang_parser::by_kind::by_kind (by_kind&& that) YY_NOEXCEPT
     : kind_ (that.kind_)
   {
     that.clear ();
@@ -8587,18 +8611,20 @@ switch (yykind)
 #endif
 
   inline
-  seclang_parser::by_kind::by_kind (const by_kind& that)
+  seclang_parser::by_kind::by_kind (const by_kind& that) YY_NOEXCEPT
     : kind_ (that.kind_)
   {}
 
   inline
-  seclang_parser::by_kind::by_kind (token_kind_type t)
+  seclang_parser::by_kind::by_kind (token_kind_type t) YY_NOEXCEPT
     : kind_ (yytranslate_ (t))
   {}
 
+
+
   inline
   void
-  seclang_parser::by_kind::clear ()
+  seclang_parser::by_kind::clear () YY_NOEXCEPT
   {
     kind_ = symbol_kind::S_YYEMPTY;
   }
@@ -8618,6 +8644,7 @@ switch (yykind)
     return kind_;
   }
 
+
   inline
   seclang_parser::symbol_kind_type
   seclang_parser::by_kind::type_get () const YY_NOEXCEPT
@@ -8625,8 +8652,9 @@ switch (yykind)
     return this->kind ();
   }
 
+
 } // yy
-#line 8630 "seclang-parser.hh"
+#line 8658 "seclang-parser.hh"
 
 
 

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1470,9 +1470,11 @@ expression:
       {
         std::string error;
         double ruleId;
-        try {
-            ruleId = std::stod($1);
-        } catch (...) {
+        std::stringstream ss_conv;
+        ss_conv<<$1;
+        ss_conv>>ruleId;
+        if (ss_conv.fail()) {
+            ss_conv.clear();
             std::stringstream ss;
             ss << "SecRuleUpdateTargetById: failed to load:";
             ss << "The input \"" + $1 + "\" does not ";
@@ -1496,9 +1498,11 @@ expression:
       {
         std::string error;
         double ruleId;
-        try {
-            ruleId = std::stod($1);
-        } catch (...) {
+        std::stringstream ss_conv;
+        ss_conv<<$1;
+        ss_conv>>ruleId;
+        if (ss_conv.fail()) {
+            ss_conv.clear();
             std::stringstream ss;
             ss << "SecRuleUpdateActionById: failed to load:";
             ss << "The input \"" + $1 + "\" does not ";
@@ -1729,9 +1733,11 @@ expression:
             YYERROR;
         }
 
-        try {
-            num = std::stod(param.back());
-        } catch (...) {
+        std::stringstream ss_conv;
+        ss_conv<<param.back();
+        ss_conv>>num;
+        if (ss_conv.fail()) {
+            ss_conv.clear();
             std::stringstream ss;
             ss << "Failed to process unicode map, last parameter is ";
             ss << "expected to be a number: " << param.back() << " ";

--- a/src/parser/stack.hh
+++ b/src/parser/stack.hh
@@ -1,4 +1,4 @@
-// A Bison parser, made by GNU Bison 3.7.2.
+// A Bison parser, made by GNU Bison 3.8.2.
 
 // Starting with Bison 3.2, this file is useless: the structure it
 // used to define is now defined with the parser itself.


### PR DESCRIPTION
Context
---
Several basic elements from the `modsecurity.conf` file (e.g. rules `200002`, `200003`, `200004`) are leading to a `RuntimeError` anticipated by a `stoi: no conversion error`.
As far as I know, the proxy Wasm SDK [does not still support](https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/116) the handling of exceptions, therefore, the `stoi` conversion based on catching an exception when the conversion fails leads to this behaviour.

Solution
---
The PR proposes to handle the conversion based on the more recent std::from_chars that handles without exceptions the outcome.

Work in progress, request for tips and discussion 
---
Other `try catch` patterns are still in place inside the code and they may lead to similar errors. Specifically:
1) Would it be possible to have some guidance or pointers on how to tweak `.cc `and `.yy` files? E.g. [seclang-parser.cc#L2907-L2915](https://github.com/SpiderLabs/ModSecurity/blob/v3/dev/wasm-experimental/src/parser/seclang-parser.cc#L2907-L2915)
2) I think that a very sensitive point is the allocation of the request body: [transaction.cc#L1019-L1025](https://github.com/SpiderLabs/ModSecurity/blob/v3/dev/wasm-experimental/src/transaction.cc#L1019-L1025). Do you have any tips on how would it possible to avoid the usage of exceptions? 

Thanks!

@martinhsv @leyao-daily