### PR TITLE
Move log opening to appropriate execution phase

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1239,35 +1239,6 @@ static const char *cmd_audit_log(cmd_parms *cmd, void *_dcfg, const char *p1)
     directory_config *dcfg = _dcfg;
 
     dcfg->auditlog_name = (char *)p1;
-
-    if (dcfg->auditlog_name[0] == '|') {
-        const char *pipe_name = dcfg->auditlog_name + 1;
-        piped_log *pipe_log;
-
-        pipe_log = ap_open_piped_log(cmd->pool, pipe_name);
-        if (pipe_log == NULL) {
-            return apr_psprintf(cmd->pool, "ModSecurity: Failed to open the audit log pipe: %s",
-                    pipe_name);
-        }
-        dcfg->auditlog_fd = ap_piped_log_write_fd(pipe_log);
-    }
-    else {
-        const char *file_name = ap_server_root_relative(cmd->pool, dcfg->auditlog_name);
-        apr_status_t rc;
-        
-        if (dcfg->auditlog_fileperms == NOT_SET) {
-            dcfg->auditlog_fileperms = CREATEMODE;
-        }
-        rc = apr_file_open(&dcfg->auditlog_fd, file_name,
-                APR_WRITE | APR_APPEND | APR_CREATE | APR_BINARY,
-                dcfg->auditlog_fileperms, cmd->pool);
-
-        if (rc != APR_SUCCESS) {
-            return apr_psprintf(cmd->pool, "ModSecurity: Failed to open the audit log file: %s",
-                    file_name);
-        }
-    }
-
     return NULL;
 }
 
@@ -1283,35 +1254,6 @@ static const char *cmd_audit_log2(cmd_parms *cmd, void *_dcfg, const char *p1)
     }
 
     dcfg->auditlog2_name = (char *)p1;
-
-    if (dcfg->auditlog2_name[0] == '|') {
-        const char *pipe_name = ap_server_root_relative(cmd->pool, dcfg->auditlog2_name + 1);
-        piped_log *pipe_log;
-
-        pipe_log = ap_open_piped_log(cmd->pool, pipe_name);
-        if (pipe_log == NULL) {
-            return apr_psprintf(cmd->pool, "ModSecurity: Failed to open the secondary audit log pipe: %s",
-                    pipe_name);
-        }
-        dcfg->auditlog2_fd = ap_piped_log_write_fd(pipe_log);
-    }
-    else {
-        const char *file_name = ap_server_root_relative(cmd->pool, dcfg->auditlog2_name);
-        apr_status_t rc;
-
-        if (dcfg->auditlog_fileperms == NOT_SET) {
-            dcfg->auditlog_fileperms = CREATEMODE;
-        }
-        rc = apr_file_open(&dcfg->auditlog2_fd, file_name,
-                APR_WRITE | APR_APPEND | APR_CREATE | APR_BINARY,
-                dcfg->auditlog_fileperms, cmd->pool);
-
-        if (rc != APR_SUCCESS) {
-            return apr_psprintf(cmd->pool, "ModSecurity: Failed to open the secondary audit log file: %s",
-                    file_name);
-        }
-    }
-
     return NULL;
 }
 

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -1735,6 +1735,7 @@ static void register_hooks(apr_pool_t *mp) {
 
     /* Logging */
     ap_hook_error_log(hook_error_log, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_open_logs(modsec_open_logs, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_log_transaction(hook_log_transaction, NULL, transaction_afterme_list, APR_HOOK_MIDDLE);
 
     /* Filter hooks */

--- a/apache2/msc_logging.h
+++ b/apache2/msc_logging.h
@@ -43,6 +43,7 @@
 #define AUDITLOG_PART_ENDMARKER             'Z'
 
 #include "modsecurity.h"
+#include "httpd.h"
 #include "apr_pools.h"
 
 int DSOLOCAL is_valid_parts_specification(char *p);
@@ -50,5 +51,7 @@ int DSOLOCAL is_valid_parts_specification(char *p);
 char DSOLOCAL *construct_log_vcombinedus_limited(modsec_rec *msr, int _limit, int *was_limited);
 
 void DSOLOCAL sec_audit_logger(modsec_rec *msr);
+
+int modsec_open_logs(apr_pool_t *pconf, apr_pool_t *p, apr_pool_t *ptemp, server_rec *s_main);
 
 #endif


### PR DESCRIPTION
When piped logs are opened during parsing of configuration it results in unexpected situations in apache httpd and can cause hang of process which is trying to log into auditlog.

Closes #2822 