### PR TITLE
Use AS_HELP_STRING instead of obsolete AC_HELP_STRING macro

### DIFF
--- a/build/curl.m4
+++ b/build/curl.m4
@@ -17,7 +17,7 @@ AC_DEFUN([CHECK_CURL], [
 
 AC_ARG_WITH(
     curl,
-    [AC_HELP_STRING([--with-curl=PATH],[Path to curl prefix or config script])],
+    [AS_HELP_STRING([--with-curl=PATH],[Path to curl prefix or config script])],
     [test_paths="${with_curl}"],
     [test_paths="/usr/local/libcurl /usr/local/curl /usr/local /opt/libcurl /opt/curl /opt /usr"])
 

--- a/build/libxml.m4
+++ b/build/libxml.m4
@@ -64,7 +64,7 @@ AC_DEFUN([CHECK_LIBXML2], [
 
 AC_ARG_WITH(
     libxml,
-    [AC_HELP_STRING([--with-libxml=PATH],[Path to libxml2 prefix or config script])],
+    [AS_HELP_STRING([--with-libxml=PATH],[Path to libxml2 prefix or config script])],
     [test_paths="${with_libxml}"],
     [test_paths="/usr/local/libxml2 /usr/local/xml2 /usr/local/xml /usr/local /opt/libxml2 /opt/libxml /opt/xml2 /opt/xml /opt /usr"])
 

--- a/build/lmdb.m4
+++ b/build/lmdb.m4
@@ -21,10 +21,7 @@ LMDB_LDFLAGS=""
 
 AC_ARG_WITH(
     lmdb,
-    AC_HELP_STRING(
-      [--with-lmdb=PATH],
-      [Path to lmdb prefix or config script]
-    )
+    [AS_HELP_STRING([--with-lmdb=PATH],[Path to lmdb prefix or config script])]
 )
 
 if test "x${with_lmdb}" == "xno"; then

--- a/build/lua.m4
+++ b/build/lua.m4
@@ -22,10 +22,7 @@ LUA_DISPLAY=""
 
 AC_ARG_WITH(
     lua,
-    AC_HELP_STRING(
-    [--with-lua=PATH],
-    [Path to lua prefix]
-    )
+    [AS_HELP_STRING([--with-lua=PATH],[Path to lua prefix])]
 )
 
 

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -17,7 +17,7 @@ AC_DEFUN([CHECK_PCRE],
 
 AC_ARG_WITH(
     pcre,
-    [AC_HELP_STRING([--with-pcre=PATH],[Path to pcre prefix or config script])],
+    [AS_HELP_STRING([--with-pcre=PATH],[Path to pcre prefix or config script])],
     [test_paths="${with_pcre}"],
     [test_paths="/usr/local/libpcre /usr/local/pcre /usr/local /opt/libpcre /opt/pcre /opt /usr /opt/local"])
 

--- a/build/pcre2.m4
+++ b/build/pcre2.m4
@@ -21,10 +21,7 @@ PCRE2_LDFLAGS=""
 
 AC_ARG_WITH(
     pcre2,
-    AC_HELP_STRING(
-      [--with-pcre2=PATH],
-      [Path to pcre2 prefix or config script]
-    )
+    [AS_HELP_STRING([--with-pcre2=PATH],[Path to pcre2 prefix or config script])]
 )
 
 if test "x${with_pcre2}" == "xno"; then

--- a/build/ssdeep.m4
+++ b/build/ssdeep.m4
@@ -22,10 +22,7 @@ SSDEEP_DISPLAY=""
 
 AC_ARG_WITH(
     ssdeep,
-    AC_HELP_STRING(
-    [--with-ssdeep=PATH],
-    [Path to ssdeep prefix]
-    )
+    [AS_HELP_STRING([--with-ssdeep=PATH],[Path to ssdeep prefix])]
 )
 
 

--- a/build/yajl.m4
+++ b/build/yajl.m4
@@ -21,10 +21,7 @@ YAJL_LDFLAGS=""
 
 AC_ARG_WITH(
     yajl,
-    AC_HELP_STRING(
-      [--with-yajl=PATH],
-      [Path to yajl prefix or config script]
-    )
+    [AS_HELP_STRING([--with-yajl=PATH],[Path to yajl prefix or config script])]
 )
 
 if test "x${with_yajl}" == "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -229,7 +229,7 @@ AC_SUBST([MSC_GIT_VERSION])
 
 
 AC_ARG_ENABLE(debug-logs,
-    [AC_HELP_STRING([--disable-debug-logs],[Turn off the SecDebugLog feature])],
+    [AS_HELP_STRING([--disable-debug-logs],[Turn off the SecDebugLog feature])],
 
     [case "${enableval}" in
         yes) debugLogs=true ;;
@@ -247,7 +247,7 @@ fi
 
 # Fuzzer
 AC_ARG_ENABLE(afl-fuzz,
-    [AC_HELP_STRING([--enable-afl-fuzz],[Turn on the afl fuzzer compilation utilities])],
+    [AS_HELP_STRING([--enable-afl-fuzz],[Turn on the afl fuzzer compilation utilities])],
 
     [case "${enableval}" in
         yes) aflFuzzer=true ;;
@@ -260,7 +260,7 @@ AC_ARG_ENABLE(afl-fuzz,
 
 # Examples
 AC_ARG_ENABLE(examples,
-    [AC_HELP_STRING([--enable-examples],[Turn on the examples compilation (default option)])],
+    [AS_HELP_STRING([--enable-examples],[Turn on the examples compilation (default option)])],
 
     [case "${enableval}" in
         yes) buildExamples=true ;;
@@ -273,7 +273,7 @@ AC_ARG_ENABLE(examples,
 
 # Parser
 AC_ARG_ENABLE(parser-generation,
-    [AC_HELP_STRING([--enable-parser-generation],[Enables parser generation during the build])],
+    [AS_HELP_STRING([--enable-parser-generation],[Enables parser generation during the build])],
 
     [case "${enableval}" in
         yes) buildParser=true ;;
@@ -286,7 +286,7 @@ AC_ARG_ENABLE(parser-generation,
 
 # Mutex
 AC_ARG_ENABLE(mutex-on-pm,
-    [AC_HELP_STRING([--enable-mutex-on-pm],[Treats pm operations as a critical section])],
+    [AS_HELP_STRING([--enable-mutex-on-pm],[Treats pm operations as a critical section])],
 
     [case "${enableval}" in
         yes) mutexPm=true ;;


### PR DESCRIPTION
`AC_HELP_STRING` has been obsolete since at least Autoconf 2.53, which was released in 2003.