### PR TITLE
Add JIT support for PCRE2

### DIFF
--- a/src/operators/verify_cc.cc
+++ b/src/operators/verify_cc.cc
@@ -148,8 +148,10 @@ bool VerifyCC::evaluate(Transaction *t, RuleWithActions *rule,
 
         if (m_pcje == 0) {
             ret = pcre2_jit_match(m_pc, pcre2_i, target_length, offset, 0, match_data, NULL);
-        } else {
-            ret = pcre2_match(m_pc, pcre2_i, target_length, offset, 0, match_data, NULL);
+        }
+        
+        if (m_pcje != 0 || ret == PCRE2_ERROR_JIT_STACKLIMIT) {
+            ret = pcre2_match(m_pc, pcre2_i, target_length, offset, PCRE2_NO_JIT, match_data, NULL);
         }
 
         /* If there was no match, then we are done. */

--- a/src/operators/verify_cc.cc
+++ b/src/operators/verify_cc.cc
@@ -36,8 +36,6 @@ namespace operators {
 VerifyCC::~VerifyCC() {
 #if WITH_PCRE2
     pcre2_code_free(m_pc);
-    pcre2_match_context_free(m_pmc);
-    pcre2_jit_stack_free(m_pcjs);
 #else
     if (m_pc != NULL) {
         pcre_free(m_pc);
@@ -107,11 +105,7 @@ bool VerifyCC::init(const std::string &param2, std::string *error) {
     if (m_pc == NULL) {
         return false;
     }
-
     m_pcje = pcre2_jit_compile(m_pc, PCRE2_JIT_COMPLETE);
-    m_pmc = pcre2_match_context_create(NULL);
-    m_pcjs = pcre2_jit_stack_create(32*1024, 512*1024, NULL);
-    pcre2_jit_stack_assign(m_pmc, NULL, m_pcjs);
 #else
     const char *errptr = NULL;
     int erroffset = 0;
@@ -153,9 +147,9 @@ bool VerifyCC::evaluate(Transaction *t, RuleWithActions *rule,
     for (offset = 0; offset < target_length; offset++) {
 
         if (m_pcje == 0) {
-            ret = pcre2_jit_match(m_pc, pcre2_i, target_length, offset, 0, match_data, m_pmc);
+            ret = pcre2_jit_match(m_pc, pcre2_i, target_length, offset, 0, match_data, NULL);
         } else {
-            ret = pcre2_match(m_pc, pcre2_i, target_length, offset, 0, match_data, m_pmc);
+            ret = pcre2_match(m_pc, pcre2_i, target_length, offset, 0, match_data, NULL);
         }
 
         /* If there was no match, then we are done. */

--- a/src/operators/verify_cc.h
+++ b/src/operators/verify_cc.h
@@ -53,6 +53,9 @@ class VerifyCC : public Operator {
  private:
 #if WITH_PCRE2
     pcre2_code *m_pc;
+    pcre2_match_context *m_pmc;
+    int m_pcje;
+    pcre2_jit_stack *m_pcjs;
 #else
     pcre *m_pc;
     pcre_extra *m_pce;

--- a/src/operators/verify_cc.h
+++ b/src/operators/verify_cc.h
@@ -39,7 +39,12 @@ class VerifyCC : public Operator {
     explicit VerifyCC(std::unique_ptr<RunTimeString> param)
         : Operator("VerifyCC", std::move(param)),
 #if WITH_PCRE2
-        m_pc(NULL) { }
+        m_pc(NULL) 
+		{
+#if WITH_PCRE2
+			m_pcje = PCRE2_ERROR_JIT_BADOPTION;
+#endif
+		}
 #else
         m_pc(NULL),
         m_pce(NULL) { }

--- a/src/operators/verify_cc.h
+++ b/src/operators/verify_cc.h
@@ -53,9 +53,7 @@ class VerifyCC : public Operator {
  private:
 #if WITH_PCRE2
     pcre2_code *m_pc;
-    pcre2_match_context *m_pmc;
     int m_pcje;
-    pcre2_jit_stack *m_pcjs;
 #else
     pcre *m_pc;
     pcre_extra *m_pce;

--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -73,11 +73,7 @@ Regex::Regex(const std::string& pattern_, bool ignoreCase)
     PCRE2_SIZE erroroffset = 0;
     m_pc = pcre2_compile(pcre2_pattern, PCRE2_ZERO_TERMINATED,
         pcre2_options, &errornumber, &erroroffset, NULL);
-
     m_pcje = pcre2_jit_compile(m_pc, PCRE2_JIT_COMPLETE);
-    m_pmc = pcre2_match_context_create(NULL);
-    m_pcjs = pcre2_jit_stack_create(32*1024, 512*1024, NULL);
-    pcre2_jit_stack_assign(m_pmc, NULL, m_pcjs);
 #else
     const char *errptr = NULL;
     int erroffset;
@@ -97,8 +93,6 @@ Regex::Regex(const std::string& pattern_, bool ignoreCase)
 Regex::~Regex() {
 #if WITH_PCRE2
     pcre2_code_free(m_pc);
-    pcre2_match_context_free(m_pmc);
-    pcre2_jit_stack_free(m_pcjs);
 #else
     if (m_pc != NULL) {
         pcre_free(m_pc);
@@ -127,10 +121,10 @@ std::list<SMatch> Regex::searchAll(const std::string& s) const {
     do {
         if (m_pcje == 0) {
             rc = pcre2_jit_match(m_pc, pcre2_s, s.length(),
-                            offset, 0, match_data, m_pmc);
+                            offset, 0, match_data, NULL);
         } else {
             rc = pcre2_match(m_pc, pcre2_s, s.length(),
-                            offset, 0, match_data, m_pmc);
+                            offset, 0, match_data, NULL);
         }
         PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 #else
@@ -173,9 +167,9 @@ bool Regex::searchOneMatch(const std::string& s, std::vector<SMatchCapture>& cap
     pcre2_match_data *match_data = pcre2_match_data_create_from_pattern(m_pc, NULL);
     int rc;
     if (m_pcje == 0) {
-        rc = pcre2_jit_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, m_pmc);
+        rc = pcre2_jit_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
     } else {
-        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, m_pmc);
+        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
     }
     PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 #else
@@ -215,7 +209,7 @@ bool Regex::searchGlobal(const std::string& s, std::vector<SMatchCapture>& captu
             pcre2_options = PCRE2_NOTEMPTY_ATSTART | PCRE2_ANCHORED;
         }
         int rc = pcre2_match(m_pc, pcre2_s, s.length(),
-                            startOffset, pcre2_options, match_data, m_pmc);
+                            startOffset, pcre2_options, match_data, NULL);
         PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 
 #else
@@ -290,10 +284,10 @@ int Regex::search(const std::string& s, SMatch *match) const {
     int ret;
     if (m_pcje == 0) {
         ret = pcre2_match(m_pc, pcre2_s, s.length(),
-            0, 0, match_data, m_pmc) > 0;
+            0, 0, match_data, NULL) > 0;
     } else {
         ret = pcre2_match(m_pc, pcre2_s, s.length(),
-            0, 0, match_data, m_pmc) > 0;
+            0, 0, match_data, NULL) > 0;
     }
     if (ret > 0) { // match
         PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
@@ -321,9 +315,9 @@ int Regex::search(const std::string& s) const {
     pcre2_match_data *match_data = pcre2_match_data_create_from_pattern(m_pc, NULL);
     int rc;
     if (m_pcje == 0) {
-        rc = pcre2_jit_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, m_pmc);
+        rc = pcre2_jit_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
     } else {
-        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, m_pmc);
+        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
     }
     pcre2_match_data_free(match_data);
     if (rc > 0) {

--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -291,7 +291,7 @@ int Regex::search(const std::string& s, SMatch *match) const {
             0, 0, match_data, NULL) > 0;
     } 
     
-    if (m_pcje != 0 || rc == PCRE2_ERROR_JIT_STACKLIMIT) {
+    if (m_pcje != 0 || ret == PCRE2_ERROR_JIT_STACKLIMIT) {
         ret = pcre2_match(m_pc, pcre2_s, s.length(),
             0, PCRE2_NO_JIT, match_data, NULL) > 0;
     }

--- a/src/utils/regex.cc
+++ b/src/utils/regex.cc
@@ -122,9 +122,11 @@ std::list<SMatch> Regex::searchAll(const std::string& s) const {
         if (m_pcje == 0) {
             rc = pcre2_jit_match(m_pc, pcre2_s, s.length(),
                             offset, 0, match_data, NULL);
-        } else {
+        } 
+        
+        if (m_pcje != 0 || rc == PCRE2_ERROR_JIT_STACKLIMIT) {
             rc = pcre2_match(m_pc, pcre2_s, s.length(),
-                            offset, 0, match_data, NULL);
+                            offset, PCRE2_NO_JIT, match_data, NULL);
         }
         PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 #else
@@ -168,8 +170,10 @@ bool Regex::searchOneMatch(const std::string& s, std::vector<SMatchCapture>& cap
     int rc;
     if (m_pcje == 0) {
         rc = pcre2_jit_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
-    } else {
-        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
+    } 
+    
+    if (m_pcje != 0 || rc == PCRE2_ERROR_JIT_STACKLIMIT) {
+        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, PCRE2_NO_JIT, match_data, NULL);
     }
     PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 #else
@@ -285,9 +289,11 @@ int Regex::search(const std::string& s, SMatch *match) const {
     if (m_pcje == 0) {
         ret = pcre2_match(m_pc, pcre2_s, s.length(),
             0, 0, match_data, NULL) > 0;
-    } else {
+    } 
+    
+    if (m_pcje != 0 || rc == PCRE2_ERROR_JIT_STACKLIMIT) {
         ret = pcre2_match(m_pc, pcre2_s, s.length(),
-            0, 0, match_data, NULL) > 0;
+            0, PCRE2_NO_JIT, match_data, NULL) > 0;
     }
     if (ret > 0) { // match
         PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
@@ -316,8 +322,10 @@ int Regex::search(const std::string& s) const {
     int rc;
     if (m_pcje == 0) {
         rc = pcre2_jit_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
-    } else {
-        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, 0, match_data, NULL);
+    }
+
+    if (m_pcje != 0 || rc == PCRE2_ERROR_JIT_STACKLIMIT) {
+        rc = pcre2_match(m_pc, pcre2_s, s.length(), 0, PCRE2_NO_JIT, match_data, NULL);
     }
     pcre2_match_data_free(match_data);
     if (rc > 0) {

--- a/src/utils/regex.h
+++ b/src/utils/regex.h
@@ -85,9 +85,7 @@ class Regex {
  private:
 #if WITH_PCRE2
     pcre2_code *m_pc;
-    pcre2_match_context *m_pmc;
     int m_pcje;
-    pcre2_jit_stack *m_pcjs;
 #else
     pcre *m_pc = NULL;
     pcre_extra *m_pce = NULL;

--- a/src/utils/regex.h
+++ b/src/utils/regex.h
@@ -85,6 +85,9 @@ class Regex {
  private:
 #if WITH_PCRE2
     pcre2_code *m_pc;
+    pcre2_match_context *m_pmc;
+    int m_pcje;
+    pcre2_jit_stack *m_pcjs;
 #else
     pcre *m_pc = NULL;
     pcre_extra *m_pce = NULL;


### PR DESCRIPTION
Added JIT to PCRE2. 

I didn't thoroughly investigate the lifetime of the `Regex` class. The lifetime of the JIT result is attached to it.

Also it is worth noticing that PCRE2 is not following the `pcre_malloc` and `pcre_free` conventions, though I wonder what it will add if the allocation is scoped to requests.