### PR TITLE
Fix: MULTIPART_INVALID_PART connected to wrong internal variable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Fix: MULTIPART_INVALID_PART connected to wrong internal variable
+    [Issue #2785 - @martinhsv]
   - Restore Unique_id to include random portion after timestamp
     [Issue #2752, #2758 - @datkps11, @martinhsv]
 

--- a/src/variables/multipart_invalid_part.h
+++ b/src/variables/multipart_invalid_part.h
@@ -31,7 +31,7 @@ namespace variables {
 
 
 DEFINE_VARIABLE(MultipartInvalidPart, MULTIPART_INVALID_PART,
-    m_variableMultipartInvalidHeaderFolding)
+    m_variableMultipartInvalidPart)
 
 
 }  // namespace variables


### PR DESCRIPTION
Despite this bug, MULTIPART_STRICT_ERROR was still being set correctly in this case. However, the 'msg' action in rule 200003 in modsecurity.conf-recommended would not show 'IP 1' properly.
