### PR TITLE
Fix: handle error with SecConnReadStateLimit configuration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Fix: handle error with SecConnReadStateLimit configuration
+   [Issue #2815, #2834 - @marcstern, @martinhsv]
  * Only check for pcre2 install if required
    [Issue #2833 - @martinhsv]
  * Adjustment of previous fix for log messages

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1732,6 +1732,12 @@ char *parser_conn_limits_operator(apr_pool_t *mp, const char *p2,
     char *param = strchr(p2, ' ');
     char *file = NULL;
     char *error_msg = NULL;
+
+    if (param == NULL) {
+        return apr_psprintf(mp, "ModSecurity: Space character between operator " \
+           "and parameter not found with ConnReadStateLimit: %s", p2);
+    }
+
     param++;
 
     config_orig_path = apr_pstrndup(mp, filename,


### PR DESCRIPTION
Fix NULL-memory use case if an admin has not correctly included both an operator and a parameter (with a space-character separator).
