### PR TITLE
Fix two rule-reload memory leak issues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Fix two rule-reload memory leak issues
+    [Issue #2801 - @Abce, @martinhsv]
   - Correct whitespace handling for Include directive
     [Issue #2800 - @877509395, @martinhsv]
 

--- a/headers/modsecurity/rule.h
+++ b/headers/modsecurity/rule.h
@@ -86,6 +86,8 @@ class Rule {
         return *this;
     }
 
+    virtual ~Rule() {}
+
     virtual bool evaluate(Transaction *transaction) = 0;
 
     virtual bool evaluate(Transaction *transaction,

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -80,6 +80,10 @@ RuleWithActions::RuleWithActions(
     m_containsStaticBlockAction(false),
     m_isChained(false) {
 
+    if (transformations != NULL) {
+        delete transformations;
+    }
+
     if (actions) {
         for (Action *a : *actions) {
             if (a->action_kind == Action::ConfigurationKind) {

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -55,8 +55,8 @@ danglingTempReference:src/modsecurity.cc:206
 knownConditionTrueFalse:src/operators/validate_url_encoding.cc:77
 knownConditionTrueFalse:src/operators/verify_svnr.cc:87
 rethrowNoCurrentException:headers/modsecurity/transaction.h:309
-rethrowNoCurrentException:src/rule_with_actions.cc:123
-ctunullpointer:src/rule_with_actions.cc:237
+rethrowNoCurrentException:src/rule_with_actions.cc:127
+ctunullpointer:src/rule_with_actions.cc:241
 ctunullpointer:src/rule_with_operator.cc:135
 ctunullpointer:src/rule_with_operator.cc:95
 passedByValue:src/variables/global.h:109
@@ -93,6 +93,10 @@ functionStatic
 variableScope
 shadowFunction
 
+constVariable
+stlcstrConstructor
+stlcstrStream
+uselessCallsSubstr
 
 // Examples
 memleak:examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h:147


### PR DESCRIPTION
This PR commits two of three issues originally submitted in https://github.com/SpiderLabs/ModSecurity/pull/2580.
