### PR TITLE
Support configurable limit on number of arguments processed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Support configurable limit on number of arguments processed
+   [Issue #2844 - @jleproust, @martinhsv]
  * Silence compiler warning about discarded const
    [Issue #2843 - @Steve8291, @martinhsv]
  * Support for JIT option for PCRE2

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -1,6 +1,6 @@
 /*
 * ModSecurity for Apache 2.x, http://www.modsecurity.org/
-* Copyright (c) 2004-2013 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+* Copyright (c) 2004-2022 Trustwave Holdings, Inc. (http://www.trustwave.com/)
 *
 * You may not use this file except in compliance with
 * the License.  You may obtain a copy of the License at
@@ -96,6 +96,7 @@ typedef struct msc_parm msc_parm;
 #define REQUEST_BODY_DEFAULT_LIMIT              134217728
 #define REQUEST_BODY_NO_FILES_DEFAULT_LIMIT     1048576
 #define REQUEST_BODY_JSON_DEPTH_DEFAULT_LIMIT   10000
+#define ARGUMENTS_LIMIT                         1000
 #define RESPONSE_BODY_DEFAULT_LIMIT             524288
 #define RESPONSE_BODY_HARD_LIMIT                1073741824L
 
@@ -500,6 +501,7 @@ struct directory_config {
     long int             reqbody_limit;
     long int             reqbody_no_files_limit;
     long int             reqbody_json_depth_limit;
+    long int             arguments_limit;
     int                  resbody_access;
 
     long int             of_limit;

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -1,6 +1,6 @@
 /*
  * ModSecurity for Apache 2.x, http://www.modsecurity.org/
- * Copyright (c) 2004-2011 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+ * Copyright (c) 2004-2022 Trustwave Holdings, Inc. (http://www.trustwave.com/)
  *
  * You may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
@@ -56,6 +56,15 @@ int json_add_argument(modsec_rec *msr, const char *value, unsigned length)
     if (msr->txcfg->debuglog_level >= 9) {
         msr_log(msr, 9, "Adding JSON argument '%s' with value '%s'",
             arg->name, arg->value);
+    }
+    if (apr_table_elts(msr->arguments)->nelts >= msr->txcfg->arguments_limit) {
+        if (msr->txcfg->debuglog_level >= 4) {
+            msr_log(msr, 4, "Skipping request argument, over limit (%s): name \"%s\", value \"%s\"",
+                    arg->origin, log_escape_ex(msr->mp, arg->name, arg->name_len),
+                    log_escape_ex(msr->mp, arg->value, arg->value_len));
+        }
+        msr->msc_reqbody_error = 1;
+        return 0;
     }
 
     apr_table_addn(msr->arguments,

--- a/tests/regression/config/10-request-directives.t
+++ b/tests/regression/config/10-request-directives.t
@@ -703,3 +703,50 @@
 	),
 },
 
+# SecArgumentsLimit
+{
+	type => "config",
+	comment => "SecArgumentsLimit (pos)",
+	conf => qq(
+		SecRuleEngine On
+		SecRequestBodyAccess On
+		SecArgumentsLimit 5
+		SecRule REQBODY_ERROR "!\@eq 0" "id:'500232',phase:2,log,deny,status:403,msg:'Failed to parse request body'"
+	),
+	match_log => {
+		error => [ qr/Access denied with code 403 /, 1 ],
+	},
+	match_response => {
+		status => qr/^403$/,
+	},
+	request => new HTTP::Request(
+		POST => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt",
+		[
+			"Content-Type" => "application/x-www-form-urlencoded",
+		],
+		"a=1&b=2&c=3&d=4&e=5&f=6",
+	),
+},
+{
+	type => "config",
+	comment => "SecArgumentsLimit (neg)",
+	conf => qq(
+		SecRuleEngine On
+		SecRequestBodyAccess On
+		SecArgumentsLimit 5
+		SecRule REQBODY_ERROR "!\@eq 0" "id:'500233',phase:2,log,deny,status:403,msg:'Failed to parse request body'"
+	),
+	match_log => {
+	},
+	match_response => {
+		status => qr/^200$/,
+	},
+	request => new HTTP::Request(
+		POST => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt",
+		[
+			"Content-Type" => "application/x-www-form-urlencoded",
+		],
+		"a=1&b=2&c=3&d=4&e=5",
+	),
+},
+


### PR DESCRIPTION
This is the ModSecurity v2 implementation of the SecArgumentsLimit configuration item, which was previously implemented in ModSecurity v3.

The limit is configurable via the new directive but there is a software default of 1000.

Exceeding the limit will set REQBODY_ERROR and additional arguments beyond the limit will not be included. With JSON body processing there is an additional short-circuit to halt parsing once the limit is breached.
