### PR TITLE
Use pkg-config to find libxml2, falling back to xml2-config if necessary

### DIFF
--- a/build/find_xml.m4
+++ b/build/find_xml.m4
@@ -4,21 +4,7 @@ dnl Sets:
 dnl  LIBXML2_CFLAGS
 dnl  LIBXML2_LIBS
 
-LIBXML2_CONFIG=""
-LIBXML2_VERSION=""
-LIBXML2_CFLAGS=""
-LIBXML2_CPPFLAGS=""
-LIBXML2_LDADD=""
-LIBXML2_LDFLAGS=""
-
-AC_DEFUN([CHECK_LIBXML2],
-[dnl
-
-AC_ARG_WITH(
-    libxml,
-    [AC_HELP_STRING([--with-libxml=PATH],[Path to libxml2 prefix or config script])],
-    [test_paths="${with_libxml}"],
-    [test_paths="/usr/local/libxml2 /usr/local/xml2 /usr/local/xml /usr/local /opt/libxml2 /opt/libxml /opt/xml2 /opt/xml /opt /usr"])
+AC_DEFUN([CHECK_XML2CONFIG], [
 
 AC_MSG_CHECKING([for libxml2 config script])
 
@@ -59,18 +45,55 @@ if test -n "${libxml2_path}"; then
     LIBXML2_LDADD="`${LIBXML2_CONFIG} --libs`"
     if test "$verbose_output" -eq 1; then AC_MSG_NOTICE(xml LDADD: $LIBXML2_LDADD); fi
 
-    AC_MSG_CHECKING([if libxml2 is at least v2.6.29])
-    libxml2_min_ver=`echo 2.6.29 | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
+    AC_MSG_CHECKING([if libxml2 is at least v${LIBXML2_MIN_VERSION}])
+    libxml2_min_ver=`echo ${LIBXML2_MIN_VERSION} | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
     libxml2_ver=`echo ${LIBXML2_VERSION} | awk -F. '{print (\$ 1 * 1000000) + (\$ 2 * 1000) + \$ 3}'`
     if test "$libxml2_ver" -ge "$libxml2_min_ver"; then
         AC_MSG_RESULT([yes, $LIBXML2_VERSION])
     else
         AC_MSG_RESULT([no, $LIBXML2_VERSION])
-        AC_MSG_ERROR([NOTE: libxml2 library must be at least 2.6.29])
+        AC_MSG_ERROR([NOTE: libxml2 library must be at least ${LIBXML2_MIN_VERSION}])
     fi
 
 else
     AC_MSG_RESULT([no])
+fi
+])
+
+AC_DEFUN([CHECK_LIBXML2], [
+
+AC_ARG_WITH(
+    libxml,
+    [AS_HELP_STRING([--with-libxml=PATH],[Path to libxml2 prefix or config script])],
+    [test_paths="${with_libxml}"],
+    [test_paths="/usr/local/libxml2 /usr/local/xml2 /usr/local/xml /usr/local /opt/libxml2 /opt/libxml /opt/xml2 /opt/xml /opt /usr"])
+
+LIBXML2_MIN_VERSION="2.6.29"
+LIBXML2_PKG_NAME="libxml-2.0"
+LIBXML2_CONFIG=""
+LIBXML2_VERSION=""
+LIBXML2_CFLAGS=""
+LIBXML2_CPPFLAGS=""
+LIBXML2_LDADD=""
+LIBXML2_LDFLAGS=""
+
+if test "x${with_libxml}" != "xno"; then
+    if test -n "${PKG_CONFIG}"; then
+        AC_MSG_CHECKING([for libxml2 >= ${LIBXML2_MIN_VERSION} via pkg-config])
+        if `${PKG_CONFIG} --exists "${LIBXML2_PKG_NAME} >= ${LIBXML2_MIN_VERSION}"`; then
+            LIBXML2_VERSION="`${PKG_CONFIG} --modversion ${LIBXML2_PKG_NAME}`"
+            LIBXML2_CFLAGS="`${PKG_CONFIG} --cflags ${LIBXML2_PKG_NAME}`"
+            LIBXML2_LDADD="`${PKG_CONFIG} --libs-only-l ${LIBXML2_PKG_NAME}`"
+            LIBXML2_LDFLAGS="`${PKG_CONFIG} --libs-only-L --libs-only-other ${LIBXML2_PKG_NAME}`"
+            AC_MSG_RESULT([found version ${LIBXML2_VERSION}])
+        else
+            AC_MSG_RESULT([not found])
+        fi
+    fi
+
+    if test -z "${LIBXML2_VERSION}"; then
+        CHECK_XML2CONFIG
+    fi
 fi
 
 AC_SUBST(LIBXML2_CONFIG)

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@ AC_PROG_MAKE_SET
 AC_PROG_GREP
 AC_PATH_PROGS(PERL, [perl perl5], )
 AC_PATH_PROGS(ENV_CMD, [env printenv], )
+PKG_PROG_PKG_CONFIG
 
 # Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
Debian is taking steps to remove `xml2-config` in favour of `pkg-config`. This means ModSecurity will build without `libxml2` support by default on Debian, Ubuntu and other distributions tracking Debian packages.

This patch modifies `build/libxml.m4` to check for `libxml2` via `pkg-config`, falling back to `xml2-config` if necessary.

Patch for ModSecurity v2, as discussed in #2714.