### PR TITLE
fix no "echo -n" in macOS's sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,15 +418,18 @@ AX_VALGRIND_CHECK
 AC_OUTPUT
 
 
+if test -z "$as_echo_n"; then
+    as_echo_n='echo -n'
+fi
 # Print a fancy summary
 echo " "
 echo " "
 echo "ModSecurity - ${MSC_GIT_VERSION} for $PLATFORM"
 echo " "
 echo " Mandatory dependencies"
-echo -n "   + libInjection                                  ...."
+$as_echo_n "   + libInjection                                  ...."
 echo LIBINJECTION_VERSION
-echo -n "   + SecLang tests                                 ...."
+$as_echo_n "   + SecLang tests                                 ...."
 echo SECLANG_TEST_VERSION
 
 echo " "
@@ -439,7 +442,7 @@ if test "x$GEOIP_FOUND" = "x0" && test "x$MAXMIND_FOUND" = "x0"; then
     echo "   + GeoIP/MaxMind                                 ....not found"
 fi
 if test "x$GEOIP_FOUND" = "x1" || test "x$MAXMIND_FOUND" = "x1"; then
-    echo -n "   + GeoIP/MaxMind                                 ....found "
+    $as_echo_n "   + GeoIP/MaxMind                                 ....found "
     echo ""
     if test "x$MAXMIND_FOUND" = "x1"; then
         echo "      * (MaxMind) v${MAXMIND_VERSION}"
@@ -460,7 +463,7 @@ if test "x$CURL_FOUND" = "x0"; then
     echo "   + LibCURL                                       ....not found"
 fi
 if test "x$CURL_FOUND" = "x1"; then
-    echo -n "   + LibCURL                                       ....found "
+    $as_echo_n "   + LibCURL                                       ....found "
     if ! test "x$CURL_VERSION" = "x"; then
         echo "v${CURL_VERSION}"
     else
@@ -478,7 +481,7 @@ if test "x$YAJL_FOUND" = "x0"; then
     echo "   + YAJL                                          ....not found"
 fi
 if test "x$YAJL_FOUND" = "x1"; then
-    echo -n "   + YAJL                                          ....found "
+    $as_echo_n "   + YAJL                                          ....found "
     if ! test "x$YAJL_VERSION" = "x"; then
         echo "v${YAJL_VERSION}"
     else
@@ -496,7 +499,7 @@ if test "x$LMDB_FOUND" = "x0"; then
     echo "   + LMDB                                          ....not found"
 fi
 if test "x$LMDB_FOUND" = "x1"; then
-    echo -n "   + LMDB                                          ....found "
+    $as_echo_n "   + LMDB                                          ....found "
     if ! test "x$LMDB_VERSION" = "x"; then
         echo "v${LMDB_VERSION}"
     else
@@ -514,7 +517,7 @@ if test "x$LIBXML2_FOUND" = "x0"; then
     echo "   + LibXML2                                       ....not found"
 fi
 if test "x$LIBXML2_FOUND" = "x1"; then
-    echo -n "   + LibXML2                                       ....found "
+    $as_echo_n "   + LibXML2                                       ....found "
     if ! test "x$LIBXML2_VERSION" = "x"; then
         echo "v${LIBXML2_VERSION}"
     else
@@ -532,7 +535,7 @@ if test "x$SSDEEP_FOUND" = "x0"; then
     echo "   + SSDEEP                                        ....not found"
 fi
 if test "x$SSDEEP_FOUND" = "x1"; then
-    echo -n "   + SSDEEP                                        ....found "
+    $as_echo_n "   + SSDEEP                                        ....found "
     if ! test "x$SSDEEP_VERSION" = "x"; then
         echo "v${SSDEEP_VERSION}"
     else
@@ -549,7 +552,7 @@ if test "x$LUA_FOUND" = "x0"; then
     echo "   + LUA                                           ....not found"
 fi
 if test "x$LUA_FOUND" = "x1"; then
-    echo -n "   + LUA                                           ....found "
+    $as_echo_n "   + LUA                                           ....found "
     if ! test "x$LUA_VERSION" = "x"; then
         echo "v${LUA_VERSION}"
     else
@@ -567,7 +570,7 @@ if test "x$PCRE2_FOUND" = "x0"; then
     echo "   + PCRE2                                          ....not found"
 fi
 if test "x$PCRE2_FOUND" = "x1"; then
-    echo -n "   + PCRE2                                          ....found "
+    $as_echo_n "   + PCRE2                                          ....found "
     if ! test "x$PCRE2_VERSION" = "x"; then
         echo "v${PCRE2_VERSION}"
     else


### PR DESCRIPTION
on macOS, the "/bin/sh" has no "-n" support.
There is $as_echo_n in autoconf, just use it.
And, there is AS_ECHO_N macro in autoconf too.