### PR TITLE
v2: make sure ModSecurity runs after mod_maxminddb (GeoIP) in phase 1

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1668,6 +1668,7 @@ static void register_hooks(apr_pool_t *mp) {
         "mod_breach_realip.c",
         "mod_breach_trans.c",
         "mod_unique_id.c",
+        "mod_maxminddb.c",
         NULL
     };
 


### PR DESCRIPTION
Very simple patch adding `mod_maxminddb.c` to `postread_beforeme_list`.

This allows to use mod_maxminddb GeoIP information in phase 1.