### PR TITLE
Clear original response code in send_error_bucket function

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -31,6 +31,11 @@ apr_status_t send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status) {
     /* Set the status line explicitly for the error document */
     f->r->status_line = ap_get_status_line(status);
 
+    /* Clear previously set response code to make clear that this is
+     * not a recursive error
+     */
+    f->r->status = 200;
+
     brigade = apr_brigade_create(f->r->pool, f->r->connection->bucket_alloc);
     if (brigade == NULL) return APR_EGENERAL;
 


### PR DESCRIPTION
If this is left intact, then apache thinks that this code was generated during processing of ErrorDocument and does not handle it properly

Fix #2849