### PR TITLE
Resolve memory leak (bison-generated position.filename)

### DIFF
--- a/src/parser/driver.cc
+++ b/src/parser/driver.cc
@@ -34,6 +34,7 @@ Driver::Driver()
 
 
 Driver::~Driver() {
+
     while (loc.empty() == false) {
         yy::location *a = loc.back();
         loc.pop_back();
@@ -129,9 +130,11 @@ int Driver::parse(const std::string &f, const std::string &ref) {
     m_lastRule = nullptr;
     loc.push_back(new yy::location());
     if (ref.empty()) {
-        loc.back()->begin.filename = loc.back()->end.filename = new std::string("<<reference missing or not informed>>");
+        m_filenames.push_back("<<reference missing or not informed>>");
+        loc.back()->begin.filename = loc.back()->end.filename = &(m_filenames.back());
     } else {
-        loc.back()->begin.filename = loc.back()->end.filename = new std::string(ref);
+        m_filenames.push_back(ref);
+        loc.back()->begin.filename = loc.back()->end.filename = &(m_filenames.back());
     }
 
     if (f.empty()) {

--- a/src/parser/driver.h
+++ b/src/parser/driver.h
@@ -53,14 +53,6 @@ typedef struct Driver_t Driver;
 #endif
 
 
-/**
- *
- * FIXME: There is a memory leak in the filename at yy::location.
- *        The filename should be converted into a shared string to
- *        save memory or be associated with the life cycle of the
- *        driver class.
- *
- **/
 class Driver : public RulesSetProperties {
  public:
     Driver();
@@ -92,6 +84,13 @@ class Driver : public RulesSetProperties {
     RuleWithActions *m_lastRule;
 
     RulesSetPhases m_rulesSetPhases;
+
+    // Retain a list of new'd filenames so that they are available during the lifetime
+    // of the Driver object, but so that they will get cleaned up by the Driver
+    // destructor. This is to resolve a memory leak of  yy.position.filename in location.hh.
+    // Ordinarily other solutions would have been preferable, but location.hh is a
+    // bison-generated file, which makes some alternative solutions impractical.
+    std::list<std::string> m_filenames;
 };
 
 

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -42,7 +42,7 @@
 
 
 // Unqualified %code blocks.
-#line 327 "seclang-parser.yy"
+#line 328 "seclang-parser.yy"
 
 #include "src/parser/driver.h"
 
@@ -1325,10 +1325,11 @@ namespace yy {
 #line 320 "seclang-parser.yy"
 {
   // Initialize the initial location.
-  yyla.location.begin.filename = yyla.location.end.filename = new std::string(driver.file);
+  driver.m_filenames.push_back(driver.file);
+  yyla.location.begin.filename = yyla.location.end.filename = &(driver.m_filenames.back());
 }
 
-#line 1332 "seclang-parser.cc"
+#line 1333 "seclang-parser.cc"
 
 
     /* Initialize the stack.  The initial state will be set in
@@ -1695,241 +1696,241 @@ namespace yy {
           switch (yyn)
             {
   case 2: // input: "end of file"
-#line 716 "seclang-parser.yy"
+#line 717 "seclang-parser.yy"
       {
         return 0;
       }
-#line 1703 "seclang-parser.cc"
+#line 1704 "seclang-parser.cc"
     break;
 
   case 6: // audit_log: "CONFIG_DIR_AUDIT_DIR_MOD"
-#line 729 "seclang-parser.yy"
+#line 730 "seclang-parser.yy"
       {
         driver.m_auditLog->setStorageDirMode(strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 8));
       }
-#line 1711 "seclang-parser.cc"
+#line 1712 "seclang-parser.cc"
     break;
 
   case 7: // audit_log: "CONFIG_DIR_AUDIT_DIR"
-#line 735 "seclang-parser.yy"
+#line 736 "seclang-parser.yy"
       {
         driver.m_auditLog->setStorageDir(yystack_[0].value.as < std::string > ());
       }
-#line 1719 "seclang-parser.cc"
+#line 1720 "seclang-parser.cc"
     break;
 
   case 8: // audit_log: "CONFIG_DIR_AUDIT_ENG" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 741 "seclang-parser.yy"
+#line 742 "seclang-parser.yy"
       {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::RelevantOnlyAuditLogStatus);
       }
-#line 1727 "seclang-parser.cc"
+#line 1728 "seclang-parser.cc"
     break;
 
   case 9: // audit_log: "CONFIG_DIR_AUDIT_ENG" "CONFIG_VALUE_OFF"
-#line 745 "seclang-parser.yy"
+#line 746 "seclang-parser.yy"
       {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::OffAuditLogStatus);
       }
-#line 1735 "seclang-parser.cc"
+#line 1736 "seclang-parser.cc"
     break;
 
   case 10: // audit_log: "CONFIG_DIR_AUDIT_ENG" "CONFIG_VALUE_ON"
-#line 749 "seclang-parser.yy"
+#line 750 "seclang-parser.yy"
       {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::OnAuditLogStatus);
       }
-#line 1743 "seclang-parser.cc"
+#line 1744 "seclang-parser.cc"
     break;
 
   case 11: // audit_log: "CONFIG_DIR_AUDIT_FLE_MOD"
-#line 755 "seclang-parser.yy"
+#line 756 "seclang-parser.yy"
       {
         driver.m_auditLog->setFileMode(strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 8));
       }
-#line 1751 "seclang-parser.cc"
+#line 1752 "seclang-parser.cc"
     break;
 
   case 12: // audit_log: "CONFIG_DIR_AUDIT_LOG2"
-#line 761 "seclang-parser.yy"
+#line 762 "seclang-parser.yy"
       {
         driver.m_auditLog->setFilePath2(yystack_[0].value.as < std::string > ());
       }
-#line 1759 "seclang-parser.cc"
+#line 1760 "seclang-parser.cc"
     break;
 
   case 13: // audit_log: "CONFIG_DIR_AUDIT_LOG_P"
-#line 767 "seclang-parser.yy"
+#line 768 "seclang-parser.yy"
       {
         driver.m_auditLog->setParts(yystack_[0].value.as < std::string > ());
       }
-#line 1767 "seclang-parser.cc"
+#line 1768 "seclang-parser.cc"
     break;
 
   case 14: // audit_log: "CONFIG_DIR_AUDIT_LOG"
-#line 773 "seclang-parser.yy"
+#line 774 "seclang-parser.yy"
       {
         driver.m_auditLog->setFilePath1(yystack_[0].value.as < std::string > ());
       }
-#line 1775 "seclang-parser.cc"
+#line 1776 "seclang-parser.cc"
     break;
 
   case 15: // audit_log: CONFIG_DIR_AUDIT_LOG_FMT JSON
-#line 778 "seclang-parser.yy"
+#line 779 "seclang-parser.yy"
       {
         driver.m_auditLog->setFormat(modsecurity::audit_log::AuditLog::JSONAuditLogFormat);
       }
-#line 1783 "seclang-parser.cc"
+#line 1784 "seclang-parser.cc"
     break;
 
   case 16: // audit_log: CONFIG_DIR_AUDIT_LOG_FMT NATIVE
-#line 783 "seclang-parser.yy"
+#line 784 "seclang-parser.yy"
       {
         driver.m_auditLog->setFormat(modsecurity::audit_log::AuditLog::NativeAuditLogFormat);
       }
-#line 1791 "seclang-parser.cc"
+#line 1792 "seclang-parser.cc"
     break;
 
   case 17: // audit_log: "CONFIG_DIR_AUDIT_STS"
-#line 789 "seclang-parser.yy"
+#line 790 "seclang-parser.yy"
       {
         std::string relevant_status(yystack_[0].value.as < std::string > ());
         driver.m_auditLog->setRelevantStatus(relevant_status);
       }
-#line 1800 "seclang-parser.cc"
+#line 1801 "seclang-parser.cc"
     break;
 
   case 18: // audit_log: "CONFIG_DIR_AUDIT_TPE" "CONFIG_VALUE_SERIAL"
-#line 796 "seclang-parser.yy"
+#line 797 "seclang-parser.yy"
       {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::SerialAuditLogType);
       }
-#line 1808 "seclang-parser.cc"
+#line 1809 "seclang-parser.cc"
     break;
 
   case 19: // audit_log: "CONFIG_DIR_AUDIT_TPE" "CONFIG_VALUE_PARALLEL"
-#line 800 "seclang-parser.yy"
+#line 801 "seclang-parser.yy"
       {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::ParallelAuditLogType);
       }
-#line 1816 "seclang-parser.cc"
+#line 1817 "seclang-parser.cc"
     break;
 
   case 20: // audit_log: "CONFIG_DIR_AUDIT_TPE" "CONFIG_VALUE_HTTPS"
-#line 804 "seclang-parser.yy"
+#line 805 "seclang-parser.yy"
       {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::HttpsAuditLogType);
       }
-#line 1824 "seclang-parser.cc"
+#line 1825 "seclang-parser.cc"
     break;
 
   case 21: // audit_log: "CONFIG_UPDLOAD_KEEP_FILES" "CONFIG_VALUE_ON"
-#line 810 "seclang-parser.yy"
+#line 811 "seclang-parser.yy"
       {
         driver.m_uploadKeepFiles = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 1832 "seclang-parser.cc"
+#line 1833 "seclang-parser.cc"
     break;
 
   case 22: // audit_log: "CONFIG_UPDLOAD_KEEP_FILES" "CONFIG_VALUE_OFF"
-#line 814 "seclang-parser.yy"
+#line 815 "seclang-parser.yy"
       {
         driver.m_uploadKeepFiles = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 1840 "seclang-parser.cc"
+#line 1841 "seclang-parser.cc"
     break;
 
   case 23: // audit_log: "CONFIG_UPDLOAD_KEEP_FILES" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 818 "seclang-parser.yy"
+#line 819 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecUploadKeepFiles RelevantOnly is not currently supported. Accepted values are On or Off");
         YYERROR;
       }
-#line 1849 "seclang-parser.cc"
+#line 1850 "seclang-parser.cc"
     break;
 
   case 24: // audit_log: "CONFIG_UPLOAD_FILE_LIMIT"
-#line 823 "seclang-parser.yy"
+#line 824 "seclang-parser.yy"
       {
         driver.m_uploadFileLimit.m_set = true;
         driver.m_uploadFileLimit.m_value = strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 10);
       }
-#line 1858 "seclang-parser.cc"
+#line 1859 "seclang-parser.cc"
     break;
 
   case 25: // audit_log: "CONFIG_UPLOAD_FILE_MODE"
-#line 828 "seclang-parser.yy"
+#line 829 "seclang-parser.yy"
       {
         driver.m_uploadFileMode.m_set = true;
         driver.m_uploadFileMode.m_value = strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 8);
       }
-#line 1867 "seclang-parser.cc"
+#line 1868 "seclang-parser.cc"
     break;
 
   case 26: // audit_log: "CONFIG_UPLOAD_DIR"
-#line 833 "seclang-parser.yy"
+#line 834 "seclang-parser.yy"
       {
         driver.m_uploadDirectory.m_set = true;
         driver.m_uploadDirectory.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 1876 "seclang-parser.cc"
+#line 1877 "seclang-parser.cc"
     break;
 
   case 27: // audit_log: "CONFIG_UPDLOAD_SAVE_TMP_FILES" "CONFIG_VALUE_ON"
-#line 838 "seclang-parser.yy"
+#line 839 "seclang-parser.yy"
       {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 1884 "seclang-parser.cc"
+#line 1885 "seclang-parser.cc"
     break;
 
   case 28: // audit_log: "CONFIG_UPDLOAD_SAVE_TMP_FILES" "CONFIG_VALUE_OFF"
-#line 842 "seclang-parser.yy"
+#line 843 "seclang-parser.yy"
       {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 1892 "seclang-parser.cc"
+#line 1893 "seclang-parser.cc"
     break;
 
   case 29: // actions: "QUOTATION_MARK" actions_may_quoted "QUOTATION_MARK"
-#line 849 "seclang-parser.yy"
+#line 850 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1900 "seclang-parser.cc"
+#line 1901 "seclang-parser.cc"
     break;
 
   case 30: // actions: actions_may_quoted
-#line 853 "seclang-parser.yy"
+#line 854 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1908 "seclang-parser.cc"
+#line 1909 "seclang-parser.cc"
     break;
 
   case 31: // actions_may_quoted: actions_may_quoted "," act
-#line 860 "seclang-parser.yy"
+#line 861 "seclang-parser.yy"
       {
         ACTION_INIT(yystack_[0].value.as < std::unique_ptr<actions::Action> > (), yystack_[3].location)
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1918 "seclang-parser.cc"
+#line 1919 "seclang-parser.cc"
     break;
 
   case 32: // actions_may_quoted: act
-#line 866 "seclang-parser.yy"
+#line 867 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<actions::Action>>> b(new std::vector<std::unique_ptr<actions::Action>>());
         ACTION_INIT(yystack_[0].value.as < std::unique_ptr<actions::Action> > (), yystack_[1].location)
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(b);
       }
-#line 1929 "seclang-parser.cc"
+#line 1930 "seclang-parser.cc"
     break;
 
   case 33: // op: op_before_init
-#line 876 "seclang-parser.yy"
+#line 877 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as < std::unique_ptr<Operator> > ());
         std::string error;
@@ -1938,11 +1939,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1942 "seclang-parser.cc"
+#line 1943 "seclang-parser.cc"
     break;
 
   case 34: // op: "NOT" op_before_init
-#line 885 "seclang-parser.yy"
+#line 886 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as < std::unique_ptr<Operator> > ());
         yylhs.value.as < std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1952,11 +1953,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1956 "seclang-parser.cc"
+#line 1957 "seclang-parser.cc"
     break;
 
   case 35: // op: run_time_string
-#line 895 "seclang-parser.yy"
+#line 896 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
         std::string error;
@@ -1965,11 +1966,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1969 "seclang-parser.cc"
+#line 1970 "seclang-parser.cc"
     break;
 
   case 36: // op: "NOT" run_time_string
-#line 904 "seclang-parser.yy"
+#line 905 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
         yylhs.value.as < std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1979,302 +1980,302 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1983 "seclang-parser.cc"
+#line 1984 "seclang-parser.cc"
     break;
 
   case 37: // op_before_init: "OPERATOR_UNCONDITIONAL_MATCH"
-#line 917 "seclang-parser.yy"
+#line 918 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::UnconditionalMatch());
       }
-#line 1991 "seclang-parser.cc"
+#line 1992 "seclang-parser.cc"
     break;
 
   case 38: // op_before_init: "OPERATOR_DETECT_SQLI"
-#line 921 "seclang-parser.yy"
+#line 922 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::DetectSQLi());
       }
-#line 1999 "seclang-parser.cc"
+#line 2000 "seclang-parser.cc"
     break;
 
   case 39: // op_before_init: "OPERATOR_DETECT_XSS"
-#line 925 "seclang-parser.yy"
+#line 926 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::DetectXSS());
       }
-#line 2007 "seclang-parser.cc"
+#line 2008 "seclang-parser.cc"
     break;
 
   case 40: // op_before_init: "OPERATOR_VALIDATE_URL_ENCODING"
-#line 929 "seclang-parser.yy"
+#line 930 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateUrlEncoding());
       }
-#line 2015 "seclang-parser.cc"
+#line 2016 "seclang-parser.cc"
     break;
 
   case 41: // op_before_init: "OPERATOR_VALIDATE_UTF8_ENCODING"
-#line 933 "seclang-parser.yy"
+#line 934 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateUtf8Encoding());
       }
-#line 2023 "seclang-parser.cc"
+#line 2024 "seclang-parser.cc"
     break;
 
   case 42: // op_before_init: "OPERATOR_INSPECT_FILE" run_time_string
-#line 937 "seclang-parser.yy"
+#line 938 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::InspectFile(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2031 "seclang-parser.cc"
+#line 2032 "seclang-parser.cc"
     break;
 
   case 43: // op_before_init: "OPERATOR_FUZZY_HASH" run_time_string
-#line 941 "seclang-parser.yy"
+#line 942 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::FuzzyHash(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2039 "seclang-parser.cc"
+#line 2040 "seclang-parser.cc"
     break;
 
   case 44: // op_before_init: "OPERATOR_VALIDATE_BYTE_RANGE" run_time_string
-#line 945 "seclang-parser.yy"
+#line 946 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateByteRange(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2047 "seclang-parser.cc"
+#line 2048 "seclang-parser.cc"
     break;
 
   case 45: // op_before_init: "OPERATOR_VALIDATE_DTD" run_time_string
-#line 949 "seclang-parser.yy"
+#line 950 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateDTD(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2055 "seclang-parser.cc"
+#line 2056 "seclang-parser.cc"
     break;
 
   case 46: // op_before_init: "OPERATOR_VALIDATE_HASH" run_time_string
-#line 953 "seclang-parser.yy"
+#line 954 "seclang-parser.yy"
       {
         /* $$ = new operators::ValidateHash($1); */
         OPERATOR_NOT_SUPPORTED("ValidateHash", yystack_[2].location);
       }
-#line 2064 "seclang-parser.cc"
+#line 2065 "seclang-parser.cc"
     break;
 
   case 47: // op_before_init: "OPERATOR_VALIDATE_SCHEMA" run_time_string
-#line 958 "seclang-parser.yy"
+#line 959 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateSchema(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2072 "seclang-parser.cc"
+#line 2073 "seclang-parser.cc"
     break;
 
   case 48: // op_before_init: "OPERATOR_VERIFY_CC" run_time_string
-#line 962 "seclang-parser.yy"
+#line 963 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifyCC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2080 "seclang-parser.cc"
+#line 2081 "seclang-parser.cc"
     break;
 
   case 49: // op_before_init: "OPERATOR_VERIFY_CPF" run_time_string
-#line 966 "seclang-parser.yy"
+#line 967 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifyCPF(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2088 "seclang-parser.cc"
+#line 2089 "seclang-parser.cc"
     break;
 
   case 50: // op_before_init: "OPERATOR_VERIFY_SSN" run_time_string
-#line 970 "seclang-parser.yy"
+#line 971 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifySSN(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2096 "seclang-parser.cc"
+#line 2097 "seclang-parser.cc"
     break;
 
   case 51: // op_before_init: "OPERATOR_VERIFY_SVNR" run_time_string
-#line 974 "seclang-parser.yy"
+#line 975 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifySVNR(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2104 "seclang-parser.cc"
+#line 2105 "seclang-parser.cc"
     break;
 
   case 52: // op_before_init: "OPERATOR_GSB_LOOKUP" run_time_string
-#line 978 "seclang-parser.yy"
+#line 979 "seclang-parser.yy"
       {
         /* $$ = new operators::GsbLookup($1); */
         OPERATOR_NOT_SUPPORTED("GsbLookup", yystack_[2].location);
       }
-#line 2113 "seclang-parser.cc"
+#line 2114 "seclang-parser.cc"
     break;
 
   case 53: // op_before_init: "OPERATOR_RSUB" run_time_string
-#line 983 "seclang-parser.yy"
+#line 984 "seclang-parser.yy"
       {
         /* $$ = new operators::Rsub($1); */
         OPERATOR_NOT_SUPPORTED("Rsub", yystack_[2].location);
       }
-#line 2122 "seclang-parser.cc"
+#line 2123 "seclang-parser.cc"
     break;
 
   case 54: // op_before_init: "OPERATOR_WITHIN" run_time_string
-#line 988 "seclang-parser.yy"
+#line 989 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Within(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2130 "seclang-parser.cc"
+#line 2131 "seclang-parser.cc"
     break;
 
   case 55: // op_before_init: "OPERATOR_CONTAINS_WORD" run_time_string
-#line 992 "seclang-parser.yy"
+#line 993 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ContainsWord(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2138 "seclang-parser.cc"
+#line 2139 "seclang-parser.cc"
     break;
 
   case 56: // op_before_init: "OPERATOR_CONTAINS" run_time_string
-#line 996 "seclang-parser.yy"
+#line 997 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Contains(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2146 "seclang-parser.cc"
+#line 2147 "seclang-parser.cc"
     break;
 
   case 57: // op_before_init: "OPERATOR_ENDS_WITH" run_time_string
-#line 1000 "seclang-parser.yy"
+#line 1001 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::EndsWith(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2154 "seclang-parser.cc"
+#line 2155 "seclang-parser.cc"
     break;
 
   case 58: // op_before_init: "OPERATOR_EQ" run_time_string
-#line 1004 "seclang-parser.yy"
+#line 1005 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Eq(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2162 "seclang-parser.cc"
+#line 2163 "seclang-parser.cc"
     break;
 
   case 59: // op_before_init: "OPERATOR_GE" run_time_string
-#line 1008 "seclang-parser.yy"
+#line 1009 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Ge(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2170 "seclang-parser.cc"
+#line 2171 "seclang-parser.cc"
     break;
 
   case 60: // op_before_init: "OPERATOR_GT" run_time_string
-#line 1012 "seclang-parser.yy"
+#line 1013 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Gt(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2178 "seclang-parser.cc"
+#line 2179 "seclang-parser.cc"
     break;
 
   case 61: // op_before_init: "OPERATOR_IP_MATCH_FROM_FILE" run_time_string
-#line 1016 "seclang-parser.yy"
+#line 1017 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::IpMatchF(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2186 "seclang-parser.cc"
+#line 2187 "seclang-parser.cc"
     break;
 
   case 62: // op_before_init: "OPERATOR_IP_MATCH" run_time_string
-#line 1020 "seclang-parser.yy"
+#line 1021 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::IpMatch(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2194 "seclang-parser.cc"
+#line 2195 "seclang-parser.cc"
     break;
 
   case 63: // op_before_init: "OPERATOR_LE" run_time_string
-#line 1024 "seclang-parser.yy"
+#line 1025 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Le(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2202 "seclang-parser.cc"
+#line 2203 "seclang-parser.cc"
     break;
 
   case 64: // op_before_init: "OPERATOR_LT" run_time_string
-#line 1028 "seclang-parser.yy"
+#line 1029 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Lt(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2210 "seclang-parser.cc"
+#line 2211 "seclang-parser.cc"
     break;
 
   case 65: // op_before_init: "OPERATOR_PM_FROM_FILE" run_time_string
-#line 1032 "seclang-parser.yy"
+#line 1033 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::PmFromFile(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2218 "seclang-parser.cc"
+#line 2219 "seclang-parser.cc"
     break;
 
   case 66: // op_before_init: "OPERATOR_PM" run_time_string
-#line 1036 "seclang-parser.yy"
+#line 1037 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Pm(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2226 "seclang-parser.cc"
+#line 2227 "seclang-parser.cc"
     break;
 
   case 67: // op_before_init: "OPERATOR_RBL" run_time_string
-#line 1040 "seclang-parser.yy"
+#line 1041 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rbl(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2234 "seclang-parser.cc"
+#line 2235 "seclang-parser.cc"
     break;
 
   case 68: // op_before_init: "OPERATOR_RX" run_time_string
-#line 1044 "seclang-parser.yy"
+#line 1045 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2242 "seclang-parser.cc"
+#line 2243 "seclang-parser.cc"
     break;
 
   case 69: // op_before_init: "OPERATOR_RX_GLOBAL" run_time_string
-#line 1048 "seclang-parser.yy"
+#line 1049 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::RxGlobal(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2250 "seclang-parser.cc"
+#line 2251 "seclang-parser.cc"
     break;
 
   case 70: // op_before_init: "OPERATOR_STR_EQ" run_time_string
-#line 1052 "seclang-parser.yy"
+#line 1053 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::StrEq(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2258 "seclang-parser.cc"
+#line 2259 "seclang-parser.cc"
     break;
 
   case 71: // op_before_init: "OPERATOR_STR_MATCH" run_time_string
-#line 1056 "seclang-parser.yy"
+#line 1057 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::StrMatch(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2266 "seclang-parser.cc"
+#line 2267 "seclang-parser.cc"
     break;
 
   case 72: // op_before_init: "OPERATOR_BEGINS_WITH" run_time_string
-#line 1060 "seclang-parser.yy"
+#line 1061 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::BeginsWith(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2274 "seclang-parser.cc"
+#line 2275 "seclang-parser.cc"
     break;
 
   case 73: // op_before_init: "OPERATOR_GEOLOOKUP"
-#line 1064 "seclang-parser.yy"
+#line 1065 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::GeoLookup());
@@ -2285,11 +2286,11 @@ namespace yy {
             YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 2289 "seclang-parser.cc"
+#line 2290 "seclang-parser.cc"
     break;
 
   case 75: // expression: "DIRECTIVE" variables op actions
-#line 1079 "seclang-parser.yy"
+#line 1080 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
@@ -2319,11 +2320,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2323 "seclang-parser.cc"
+#line 2324 "seclang-parser.cc"
     break;
 
   case 76: // expression: "DIRECTIVE" variables op
-#line 1109 "seclang-parser.yy"
+#line 1110 "seclang-parser.yy"
       {
         variables::Variables *v = new variables::Variables();
         for (auto &i : *yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ().get()) {
@@ -2342,11 +2343,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2346 "seclang-parser.cc"
+#line 2347 "seclang-parser.cc"
     break;
 
   case 77: // expression: "CONFIG_DIR_SEC_ACTION" actions
-#line 1128 "seclang-parser.yy"
+#line 1129 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
@@ -2365,11 +2366,11 @@ namespace yy {
             ));
         driver.addSecAction(std::move(rule));
       }
-#line 2369 "seclang-parser.cc"
+#line 2370 "seclang-parser.cc"
     break;
 
   case 78: // expression: "DIRECTIVE_SECRULESCRIPT" actions
-#line 1147 "seclang-parser.yy"
+#line 1148 "seclang-parser.yy"
       {
         std::string err;
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
@@ -2397,11 +2398,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2401 "seclang-parser.cc"
+#line 2402 "seclang-parser.cc"
     break;
 
   case 79: // expression: "CONFIG_DIR_SEC_DEFAULT_ACTION" actions
-#line 1175 "seclang-parser.yy"
+#line 1176 "seclang-parser.yy"
       {
         bool hasDisruptive = false;
         std::vector<actions::Action *> *actions = new std::vector<actions::Action *>();
@@ -2458,78 +2459,78 @@ namespace yy {
 
         delete actions;
       }
-#line 2462 "seclang-parser.cc"
+#line 2463 "seclang-parser.cc"
     break;
 
   case 80: // expression: "CONFIG_DIR_SEC_MARKER"
-#line 1232 "seclang-parser.yy"
+#line 1233 "seclang-parser.yy"
       {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as < std::string > ()),
             /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[0].location.end.filename)),
             /* line number */ yystack_[0].location.end.line
         );
       }
-#line 2473 "seclang-parser.cc"
+#line 2474 "seclang-parser.cc"
     break;
 
   case 81: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_OFF"
-#line 1239 "seclang-parser.yy"
+#line 1240 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DisabledRuleEngine;
       }
-#line 2481 "seclang-parser.cc"
+#line 2482 "seclang-parser.cc"
     break;
 
   case 82: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_ON"
-#line 1243 "seclang-parser.yy"
+#line 1244 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::EnabledRuleEngine;
       }
-#line 2489 "seclang-parser.cc"
+#line 2490 "seclang-parser.cc"
     break;
 
   case 83: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_DETC"
-#line 1247 "seclang-parser.yy"
+#line 1248 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DetectionOnlyRuleEngine;
       }
-#line 2497 "seclang-parser.cc"
+#line 2498 "seclang-parser.cc"
     break;
 
   case 84: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_ON"
-#line 1251 "seclang-parser.yy"
+#line 1252 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2505 "seclang-parser.cc"
+#line 2506 "seclang-parser.cc"
     break;
 
   case 85: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_OFF"
-#line 1255 "seclang-parser.yy"
+#line 1256 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2513 "seclang-parser.cc"
+#line 2514 "seclang-parser.cc"
     break;
 
   case 86: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_ON"
-#line 1259 "seclang-parser.yy"
+#line 1260 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2521 "seclang-parser.cc"
+#line 2522 "seclang-parser.cc"
     break;
 
   case 87: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_OFF"
-#line 1263 "seclang-parser.yy"
+#line 1264 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2529 "seclang-parser.cc"
+#line 2530 "seclang-parser.cc"
     break;
 
   case 88: // expression: "CONFIG_SEC_ARGUMENT_SEPARATOR"
-#line 1267 "seclang-parser.yy"
+#line 1268 "seclang-parser.yy"
       {
         if (yystack_[0].value.as < std::string > ().length() != 1) {
           driver.error(yystack_[1].location, "Argument separator should be set to a single character.");
@@ -2538,259 +2539,259 @@ namespace yy {
         driver.m_secArgumentSeparator.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secArgumentSeparator.m_set = true;
       }
-#line 2542 "seclang-parser.cc"
+#line 2543 "seclang-parser.cc"
     break;
 
   case 89: // expression: "CONFIG_COMPONENT_SIG"
-#line 1276 "seclang-parser.yy"
+#line 1277 "seclang-parser.yy"
       {
         driver.m_components.push_back(yystack_[0].value.as < std::string > ());
       }
-#line 2550 "seclang-parser.cc"
+#line 2551 "seclang-parser.cc"
     break;
 
   case 90: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_ON"
-#line 1280 "seclang-parser.yy"
+#line 1281 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecConnEngine is not yet supported.");
         YYERROR;
       }
-#line 2559 "seclang-parser.cc"
+#line 2560 "seclang-parser.cc"
     break;
 
   case 91: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_OFF"
-#line 1285 "seclang-parser.yy"
+#line 1286 "seclang-parser.yy"
       {
       }
-#line 2566 "seclang-parser.cc"
+#line 2567 "seclang-parser.cc"
     break;
 
   case 92: // expression: "CONFIG_SEC_WEB_APP_ID"
-#line 1288 "seclang-parser.yy"
+#line 1289 "seclang-parser.yy"
       {
         driver.m_secWebAppId.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secWebAppId.m_set = true;
       }
-#line 2575 "seclang-parser.cc"
+#line 2576 "seclang-parser.cc"
     break;
 
   case 93: // expression: "CONFIG_SEC_SERVER_SIG"
-#line 1293 "seclang-parser.yy"
+#line 1294 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecServerSignature is not supported.");
         YYERROR;
       }
-#line 2584 "seclang-parser.cc"
+#line 2585 "seclang-parser.cc"
     break;
 
   case 94: // expression: "CONFIG_SEC_CACHE_TRANSFORMATIONS"
-#line 1298 "seclang-parser.yy"
+#line 1299 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCacheTransformations is not supported.");
         YYERROR;
       }
-#line 2593 "seclang-parser.cc"
+#line 2594 "seclang-parser.cc"
     break;
 
   case 95: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_ON"
-#line 1303 "seclang-parser.yy"
+#line 1304 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecDisableBackendCompression is not supported.");
         YYERROR;
       }
-#line 2602 "seclang-parser.cc"
+#line 2603 "seclang-parser.cc"
     break;
 
   case 96: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_OFF"
-#line 1308 "seclang-parser.yy"
+#line 1309 "seclang-parser.yy"
       {
       }
-#line 2609 "seclang-parser.cc"
+#line 2610 "seclang-parser.cc"
     break;
 
   case 97: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_ON"
-#line 1311 "seclang-parser.yy"
+#line 1312 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecContentInjection is not yet supported.");
         YYERROR;
       }
-#line 2618 "seclang-parser.cc"
+#line 2619 "seclang-parser.cc"
     break;
 
   case 98: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_OFF"
-#line 1316 "seclang-parser.yy"
+#line 1317 "seclang-parser.yy"
       {
       }
-#line 2625 "seclang-parser.cc"
+#line 2626 "seclang-parser.cc"
     break;
 
   case 99: // expression: "CONFIG_SEC_CHROOT_DIR"
-#line 1319 "seclang-parser.yy"
+#line 1320 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecChrootDir is not supported.");
         YYERROR;
       }
-#line 2634 "seclang-parser.cc"
+#line 2635 "seclang-parser.cc"
     break;
 
   case 100: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_ON"
-#line 1324 "seclang-parser.yy"
+#line 1325 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecHashEngine is not yet supported.");
         YYERROR;
       }
-#line 2643 "seclang-parser.cc"
+#line 2644 "seclang-parser.cc"
     break;
 
   case 101: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_OFF"
-#line 1329 "seclang-parser.yy"
+#line 1330 "seclang-parser.yy"
       {
       }
-#line 2650 "seclang-parser.cc"
+#line 2651 "seclang-parser.cc"
     break;
 
   case 102: // expression: "CONFIG_SEC_HASH_KEY"
-#line 1332 "seclang-parser.yy"
+#line 1333 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashKey is not yet supported.");
         YYERROR;
       }
-#line 2659 "seclang-parser.cc"
+#line 2660 "seclang-parser.cc"
     break;
 
   case 103: // expression: "CONFIG_SEC_HASH_PARAM"
-#line 1337 "seclang-parser.yy"
+#line 1338 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashParam is not yet supported.");
         YYERROR;
       }
-#line 2668 "seclang-parser.cc"
+#line 2669 "seclang-parser.cc"
     break;
 
   case 104: // expression: "CONFIG_SEC_HASH_METHOD_RX"
-#line 1342 "seclang-parser.yy"
+#line 1343 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodRx is not yet supported.");
         YYERROR;
       }
-#line 2677 "seclang-parser.cc"
+#line 2678 "seclang-parser.cc"
     break;
 
   case 105: // expression: "CONFIG_SEC_HASH_METHOD_PM"
-#line 1347 "seclang-parser.yy"
+#line 1348 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodPm is not yet supported.");
         YYERROR;
       }
-#line 2686 "seclang-parser.cc"
+#line 2687 "seclang-parser.cc"
     break;
 
   case 106: // expression: "CONFIG_DIR_GSB_DB"
-#line 1352 "seclang-parser.yy"
+#line 1353 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGsbLookupDb is not supported.");
         YYERROR;
       }
-#line 2695 "seclang-parser.cc"
+#line 2696 "seclang-parser.cc"
     break;
 
   case 107: // expression: "CONFIG_SEC_GUARDIAN_LOG"
-#line 1357 "seclang-parser.yy"
+#line 1358 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGuardianLog is not supported.");
         YYERROR;
       }
-#line 2704 "seclang-parser.cc"
+#line 2705 "seclang-parser.cc"
     break;
 
   case 108: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_ON"
-#line 1362 "seclang-parser.yy"
+#line 1363 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecInterceptOnError is not yet supported.");
         YYERROR;
       }
-#line 2713 "seclang-parser.cc"
+#line 2714 "seclang-parser.cc"
     break;
 
   case 109: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_OFF"
-#line 1367 "seclang-parser.yy"
+#line 1368 "seclang-parser.yy"
       {
       }
-#line 2720 "seclang-parser.cc"
+#line 2721 "seclang-parser.cc"
     break;
 
   case 110: // expression: "CONFIG_SEC_CONN_R_STATE_LIMIT"
-#line 1370 "seclang-parser.yy"
+#line 1371 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnReadStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2729 "seclang-parser.cc"
+#line 2730 "seclang-parser.cc"
     break;
 
   case 111: // expression: "CONFIG_SEC_CONN_W_STATE_LIMIT"
-#line 1375 "seclang-parser.yy"
+#line 1376 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnWriteStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2738 "seclang-parser.cc"
+#line 2739 "seclang-parser.cc"
     break;
 
   case 112: // expression: "CONFIG_SEC_SENSOR_ID"
-#line 1380 "seclang-parser.yy"
+#line 1381 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecSensorId is not yet supported.");
         YYERROR;
       }
-#line 2747 "seclang-parser.cc"
+#line 2748 "seclang-parser.cc"
     break;
 
   case 113: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_ON"
-#line 1385 "seclang-parser.yy"
+#line 1386 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecRuleInheritance is not yet supported.");
         YYERROR;
       }
-#line 2756 "seclang-parser.cc"
+#line 2757 "seclang-parser.cc"
     break;
 
   case 114: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_OFF"
-#line 1390 "seclang-parser.yy"
+#line 1391 "seclang-parser.yy"
       {
       }
-#line 2763 "seclang-parser.cc"
+#line 2764 "seclang-parser.cc"
     break;
 
   case 115: // expression: "CONFIG_SEC_RULE_PERF_TIME"
-#line 1393 "seclang-parser.yy"
+#line 1394 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecRulePerfTime is not yet supported.");
         YYERROR;
       }
-#line 2772 "seclang-parser.cc"
+#line 2773 "seclang-parser.cc"
     break;
 
   case 116: // expression: "CONFIG_SEC_STREAM_IN_BODY_INSPECTION"
-#line 1398 "seclang-parser.yy"
+#line 1399 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamInBodyInspection is not supported.");
         YYERROR;
       }
-#line 2781 "seclang-parser.cc"
+#line 2782 "seclang-parser.cc"
     break;
 
   case 117: // expression: "CONFIG_SEC_STREAM_OUT_BODY_INSPECTION"
-#line 1403 "seclang-parser.yy"
+#line 1404 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamOutBodyInspection is not supported.");
         YYERROR;
       }
-#line 2790 "seclang-parser.cc"
+#line 2791 "seclang-parser.cc"
     break;
 
   case 118: // expression: "CONFIG_SEC_RULE_REMOVE_BY_ID"
-#line 1408 "seclang-parser.yy"
+#line 1409 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.load(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2803,11 +2804,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2807 "seclang-parser.cc"
+#line 2808 "seclang-parser.cc"
     break;
 
   case 119: // expression: "CONFIG_SEC_RULE_REMOVE_BY_TAG"
-#line 1421 "seclang-parser.yy"
+#line 1422 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByTag(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2820,11 +2821,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2824 "seclang-parser.cc"
+#line 2825 "seclang-parser.cc"
     break;
 
   case 120: // expression: "CONFIG_SEC_RULE_REMOVE_BY_MSG"
-#line 1434 "seclang-parser.yy"
+#line 1435 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByMsg(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2837,11 +2838,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2841 "seclang-parser.cc"
+#line 2842 "seclang-parser.cc"
     break;
 
   case 121: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_TAG" variables_pre_process
-#line 1447 "seclang-parser.yy"
+#line 1448 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByTag(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2854,11 +2855,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2858 "seclang-parser.cc"
+#line 2859 "seclang-parser.cc"
     break;
 
   case 122: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_MSG" variables_pre_process
-#line 1460 "seclang-parser.yy"
+#line 1461 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByMsg(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2871,11 +2872,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2875 "seclang-parser.cc"
+#line 2876 "seclang-parser.cc"
     break;
 
   case 123: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID" variables_pre_process
-#line 1473 "seclang-parser.yy"
+#line 1474 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2901,11 +2902,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2905 "seclang-parser.cc"
+#line 2906 "seclang-parser.cc"
     break;
 
   case 124: // expression: "CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID" actions
-#line 1499 "seclang-parser.yy"
+#line 1500 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2932,11 +2933,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2936 "seclang-parser.cc"
+#line 2937 "seclang-parser.cc"
     break;
 
   case 125: // expression: "CONFIG_DIR_DEBUG_LVL"
-#line 1527 "seclang-parser.yy"
+#line 1528 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as < std::string > ().c_str()));
@@ -2948,11 +2949,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2952 "seclang-parser.cc"
+#line 2953 "seclang-parser.cc"
     break;
 
   case 126: // expression: "CONFIG_DIR_DEBUG_LOG"
-#line 1539 "seclang-parser.yy"
+#line 1540 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -2971,11 +2972,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2975 "seclang-parser.cc"
+#line 2976 "seclang-parser.cc"
     break;
 
   case 127: // expression: "CONFIG_DIR_GEO_DB"
-#line 1559 "seclang-parser.yy"
+#line 1560 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
@@ -3002,47 +3003,47 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 3006 "seclang-parser.cc"
+#line 3007 "seclang-parser.cc"
     break;
 
   case 128: // expression: "CONFIG_DIR_ARGS_LIMIT"
-#line 1586 "seclang-parser.yy"
+#line 1587 "seclang-parser.yy"
       {
         driver.m_argumentsLimit.m_set = true;
         driver.m_argumentsLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3015 "seclang-parser.cc"
+#line 3016 "seclang-parser.cc"
     break;
 
   case 129: // expression: "CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT"
-#line 1591 "seclang-parser.yy"
+#line 1592 "seclang-parser.yy"
       {
         driver.m_requestBodyJsonDepthLimit.m_set = true;
         driver.m_requestBodyJsonDepthLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3024 "seclang-parser.cc"
+#line 3025 "seclang-parser.cc"
     break;
 
   case 130: // expression: "CONFIG_DIR_REQ_BODY_LIMIT"
-#line 1597 "seclang-parser.yy"
+#line 1598 "seclang-parser.yy"
       {
         driver.m_requestBodyLimit.m_set = true;
         driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3033 "seclang-parser.cc"
+#line 3034 "seclang-parser.cc"
     break;
 
   case 131: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
-#line 1602 "seclang-parser.yy"
+#line 1603 "seclang-parser.yy"
       {
         driver.m_requestBodyNoFilesLimit.m_set = true;
         driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3042 "seclang-parser.cc"
+#line 3043 "seclang-parser.cc"
     break;
 
   case 132: // expression: "CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT"
-#line 1607 "seclang-parser.yy"
+#line 1608 "seclang-parser.yy"
       {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -3051,68 +3052,68 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 3055 "seclang-parser.cc"
+#line 3056 "seclang-parser.cc"
     break;
 
   case 133: // expression: "CONFIG_DIR_RES_BODY_LIMIT"
-#line 1616 "seclang-parser.yy"
+#line 1617 "seclang-parser.yy"
       {
         driver.m_responseBodyLimit.m_set = true;
         driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3064 "seclang-parser.cc"
+#line 3065 "seclang-parser.cc"
     break;
 
   case 134: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1621 "seclang-parser.yy"
+#line 1622 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3072 "seclang-parser.cc"
+#line 3073 "seclang-parser.cc"
     break;
 
   case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1625 "seclang-parser.yy"
+#line 1626 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3080 "seclang-parser.cc"
+#line 3081 "seclang-parser.cc"
     break;
 
   case 136: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1629 "seclang-parser.yy"
+#line 1630 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3088 "seclang-parser.cc"
+#line 3089 "seclang-parser.cc"
     break;
 
   case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1633 "seclang-parser.yy"
+#line 1634 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3096 "seclang-parser.cc"
+#line 3097 "seclang-parser.cc"
     break;
 
   case 138: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
-#line 1637 "seclang-parser.yy"
+#line 1638 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 3104 "seclang-parser.cc"
+#line 3105 "seclang-parser.cc"
     break;
 
   case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
-#line 1641 "seclang-parser.yy"
+#line 1642 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 3112 "seclang-parser.cc"
+#line 3113 "seclang-parser.cc"
     break;
 
   case 142: // expression: "CONGIG_DIR_RESPONSE_BODY_MP"
-#line 1655 "seclang-parser.yy"
+#line 1656 "seclang-parser.yy"
       {
         std::istringstream buf(yystack_[0].value.as < std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -3124,37 +3125,37 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 3128 "seclang-parser.cc"
+#line 3129 "seclang-parser.cc"
     break;
 
   case 143: // expression: "CONGIG_DIR_RESPONSE_BODY_MP_CLEAR"
-#line 1667 "seclang-parser.yy"
+#line 1668 "seclang-parser.yy"
       {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 3138 "seclang-parser.cc"
+#line 3139 "seclang-parser.cc"
     break;
 
   case 144: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
-#line 1673 "seclang-parser.yy"
+#line 1674 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 3146 "seclang-parser.cc"
+#line 3147 "seclang-parser.cc"
     break;
 
   case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
-#line 1677 "seclang-parser.yy"
+#line 1678 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 3154 "seclang-parser.cc"
+#line 3155 "seclang-parser.cc"
     break;
 
   case 146: // expression: "CONGIG_DIR_SEC_TMP_DIR"
-#line 1681 "seclang-parser.yy"
+#line 1682 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
         std::stringstream ss;
@@ -3165,31 +3166,31 @@ namespace yy {
         YYERROR;
 */
       }
-#line 3169 "seclang-parser.cc"
+#line 3170 "seclang-parser.cc"
     break;
 
   case 149: // expression: "CONGIG_DIR_SEC_COOKIE_FORMAT"
-#line 1702 "seclang-parser.yy"
+#line 1703 "seclang-parser.yy"
       {
         if (atoi(yystack_[0].value.as < std::string > ().c_str()) == 1) {
           driver.error(yystack_[1].location, "SecCookieFormat 1 is not yet supported.");
           YYERROR;
         }
       }
-#line 3180 "seclang-parser.cc"
+#line 3181 "seclang-parser.cc"
     break;
 
   case 150: // expression: "CONFIG_SEC_COOKIEV0_SEPARATOR"
-#line 1709 "seclang-parser.yy"
+#line 1710 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCookieV0Separator is not yet supported.");
         YYERROR;
       }
-#line 3189 "seclang-parser.cc"
+#line 3190 "seclang-parser.cc"
     break;
 
   case 152: // expression: "CONFIG_DIR_UNICODE_MAP_FILE"
-#line 1719 "seclang-parser.yy"
+#line 1720 "seclang-parser.yy"
       {
         std::string error;
         std::vector<std::string> param;
@@ -3243,31 +3244,31 @@ namespace yy {
         }
 
       }
-#line 3247 "seclang-parser.cc"
+#line 3248 "seclang-parser.cc"
     break;
 
   case 153: // expression: "CONFIG_SEC_COLLECTION_TIMEOUT"
-#line 1773 "seclang-parser.yy"
+#line 1774 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default CRS installations with crs-setup.conf-recommended
         driver.error(@0, "SecCollectionTimeout is not yet supported.");
         YYERROR;
 */
       }
-#line 3258 "seclang-parser.cc"
+#line 3259 "seclang-parser.cc"
     break;
 
   case 154: // expression: "CONFIG_SEC_HTTP_BLKEY"
-#line 1780 "seclang-parser.yy"
+#line 1781 "seclang-parser.yy"
       {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 3267 "seclang-parser.cc"
+#line 3268 "seclang-parser.cc"
     break;
 
   case 155: // variables: variables_pre_process
-#line 1788 "seclang-parser.yy"
+#line 1789 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable> > > originalList = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> newList(new std::vector<std::unique_ptr<Variable>>());
@@ -3301,2386 +3302,2386 @@ namespace yy {
         }
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(newNewList);
       }
-#line 3305 "seclang-parser.cc"
+#line 3306 "seclang-parser.cc"
     break;
 
   case 156: // variables_pre_process: variables_may_be_quoted
-#line 1825 "seclang-parser.yy"
+#line 1826 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3313 "seclang-parser.cc"
+#line 3314 "seclang-parser.cc"
     break;
 
   case 157: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
-#line 1829 "seclang-parser.yy"
+#line 1830 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3321 "seclang-parser.cc"
+#line 3322 "seclang-parser.cc"
     break;
 
   case 158: // variables_may_be_quoted: variables_may_be_quoted PIPE var
-#line 1836 "seclang-parser.yy"
+#line 1837 "seclang-parser.yy"
       {
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3330 "seclang-parser.cc"
+#line 3331 "seclang-parser.cc"
     break;
 
   case 159: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_EXCLUSION var
-#line 1841 "seclang-parser.yy"
+#line 1842 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3340 "seclang-parser.cc"
+#line 3341 "seclang-parser.cc"
     break;
 
   case 160: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_COUNT var
-#line 1847 "seclang-parser.yy"
+#line 1848 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3350 "seclang-parser.cc"
+#line 3351 "seclang-parser.cc"
     break;
 
   case 161: // variables_may_be_quoted: var
-#line 1853 "seclang-parser.yy"
+#line 1854 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3360 "seclang-parser.cc"
+#line 3361 "seclang-parser.cc"
     break;
 
   case 162: // variables_may_be_quoted: VAR_EXCLUSION var
-#line 1859 "seclang-parser.yy"
+#line 1860 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3371 "seclang-parser.cc"
+#line 3372 "seclang-parser.cc"
     break;
 
   case 163: // variables_may_be_quoted: VAR_COUNT var
-#line 1866 "seclang-parser.yy"
+#line 1867 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3382 "seclang-parser.cc"
+#line 3383 "seclang-parser.cc"
     break;
 
   case 164: // var: VARIABLE_ARGS "Dictionary element"
-#line 1876 "seclang-parser.yy"
+#line 1877 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3390 "seclang-parser.cc"
+#line 3391 "seclang-parser.cc"
     break;
 
   case 165: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
-#line 1880 "seclang-parser.yy"
+#line 1881 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3398 "seclang-parser.cc"
+#line 3399 "seclang-parser.cc"
     break;
 
   case 166: // var: VARIABLE_ARGS
-#line 1884 "seclang-parser.yy"
+#line 1885 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
       }
-#line 3406 "seclang-parser.cc"
+#line 3407 "seclang-parser.cc"
     break;
 
   case 167: // var: VARIABLE_ARGS_POST "Dictionary element"
-#line 1888 "seclang-parser.yy"
+#line 1889 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3414 "seclang-parser.cc"
+#line 3415 "seclang-parser.cc"
     break;
 
   case 168: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
-#line 1892 "seclang-parser.yy"
+#line 1893 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3422 "seclang-parser.cc"
+#line 3423 "seclang-parser.cc"
     break;
 
   case 169: // var: VARIABLE_ARGS_POST
-#line 1896 "seclang-parser.yy"
+#line 1897 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
       }
-#line 3430 "seclang-parser.cc"
+#line 3431 "seclang-parser.cc"
     break;
 
   case 170: // var: VARIABLE_ARGS_GET "Dictionary element"
-#line 1900 "seclang-parser.yy"
+#line 1901 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3438 "seclang-parser.cc"
+#line 3439 "seclang-parser.cc"
     break;
 
   case 171: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
-#line 1904 "seclang-parser.yy"
+#line 1905 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3446 "seclang-parser.cc"
+#line 3447 "seclang-parser.cc"
     break;
 
   case 172: // var: VARIABLE_ARGS_GET
-#line 1908 "seclang-parser.yy"
+#line 1909 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
       }
-#line 3454 "seclang-parser.cc"
+#line 3455 "seclang-parser.cc"
     break;
 
   case 173: // var: VARIABLE_FILES_SIZES "Dictionary element"
-#line 1912 "seclang-parser.yy"
+#line 1913 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3462 "seclang-parser.cc"
+#line 3463 "seclang-parser.cc"
     break;
 
   case 174: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
-#line 1916 "seclang-parser.yy"
+#line 1917 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3470 "seclang-parser.cc"
+#line 3471 "seclang-parser.cc"
     break;
 
   case 175: // var: VARIABLE_FILES_SIZES
-#line 1920 "seclang-parser.yy"
+#line 1921 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
       }
-#line 3478 "seclang-parser.cc"
+#line 3479 "seclang-parser.cc"
     break;
 
   case 176: // var: VARIABLE_FILES_NAMES "Dictionary element"
-#line 1924 "seclang-parser.yy"
+#line 1925 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3486 "seclang-parser.cc"
+#line 3487 "seclang-parser.cc"
     break;
 
   case 177: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
-#line 1928 "seclang-parser.yy"
+#line 1929 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3494 "seclang-parser.cc"
+#line 3495 "seclang-parser.cc"
     break;
 
   case 178: // var: VARIABLE_FILES_NAMES
-#line 1932 "seclang-parser.yy"
+#line 1933 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
       }
-#line 3502 "seclang-parser.cc"
+#line 3503 "seclang-parser.cc"
     break;
 
   case 179: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
-#line 1936 "seclang-parser.yy"
+#line 1937 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3510 "seclang-parser.cc"
+#line 3511 "seclang-parser.cc"
     break;
 
   case 180: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
-#line 1940 "seclang-parser.yy"
+#line 1941 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3518 "seclang-parser.cc"
+#line 3519 "seclang-parser.cc"
     break;
 
   case 181: // var: VARIABLE_FILES_TMP_CONTENT
-#line 1944 "seclang-parser.yy"
+#line 1945 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
       }
-#line 3526 "seclang-parser.cc"
+#line 3527 "seclang-parser.cc"
     break;
 
   case 182: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
-#line 1948 "seclang-parser.yy"
+#line 1949 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3534 "seclang-parser.cc"
+#line 3535 "seclang-parser.cc"
     break;
 
   case 183: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
-#line 1952 "seclang-parser.yy"
+#line 1953 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3542 "seclang-parser.cc"
+#line 3543 "seclang-parser.cc"
     break;
 
   case 184: // var: VARIABLE_MULTIPART_FILENAME
-#line 1956 "seclang-parser.yy"
+#line 1957 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
       }
-#line 3550 "seclang-parser.cc"
+#line 3551 "seclang-parser.cc"
     break;
 
   case 185: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
-#line 1960 "seclang-parser.yy"
+#line 1961 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3558 "seclang-parser.cc"
+#line 3559 "seclang-parser.cc"
     break;
 
   case 186: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
-#line 1964 "seclang-parser.yy"
+#line 1965 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3566 "seclang-parser.cc"
+#line 3567 "seclang-parser.cc"
     break;
 
   case 187: // var: VARIABLE_MULTIPART_NAME
-#line 1968 "seclang-parser.yy"
+#line 1969 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
       }
-#line 3574 "seclang-parser.cc"
+#line 3575 "seclang-parser.cc"
     break;
 
   case 188: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
-#line 1972 "seclang-parser.yy"
+#line 1973 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3582 "seclang-parser.cc"
+#line 3583 "seclang-parser.cc"
     break;
 
   case 189: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
-#line 1976 "seclang-parser.yy"
+#line 1977 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3590 "seclang-parser.cc"
+#line 3591 "seclang-parser.cc"
     break;
 
   case 190: // var: VARIABLE_MATCHED_VARS_NAMES
-#line 1980 "seclang-parser.yy"
+#line 1981 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
       }
-#line 3598 "seclang-parser.cc"
+#line 3599 "seclang-parser.cc"
     break;
 
   case 191: // var: VARIABLE_MATCHED_VARS "Dictionary element"
-#line 1984 "seclang-parser.yy"
+#line 1985 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3606 "seclang-parser.cc"
+#line 3607 "seclang-parser.cc"
     break;
 
   case 192: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
-#line 1988 "seclang-parser.yy"
+#line 1989 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3614 "seclang-parser.cc"
+#line 3615 "seclang-parser.cc"
     break;
 
   case 193: // var: VARIABLE_MATCHED_VARS
-#line 1992 "seclang-parser.yy"
+#line 1993 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
       }
-#line 3622 "seclang-parser.cc"
+#line 3623 "seclang-parser.cc"
     break;
 
   case 194: // var: VARIABLE_FILES "Dictionary element"
-#line 1996 "seclang-parser.yy"
+#line 1997 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3630 "seclang-parser.cc"
+#line 3631 "seclang-parser.cc"
     break;
 
   case 195: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
-#line 2000 "seclang-parser.yy"
+#line 2001 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3638 "seclang-parser.cc"
+#line 3639 "seclang-parser.cc"
     break;
 
   case 196: // var: VARIABLE_FILES
-#line 2004 "seclang-parser.yy"
+#line 2005 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
       }
-#line 3646 "seclang-parser.cc"
+#line 3647 "seclang-parser.cc"
     break;
 
   case 197: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
-#line 2008 "seclang-parser.yy"
+#line 2009 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3654 "seclang-parser.cc"
+#line 3655 "seclang-parser.cc"
     break;
 
   case 198: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
-#line 2012 "seclang-parser.yy"
+#line 2013 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3662 "seclang-parser.cc"
+#line 3663 "seclang-parser.cc"
     break;
 
   case 199: // var: VARIABLE_REQUEST_COOKIES
-#line 2016 "seclang-parser.yy"
+#line 2017 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
       }
-#line 3670 "seclang-parser.cc"
+#line 3671 "seclang-parser.cc"
     break;
 
   case 200: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
-#line 2020 "seclang-parser.yy"
+#line 2021 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3678 "seclang-parser.cc"
+#line 3679 "seclang-parser.cc"
     break;
 
   case 201: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
-#line 2024 "seclang-parser.yy"
+#line 2025 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3686 "seclang-parser.cc"
+#line 3687 "seclang-parser.cc"
     break;
 
   case 202: // var: VARIABLE_REQUEST_HEADERS
-#line 2028 "seclang-parser.yy"
+#line 2029 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
       }
-#line 3694 "seclang-parser.cc"
+#line 3695 "seclang-parser.cc"
     break;
 
   case 203: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
-#line 2032 "seclang-parser.yy"
+#line 2033 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3702 "seclang-parser.cc"
+#line 3703 "seclang-parser.cc"
     break;
 
   case 204: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
-#line 2036 "seclang-parser.yy"
+#line 2037 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3710 "seclang-parser.cc"
+#line 3711 "seclang-parser.cc"
     break;
 
   case 205: // var: VARIABLE_RESPONSE_HEADERS
-#line 2040 "seclang-parser.yy"
+#line 2041 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
       }
-#line 3718 "seclang-parser.cc"
+#line 3719 "seclang-parser.cc"
     break;
 
   case 206: // var: VARIABLE_GEO "Dictionary element"
-#line 2044 "seclang-parser.yy"
+#line 2045 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3726 "seclang-parser.cc"
+#line 3727 "seclang-parser.cc"
     break;
 
   case 207: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
-#line 2048 "seclang-parser.yy"
+#line 2049 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3734 "seclang-parser.cc"
+#line 3735 "seclang-parser.cc"
     break;
 
   case 208: // var: VARIABLE_GEO
-#line 2052 "seclang-parser.yy"
+#line 2053 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
       }
-#line 3742 "seclang-parser.cc"
+#line 3743 "seclang-parser.cc"
     break;
 
   case 209: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
-#line 2056 "seclang-parser.yy"
+#line 2057 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3750 "seclang-parser.cc"
+#line 3751 "seclang-parser.cc"
     break;
 
   case 210: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
-#line 2060 "seclang-parser.yy"
+#line 2061 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3758 "seclang-parser.cc"
+#line 3759 "seclang-parser.cc"
     break;
 
   case 211: // var: VARIABLE_REQUEST_COOKIES_NAMES
-#line 2064 "seclang-parser.yy"
+#line 2065 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
       }
-#line 3766 "seclang-parser.cc"
+#line 3767 "seclang-parser.cc"
     break;
 
   case 212: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element"
-#line 2068 "seclang-parser.yy"
+#line 2069 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3774 "seclang-parser.cc"
+#line 3775 "seclang-parser.cc"
     break;
 
   case 213: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element, selected by regexp"
-#line 2072 "seclang-parser.yy"
+#line 2073 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3782 "seclang-parser.cc"
+#line 3783 "seclang-parser.cc"
     break;
 
   case 214: // var: VARIABLE_MULTIPART_PART_HEADERS
-#line 2076 "seclang-parser.yy"
+#line 2077 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_NoDictElement());
       }
-#line 3790 "seclang-parser.cc"
+#line 3791 "seclang-parser.cc"
     break;
 
   case 215: // var: VARIABLE_RULE "Dictionary element"
-#line 2080 "seclang-parser.yy"
+#line 2081 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3798 "seclang-parser.cc"
+#line 3799 "seclang-parser.cc"
     break;
 
   case 216: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
-#line 2084 "seclang-parser.yy"
+#line 2085 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3806 "seclang-parser.cc"
+#line 3807 "seclang-parser.cc"
     break;
 
   case 217: // var: VARIABLE_RULE
-#line 2088 "seclang-parser.yy"
+#line 2089 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
       }
-#line 3814 "seclang-parser.cc"
+#line 3815 "seclang-parser.cc"
     break;
 
   case 218: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
-#line 2092 "seclang-parser.yy"
+#line 2093 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3822 "seclang-parser.cc"
+#line 3823 "seclang-parser.cc"
     break;
 
   case 219: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
-#line 2096 "seclang-parser.yy"
+#line 2097 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3830 "seclang-parser.cc"
+#line 3831 "seclang-parser.cc"
     break;
 
   case 220: // var: "RUN_TIME_VAR_ENV"
-#line 2100 "seclang-parser.yy"
+#line 2101 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
       }
-#line 3838 "seclang-parser.cc"
+#line 3839 "seclang-parser.cc"
     break;
 
   case 221: // var: "RUN_TIME_VAR_XML" "Dictionary element"
-#line 2104 "seclang-parser.yy"
+#line 2105 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3846 "seclang-parser.cc"
+#line 3847 "seclang-parser.cc"
     break;
 
   case 222: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
-#line 2108 "seclang-parser.yy"
+#line 2109 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3854 "seclang-parser.cc"
+#line 3855 "seclang-parser.cc"
     break;
 
   case 223: // var: "RUN_TIME_VAR_XML"
-#line 2112 "seclang-parser.yy"
+#line 2113 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
       }
-#line 3862 "seclang-parser.cc"
+#line 3863 "seclang-parser.cc"
     break;
 
   case 224: // var: "FILES_TMPNAMES" "Dictionary element"
-#line 2116 "seclang-parser.yy"
+#line 2117 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3870 "seclang-parser.cc"
+#line 3871 "seclang-parser.cc"
     break;
 
   case 225: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
-#line 2120 "seclang-parser.yy"
+#line 2121 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3878 "seclang-parser.cc"
+#line 3879 "seclang-parser.cc"
     break;
 
   case 226: // var: "FILES_TMPNAMES"
-#line 2124 "seclang-parser.yy"
+#line 2125 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
       }
-#line 3886 "seclang-parser.cc"
+#line 3887 "seclang-parser.cc"
     break;
 
   case 227: // var: "RESOURCE" run_time_string
-#line 2128 "seclang-parser.yy"
+#line 2129 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3894 "seclang-parser.cc"
+#line 3895 "seclang-parser.cc"
     break;
 
   case 228: // var: "RESOURCE" "Dictionary element"
-#line 2132 "seclang-parser.yy"
+#line 2133 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3902 "seclang-parser.cc"
+#line 3903 "seclang-parser.cc"
     break;
 
   case 229: // var: "RESOURCE" "Dictionary element, selected by regexp"
-#line 2136 "seclang-parser.yy"
+#line 2137 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3910 "seclang-parser.cc"
+#line 3911 "seclang-parser.cc"
     break;
 
   case 230: // var: "RESOURCE"
-#line 2140 "seclang-parser.yy"
+#line 2141 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
       }
-#line 3918 "seclang-parser.cc"
+#line 3919 "seclang-parser.cc"
     break;
 
   case 231: // var: "VARIABLE_IP" run_time_string
-#line 2144 "seclang-parser.yy"
+#line 2145 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3926 "seclang-parser.cc"
+#line 3927 "seclang-parser.cc"
     break;
 
   case 232: // var: "VARIABLE_IP" "Dictionary element"
-#line 2148 "seclang-parser.yy"
+#line 2149 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3934 "seclang-parser.cc"
+#line 3935 "seclang-parser.cc"
     break;
 
   case 233: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
-#line 2152 "seclang-parser.yy"
+#line 2153 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3942 "seclang-parser.cc"
+#line 3943 "seclang-parser.cc"
     break;
 
   case 234: // var: "VARIABLE_IP"
-#line 2156 "seclang-parser.yy"
+#line 2157 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
       }
-#line 3950 "seclang-parser.cc"
+#line 3951 "seclang-parser.cc"
     break;
 
   case 235: // var: "VARIABLE_GLOBAL" run_time_string
-#line 2160 "seclang-parser.yy"
+#line 2161 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3958 "seclang-parser.cc"
+#line 3959 "seclang-parser.cc"
     break;
 
   case 236: // var: "VARIABLE_GLOBAL" "Dictionary element"
-#line 2164 "seclang-parser.yy"
+#line 2165 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3966 "seclang-parser.cc"
+#line 3967 "seclang-parser.cc"
     break;
 
   case 237: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
-#line 2168 "seclang-parser.yy"
+#line 2169 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3974 "seclang-parser.cc"
+#line 3975 "seclang-parser.cc"
     break;
 
   case 238: // var: "VARIABLE_GLOBAL"
-#line 2172 "seclang-parser.yy"
+#line 2173 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
       }
-#line 3982 "seclang-parser.cc"
+#line 3983 "seclang-parser.cc"
     break;
 
   case 239: // var: "VARIABLE_USER" run_time_string
-#line 2176 "seclang-parser.yy"
+#line 2177 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3990 "seclang-parser.cc"
+#line 3991 "seclang-parser.cc"
     break;
 
   case 240: // var: "VARIABLE_USER" "Dictionary element"
-#line 2180 "seclang-parser.yy"
+#line 2181 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3998 "seclang-parser.cc"
+#line 3999 "seclang-parser.cc"
     break;
 
   case 241: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
-#line 2184 "seclang-parser.yy"
+#line 2185 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4006 "seclang-parser.cc"
+#line 4007 "seclang-parser.cc"
     break;
 
   case 242: // var: "VARIABLE_USER"
-#line 2188 "seclang-parser.yy"
+#line 2189 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
       }
-#line 4014 "seclang-parser.cc"
+#line 4015 "seclang-parser.cc"
     break;
 
   case 243: // var: "VARIABLE_TX" run_time_string
-#line 2192 "seclang-parser.yy"
+#line 2193 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4022 "seclang-parser.cc"
+#line 4023 "seclang-parser.cc"
     break;
 
   case 244: // var: "VARIABLE_TX" "Dictionary element"
-#line 2196 "seclang-parser.yy"
+#line 2197 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4030 "seclang-parser.cc"
+#line 4031 "seclang-parser.cc"
     break;
 
   case 245: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
-#line 2200 "seclang-parser.yy"
+#line 2201 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4038 "seclang-parser.cc"
+#line 4039 "seclang-parser.cc"
     break;
 
   case 246: // var: "VARIABLE_TX"
-#line 2204 "seclang-parser.yy"
+#line 2205 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
       }
-#line 4046 "seclang-parser.cc"
+#line 4047 "seclang-parser.cc"
     break;
 
   case 247: // var: "VARIABLE_SESSION" run_time_string
-#line 2208 "seclang-parser.yy"
+#line 2209 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4054 "seclang-parser.cc"
+#line 4055 "seclang-parser.cc"
     break;
 
   case 248: // var: "VARIABLE_SESSION" "Dictionary element"
-#line 2212 "seclang-parser.yy"
+#line 2213 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4062 "seclang-parser.cc"
+#line 4063 "seclang-parser.cc"
     break;
 
   case 249: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
-#line 2216 "seclang-parser.yy"
+#line 2217 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4070 "seclang-parser.cc"
+#line 4071 "seclang-parser.cc"
     break;
 
   case 250: // var: "VARIABLE_SESSION"
-#line 2220 "seclang-parser.yy"
+#line 2221 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
       }
-#line 4078 "seclang-parser.cc"
+#line 4079 "seclang-parser.cc"
     break;
 
   case 251: // var: "Variable ARGS_NAMES" "Dictionary element"
-#line 2224 "seclang-parser.yy"
+#line 2225 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4086 "seclang-parser.cc"
+#line 4087 "seclang-parser.cc"
     break;
 
   case 252: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
-#line 2228 "seclang-parser.yy"
+#line 2229 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4094 "seclang-parser.cc"
+#line 4095 "seclang-parser.cc"
     break;
 
   case 253: // var: "Variable ARGS_NAMES"
-#line 2232 "seclang-parser.yy"
+#line 2233 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
       }
-#line 4102 "seclang-parser.cc"
+#line 4103 "seclang-parser.cc"
     break;
 
   case 254: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
-#line 2236 "seclang-parser.yy"
+#line 2237 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4110 "seclang-parser.cc"
+#line 4111 "seclang-parser.cc"
     break;
 
   case 255: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
-#line 2240 "seclang-parser.yy"
+#line 2241 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4118 "seclang-parser.cc"
+#line 4119 "seclang-parser.cc"
     break;
 
   case 256: // var: VARIABLE_ARGS_GET_NAMES
-#line 2244 "seclang-parser.yy"
+#line 2245 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
       }
-#line 4126 "seclang-parser.cc"
+#line 4127 "seclang-parser.cc"
     break;
 
   case 257: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
-#line 2249 "seclang-parser.yy"
+#line 2250 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4134 "seclang-parser.cc"
+#line 4135 "seclang-parser.cc"
     break;
 
   case 258: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
-#line 2253 "seclang-parser.yy"
+#line 2254 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4142 "seclang-parser.cc"
+#line 4143 "seclang-parser.cc"
     break;
 
   case 259: // var: VARIABLE_ARGS_POST_NAMES
-#line 2257 "seclang-parser.yy"
+#line 2258 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
       }
-#line 4150 "seclang-parser.cc"
+#line 4151 "seclang-parser.cc"
     break;
 
   case 260: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
-#line 2262 "seclang-parser.yy"
+#line 2263 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4158 "seclang-parser.cc"
+#line 4159 "seclang-parser.cc"
     break;
 
   case 261: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2266 "seclang-parser.yy"
+#line 2267 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4166 "seclang-parser.cc"
+#line 4167 "seclang-parser.cc"
     break;
 
   case 262: // var: VARIABLE_REQUEST_HEADERS_NAMES
-#line 2270 "seclang-parser.yy"
+#line 2271 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
       }
-#line 4174 "seclang-parser.cc"
+#line 4175 "seclang-parser.cc"
     break;
 
   case 263: // var: VARIABLE_RESPONSE_CONTENT_TYPE
-#line 2275 "seclang-parser.yy"
+#line 2276 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
       }
-#line 4182 "seclang-parser.cc"
+#line 4183 "seclang-parser.cc"
     break;
 
   case 264: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
-#line 2280 "seclang-parser.yy"
+#line 2281 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4190 "seclang-parser.cc"
+#line 4191 "seclang-parser.cc"
     break;
 
   case 265: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2284 "seclang-parser.yy"
+#line 2285 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4198 "seclang-parser.cc"
+#line 4199 "seclang-parser.cc"
     break;
 
   case 266: // var: VARIABLE_RESPONSE_HEADERS_NAMES
-#line 2288 "seclang-parser.yy"
+#line 2289 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
       }
-#line 4206 "seclang-parser.cc"
+#line 4207 "seclang-parser.cc"
     break;
 
   case 267: // var: VARIABLE_ARGS_COMBINED_SIZE
-#line 2292 "seclang-parser.yy"
+#line 2293 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
       }
-#line 4214 "seclang-parser.cc"
+#line 4215 "seclang-parser.cc"
     break;
 
   case 268: // var: "AUTH_TYPE"
-#line 2296 "seclang-parser.yy"
+#line 2297 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
       }
-#line 4222 "seclang-parser.cc"
+#line 4223 "seclang-parser.cc"
     break;
 
   case 269: // var: "FILES_COMBINED_SIZE"
-#line 2300 "seclang-parser.yy"
+#line 2301 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
       }
-#line 4230 "seclang-parser.cc"
+#line 4231 "seclang-parser.cc"
     break;
 
   case 270: // var: "FULL_REQUEST"
-#line 2304 "seclang-parser.yy"
+#line 2305 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
       }
-#line 4238 "seclang-parser.cc"
+#line 4239 "seclang-parser.cc"
     break;
 
   case 271: // var: "FULL_REQUEST_LENGTH"
-#line 2308 "seclang-parser.yy"
+#line 2309 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
       }
-#line 4246 "seclang-parser.cc"
+#line 4247 "seclang-parser.cc"
     break;
 
   case 272: // var: "INBOUND_DATA_ERROR"
-#line 2312 "seclang-parser.yy"
+#line 2313 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
       }
-#line 4254 "seclang-parser.cc"
+#line 4255 "seclang-parser.cc"
     break;
 
   case 273: // var: "MATCHED_VAR"
-#line 2316 "seclang-parser.yy"
+#line 2317 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
       }
-#line 4262 "seclang-parser.cc"
+#line 4263 "seclang-parser.cc"
     break;
 
   case 274: // var: "MATCHED_VAR_NAME"
-#line 2320 "seclang-parser.yy"
+#line 2321 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
       }
-#line 4270 "seclang-parser.cc"
+#line 4271 "seclang-parser.cc"
     break;
 
   case 275: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
-#line 2324 "seclang-parser.yy"
+#line 2325 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
       }
-#line 4278 "seclang-parser.cc"
+#line 4279 "seclang-parser.cc"
     break;
 
   case 276: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
-#line 2328 "seclang-parser.yy"
+#line 2329 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
       }
-#line 4286 "seclang-parser.cc"
+#line 4287 "seclang-parser.cc"
     break;
 
   case 277: // var: "MULTIPART_CRLF_LF_LINES"
-#line 2332 "seclang-parser.yy"
+#line 2333 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
       }
-#line 4294 "seclang-parser.cc"
+#line 4295 "seclang-parser.cc"
     break;
 
   case 278: // var: "MULTIPART_DATA_AFTER"
-#line 2336 "seclang-parser.yy"
+#line 2337 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
       }
-#line 4302 "seclang-parser.cc"
+#line 4303 "seclang-parser.cc"
     break;
 
   case 279: // var: VARIABLE_MULTIPART_DATA_BEFORE
-#line 2340 "seclang-parser.yy"
+#line 2341 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
       }
-#line 4310 "seclang-parser.cc"
+#line 4311 "seclang-parser.cc"
     break;
 
   case 280: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
-#line 2344 "seclang-parser.yy"
+#line 2345 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
       }
-#line 4318 "seclang-parser.cc"
+#line 4319 "seclang-parser.cc"
     break;
 
   case 281: // var: "MULTIPART_HEADER_FOLDING"
-#line 2348 "seclang-parser.yy"
+#line 2349 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
       }
-#line 4326 "seclang-parser.cc"
+#line 4327 "seclang-parser.cc"
     break;
 
   case 282: // var: "MULTIPART_INVALID_HEADER_FOLDING"
-#line 2352 "seclang-parser.yy"
+#line 2353 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
       }
-#line 4334 "seclang-parser.cc"
+#line 4335 "seclang-parser.cc"
     break;
 
   case 283: // var: VARIABLE_MULTIPART_INVALID_PART
-#line 2356 "seclang-parser.yy"
+#line 2357 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
       }
-#line 4342 "seclang-parser.cc"
+#line 4343 "seclang-parser.cc"
     break;
 
   case 284: // var: "MULTIPART_INVALID_QUOTING"
-#line 2360 "seclang-parser.yy"
+#line 2361 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
       }
-#line 4350 "seclang-parser.cc"
+#line 4351 "seclang-parser.cc"
     break;
 
   case 285: // var: VARIABLE_MULTIPART_LF_LINE
-#line 2364 "seclang-parser.yy"
+#line 2365 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
       }
-#line 4358 "seclang-parser.cc"
+#line 4359 "seclang-parser.cc"
     break;
 
   case 286: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
-#line 2368 "seclang-parser.yy"
+#line 2369 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4366 "seclang-parser.cc"
+#line 4367 "seclang-parser.cc"
     break;
 
   case 287: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
-#line 2372 "seclang-parser.yy"
+#line 2373 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4374 "seclang-parser.cc"
+#line 4375 "seclang-parser.cc"
     break;
 
   case 288: // var: "MULTIPART_STRICT_ERROR"
-#line 2376 "seclang-parser.yy"
+#line 2377 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
       }
-#line 4382 "seclang-parser.cc"
+#line 4383 "seclang-parser.cc"
     break;
 
   case 289: // var: "MULTIPART_UNMATCHED_BOUNDARY"
-#line 2380 "seclang-parser.yy"
+#line 2381 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
       }
-#line 4390 "seclang-parser.cc"
+#line 4391 "seclang-parser.cc"
     break;
 
   case 290: // var: "OUTBOUND_DATA_ERROR"
-#line 2384 "seclang-parser.yy"
+#line 2385 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
       }
-#line 4398 "seclang-parser.cc"
+#line 4399 "seclang-parser.cc"
     break;
 
   case 291: // var: "PATH_INFO"
-#line 2388 "seclang-parser.yy"
+#line 2389 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
       }
-#line 4406 "seclang-parser.cc"
+#line 4407 "seclang-parser.cc"
     break;
 
   case 292: // var: "QUERY_STRING"
-#line 2392 "seclang-parser.yy"
+#line 2393 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
       }
-#line 4414 "seclang-parser.cc"
+#line 4415 "seclang-parser.cc"
     break;
 
   case 293: // var: "REMOTE_ADDR"
-#line 2396 "seclang-parser.yy"
+#line 2397 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
       }
-#line 4422 "seclang-parser.cc"
+#line 4423 "seclang-parser.cc"
     break;
 
   case 294: // var: "REMOTE_HOST"
-#line 2400 "seclang-parser.yy"
+#line 2401 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
       }
-#line 4430 "seclang-parser.cc"
+#line 4431 "seclang-parser.cc"
     break;
 
   case 295: // var: "REMOTE_PORT"
-#line 2404 "seclang-parser.yy"
+#line 2405 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
       }
-#line 4438 "seclang-parser.cc"
+#line 4439 "seclang-parser.cc"
     break;
 
   case 296: // var: "REQBODY_ERROR"
-#line 2408 "seclang-parser.yy"
+#line 2409 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
       }
-#line 4446 "seclang-parser.cc"
+#line 4447 "seclang-parser.cc"
     break;
 
   case 297: // var: "REQBODY_ERROR_MSG"
-#line 2412 "seclang-parser.yy"
+#line 2413 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
       }
-#line 4454 "seclang-parser.cc"
+#line 4455 "seclang-parser.cc"
     break;
 
   case 298: // var: "REQBODY_PROCESSOR"
-#line 2416 "seclang-parser.yy"
+#line 2417 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
       }
-#line 4462 "seclang-parser.cc"
+#line 4463 "seclang-parser.cc"
     break;
 
   case 299: // var: "REQBODY_PROCESSOR_ERROR"
-#line 2420 "seclang-parser.yy"
+#line 2421 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
       }
-#line 4470 "seclang-parser.cc"
+#line 4471 "seclang-parser.cc"
     break;
 
   case 300: // var: "REQBODY_PROCESSOR_ERROR_MSG"
-#line 2424 "seclang-parser.yy"
+#line 2425 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
       }
-#line 4478 "seclang-parser.cc"
+#line 4479 "seclang-parser.cc"
     break;
 
   case 301: // var: "REQUEST_BASENAME"
-#line 2428 "seclang-parser.yy"
+#line 2429 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
       }
-#line 4486 "seclang-parser.cc"
+#line 4487 "seclang-parser.cc"
     break;
 
   case 302: // var: "REQUEST_BODY"
-#line 2432 "seclang-parser.yy"
+#line 2433 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
       }
-#line 4494 "seclang-parser.cc"
+#line 4495 "seclang-parser.cc"
     break;
 
   case 303: // var: "REQUEST_BODY_LENGTH"
-#line 2436 "seclang-parser.yy"
+#line 2437 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
       }
-#line 4502 "seclang-parser.cc"
+#line 4503 "seclang-parser.cc"
     break;
 
   case 304: // var: "REQUEST_FILENAME"
-#line 2440 "seclang-parser.yy"
+#line 2441 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
       }
-#line 4510 "seclang-parser.cc"
+#line 4511 "seclang-parser.cc"
     break;
 
   case 305: // var: "REQUEST_LINE"
-#line 2444 "seclang-parser.yy"
+#line 2445 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
       }
-#line 4518 "seclang-parser.cc"
+#line 4519 "seclang-parser.cc"
     break;
 
   case 306: // var: "REQUEST_METHOD"
-#line 2448 "seclang-parser.yy"
+#line 2449 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
       }
-#line 4526 "seclang-parser.cc"
+#line 4527 "seclang-parser.cc"
     break;
 
   case 307: // var: "REQUEST_PROTOCOL"
-#line 2452 "seclang-parser.yy"
+#line 2453 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
       }
-#line 4534 "seclang-parser.cc"
+#line 4535 "seclang-parser.cc"
     break;
 
   case 308: // var: "REQUEST_URI"
-#line 2456 "seclang-parser.yy"
+#line 2457 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
       }
-#line 4542 "seclang-parser.cc"
+#line 4543 "seclang-parser.cc"
     break;
 
   case 309: // var: "REQUEST_URI_RAW"
-#line 2460 "seclang-parser.yy"
+#line 2461 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
       }
-#line 4550 "seclang-parser.cc"
+#line 4551 "seclang-parser.cc"
     break;
 
   case 310: // var: "RESPONSE_BODY"
-#line 2464 "seclang-parser.yy"
+#line 2465 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
       }
-#line 4558 "seclang-parser.cc"
+#line 4559 "seclang-parser.cc"
     break;
 
   case 311: // var: "RESPONSE_CONTENT_LENGTH"
-#line 2468 "seclang-parser.yy"
+#line 2469 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
       }
-#line 4566 "seclang-parser.cc"
+#line 4567 "seclang-parser.cc"
     break;
 
   case 312: // var: "RESPONSE_PROTOCOL"
-#line 2472 "seclang-parser.yy"
+#line 2473 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
       }
-#line 4574 "seclang-parser.cc"
+#line 4575 "seclang-parser.cc"
     break;
 
   case 313: // var: "RESPONSE_STATUS"
-#line 2476 "seclang-parser.yy"
+#line 2477 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
       }
-#line 4582 "seclang-parser.cc"
+#line 4583 "seclang-parser.cc"
     break;
 
   case 314: // var: "SERVER_ADDR"
-#line 2480 "seclang-parser.yy"
+#line 2481 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
       }
-#line 4590 "seclang-parser.cc"
+#line 4591 "seclang-parser.cc"
     break;
 
   case 315: // var: "SERVER_NAME"
-#line 2484 "seclang-parser.yy"
+#line 2485 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
       }
-#line 4598 "seclang-parser.cc"
+#line 4599 "seclang-parser.cc"
     break;
 
   case 316: // var: "SERVER_PORT"
-#line 2488 "seclang-parser.yy"
+#line 2489 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
       }
-#line 4606 "seclang-parser.cc"
+#line 4607 "seclang-parser.cc"
     break;
 
   case 317: // var: "SESSIONID"
-#line 2492 "seclang-parser.yy"
+#line 2493 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
       }
-#line 4614 "seclang-parser.cc"
+#line 4615 "seclang-parser.cc"
     break;
 
   case 318: // var: "UNIQUE_ID"
-#line 2496 "seclang-parser.yy"
+#line 2497 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
       }
-#line 4622 "seclang-parser.cc"
+#line 4623 "seclang-parser.cc"
     break;
 
   case 319: // var: "URLENCODED_ERROR"
-#line 2500 "seclang-parser.yy"
+#line 2501 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
       }
-#line 4630 "seclang-parser.cc"
+#line 4631 "seclang-parser.cc"
     break;
 
   case 320: // var: "USERID"
-#line 2504 "seclang-parser.yy"
+#line 2505 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
       }
-#line 4638 "seclang-parser.cc"
+#line 4639 "seclang-parser.cc"
     break;
 
   case 321: // var: "VARIABLE_STATUS"
-#line 2508 "seclang-parser.yy"
+#line 2509 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4646 "seclang-parser.cc"
+#line 4647 "seclang-parser.cc"
     break;
 
   case 322: // var: "VARIABLE_STATUS_LINE"
-#line 2512 "seclang-parser.yy"
+#line 2513 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4654 "seclang-parser.cc"
+#line 4655 "seclang-parser.cc"
     break;
 
   case 323: // var: "WEBAPPID"
-#line 2516 "seclang-parser.yy"
+#line 2517 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
       }
-#line 4662 "seclang-parser.cc"
+#line 4663 "seclang-parser.cc"
     break;
 
   case 324: // var: "RUN_TIME_VAR_DUR"
-#line 2520 "seclang-parser.yy"
+#line 2521 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4673 "seclang-parser.cc"
+#line 4674 "seclang-parser.cc"
     break;
 
   case 325: // var: "RUN_TIME_VAR_BLD"
-#line 2528 "seclang-parser.yy"
+#line 2529 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4684 "seclang-parser.cc"
+#line 4685 "seclang-parser.cc"
     break;
 
   case 326: // var: "RUN_TIME_VAR_HSV"
-#line 2535 "seclang-parser.yy"
+#line 2536 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4695 "seclang-parser.cc"
+#line 4696 "seclang-parser.cc"
     break;
 
   case 327: // var: "RUN_TIME_VAR_REMOTE_USER"
-#line 2542 "seclang-parser.yy"
+#line 2543 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4706 "seclang-parser.cc"
+#line 4707 "seclang-parser.cc"
     break;
 
   case 328: // var: "RUN_TIME_VAR_TIME"
-#line 2549 "seclang-parser.yy"
+#line 2550 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4717 "seclang-parser.cc"
+#line 4718 "seclang-parser.cc"
     break;
 
   case 329: // var: "RUN_TIME_VAR_TIME_DAY"
-#line 2556 "seclang-parser.yy"
+#line 2557 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4728 "seclang-parser.cc"
+#line 4729 "seclang-parser.cc"
     break;
 
   case 330: // var: "RUN_TIME_VAR_TIME_EPOCH"
-#line 2563 "seclang-parser.yy"
+#line 2564 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4739 "seclang-parser.cc"
+#line 4740 "seclang-parser.cc"
     break;
 
   case 331: // var: "RUN_TIME_VAR_TIME_HOUR"
-#line 2570 "seclang-parser.yy"
+#line 2571 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4750 "seclang-parser.cc"
+#line 4751 "seclang-parser.cc"
     break;
 
   case 332: // var: "RUN_TIME_VAR_TIME_MIN"
-#line 2577 "seclang-parser.yy"
+#line 2578 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4761 "seclang-parser.cc"
+#line 4762 "seclang-parser.cc"
     break;
 
   case 333: // var: "RUN_TIME_VAR_TIME_MON"
-#line 2584 "seclang-parser.yy"
+#line 2585 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4772 "seclang-parser.cc"
+#line 4773 "seclang-parser.cc"
     break;
 
   case 334: // var: "RUN_TIME_VAR_TIME_SEC"
-#line 2591 "seclang-parser.yy"
+#line 2592 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4783 "seclang-parser.cc"
+#line 4784 "seclang-parser.cc"
     break;
 
   case 335: // var: "RUN_TIME_VAR_TIME_WDAY"
-#line 2598 "seclang-parser.yy"
+#line 2599 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4794 "seclang-parser.cc"
+#line 4795 "seclang-parser.cc"
     break;
 
   case 336: // var: "RUN_TIME_VAR_TIME_YEAR"
-#line 2605 "seclang-parser.yy"
+#line 2606 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4805 "seclang-parser.cc"
+#line 4806 "seclang-parser.cc"
     break;
 
   case 337: // act: "Accuracy"
-#line 2615 "seclang-parser.yy"
+#line 2616 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
       }
-#line 4813 "seclang-parser.cc"
+#line 4814 "seclang-parser.cc"
     break;
 
   case 338: // act: "Allow"
-#line 2619 "seclang-parser.yy"
+#line 2620 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
       }
-#line 4821 "seclang-parser.cc"
+#line 4822 "seclang-parser.cc"
     break;
 
   case 339: // act: "Append"
-#line 2623 "seclang-parser.yy"
+#line 2624 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 4829 "seclang-parser.cc"
+#line 4830 "seclang-parser.cc"
     break;
 
   case 340: // act: "AuditLog"
-#line 2627 "seclang-parser.yy"
+#line 2628 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 4837 "seclang-parser.cc"
+#line 4838 "seclang-parser.cc"
     break;
 
   case 341: // act: "Block"
-#line 2631 "seclang-parser.yy"
+#line 2632 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
       }
-#line 4845 "seclang-parser.cc"
+#line 4846 "seclang-parser.cc"
     break;
 
   case 342: // act: "Capture"
-#line 2635 "seclang-parser.yy"
+#line 2636 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
       }
-#line 4853 "seclang-parser.cc"
+#line 4854 "seclang-parser.cc"
     break;
 
   case 343: // act: "Chain"
-#line 2639 "seclang-parser.yy"
+#line 2640 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
       }
-#line 4861 "seclang-parser.cc"
+#line 4862 "seclang-parser.cc"
     break;
 
   case 344: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_ON"
-#line 2643 "seclang-parser.yy"
+#line 2644 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=on"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4870 "seclang-parser.cc"
+#line 4871 "seclang-parser.cc"
     break;
 
   case 345: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
-#line 2648 "seclang-parser.yy"
+#line 2649 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
       }
-#line 4878 "seclang-parser.cc"
+#line 4879 "seclang-parser.cc"
     break;
 
   case 346: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 2652 "seclang-parser.yy"
+#line 2653 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=relevantonly"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4887 "seclang-parser.cc"
+#line 4888 "seclang-parser.cc"
     break;
 
   case 347: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
-#line 2657 "seclang-parser.yy"
+#line 2658 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
       }
-#line 4895 "seclang-parser.cc"
+#line 4896 "seclang-parser.cc"
     break;
 
   case 348: // act: "ACTION_CTL_BDY_JSON"
-#line 2661 "seclang-parser.yy"
+#line 2662 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
       }
-#line 4903 "seclang-parser.cc"
+#line 4904 "seclang-parser.cc"
     break;
 
   case 349: // act: "ACTION_CTL_BDY_XML"
-#line 2665 "seclang-parser.yy"
+#line 2666 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
       }
-#line 4911 "seclang-parser.cc"
+#line 4912 "seclang-parser.cc"
     break;
 
   case 350: // act: "ACTION_CTL_BDY_URLENCODED"
-#line 2669 "seclang-parser.yy"
+#line 2670 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
       }
-#line 4919 "seclang-parser.cc"
+#line 4920 "seclang-parser.cc"
     break;
 
   case 351: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
-#line 2673 "seclang-parser.yy"
+#line 2674 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4928 "seclang-parser.cc"
+#line 4929 "seclang-parser.cc"
     break;
 
   case 352: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
-#line 2678 "seclang-parser.yy"
+#line 2679 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4937 "seclang-parser.cc"
+#line 4938 "seclang-parser.cc"
     break;
 
   case 353: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
-#line 2683 "seclang-parser.yy"
+#line 2684 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
       }
-#line 4945 "seclang-parser.cc"
+#line 4946 "seclang-parser.cc"
     break;
 
   case 354: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
-#line 2687 "seclang-parser.yy"
+#line 2688 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
       }
-#line 4953 "seclang-parser.cc"
+#line 4954 "seclang-parser.cc"
     break;
 
   case 355: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
-#line 2691 "seclang-parser.yy"
+#line 2692 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 4961 "seclang-parser.cc"
+#line 4962 "seclang-parser.cc"
     break;
 
   case 356: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
-#line 2695 "seclang-parser.yy"
+#line 2696 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 4969 "seclang-parser.cc"
+#line 4970 "seclang-parser.cc"
     break;
 
   case 357: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
-#line 2699 "seclang-parser.yy"
+#line 2700 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 4977 "seclang-parser.cc"
+#line 4978 "seclang-parser.cc"
     break;
 
   case 358: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
-#line 2703 "seclang-parser.yy"
+#line 2704 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
       }
-#line 4985 "seclang-parser.cc"
+#line 4986 "seclang-parser.cc"
     break;
 
   case 359: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
-#line 2707 "seclang-parser.yy"
+#line 2708 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 4993 "seclang-parser.cc"
+#line 4994 "seclang-parser.cc"
     break;
 
   case 360: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
-#line 2711 "seclang-parser.yy"
+#line 2712 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
       }
-#line 5001 "seclang-parser.cc"
+#line 5002 "seclang-parser.cc"
     break;
 
   case 361: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
-#line 2715 "seclang-parser.yy"
+#line 2716 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5009 "seclang-parser.cc"
+#line 5010 "seclang-parser.cc"
     break;
 
   case 362: // act: "Deny"
-#line 2719 "seclang-parser.yy"
+#line 2720 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
       }
-#line 5017 "seclang-parser.cc"
+#line 5018 "seclang-parser.cc"
     break;
 
   case 363: // act: "DeprecateVar"
-#line 2723 "seclang-parser.yy"
+#line 2724 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 5025 "seclang-parser.cc"
+#line 5026 "seclang-parser.cc"
     break;
 
   case 364: // act: "Drop"
-#line 2727 "seclang-parser.yy"
+#line 2728 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
       }
-#line 5033 "seclang-parser.cc"
+#line 5034 "seclang-parser.cc"
     break;
 
   case 365: // act: "Exec"
-#line 2731 "seclang-parser.yy"
+#line 2732 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
       }
-#line 5041 "seclang-parser.cc"
+#line 5042 "seclang-parser.cc"
     break;
 
   case 366: // act: "ExpireVar"
-#line 2735 "seclang-parser.yy"
+#line 2736 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("ExpireVar", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[0].value.as < std::string > ()));
       }
-#line 5050 "seclang-parser.cc"
+#line 5051 "seclang-parser.cc"
     break;
 
   case 367: // act: "Id"
-#line 2740 "seclang-parser.yy"
+#line 2741 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
       }
-#line 5058 "seclang-parser.cc"
+#line 5059 "seclang-parser.cc"
     break;
 
   case 368: // act: "InitCol" run_time_string
-#line 2744 "seclang-parser.yy"
+#line 2745 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5066 "seclang-parser.cc"
+#line 5067 "seclang-parser.cc"
     break;
 
   case 369: // act: "LogData" run_time_string
-#line 2748 "seclang-parser.yy"
+#line 2749 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5074 "seclang-parser.cc"
+#line 5075 "seclang-parser.cc"
     break;
 
   case 370: // act: "Log"
-#line 2752 "seclang-parser.yy"
+#line 2753 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
       }
-#line 5082 "seclang-parser.cc"
+#line 5083 "seclang-parser.cc"
     break;
 
   case 371: // act: "Maturity"
-#line 2756 "seclang-parser.yy"
+#line 2757 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
       }
-#line 5090 "seclang-parser.cc"
+#line 5091 "seclang-parser.cc"
     break;
 
   case 372: // act: "Msg" run_time_string
-#line 2760 "seclang-parser.yy"
+#line 2761 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5098 "seclang-parser.cc"
+#line 5099 "seclang-parser.cc"
     break;
 
   case 373: // act: "MultiMatch"
-#line 2764 "seclang-parser.yy"
+#line 2765 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
       }
-#line 5106 "seclang-parser.cc"
+#line 5107 "seclang-parser.cc"
     break;
 
   case 374: // act: "NoAuditLog"
-#line 2768 "seclang-parser.yy"
+#line 2769 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5114 "seclang-parser.cc"
+#line 5115 "seclang-parser.cc"
     break;
 
   case 375: // act: "NoLog"
-#line 2772 "seclang-parser.yy"
+#line 2773 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5122 "seclang-parser.cc"
+#line 5123 "seclang-parser.cc"
     break;
 
   case 376: // act: "Pass"
-#line 2776 "seclang-parser.yy"
+#line 2777 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
       }
-#line 5130 "seclang-parser.cc"
+#line 5131 "seclang-parser.cc"
     break;
 
   case 377: // act: "Pause"
-#line 2780 "seclang-parser.yy"
+#line 2781 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 5138 "seclang-parser.cc"
+#line 5139 "seclang-parser.cc"
     break;
 
   case 378: // act: "Phase"
-#line 2784 "seclang-parser.yy"
+#line 2785 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
       }
-#line 5146 "seclang-parser.cc"
+#line 5147 "seclang-parser.cc"
     break;
 
   case 379: // act: "Prepend"
-#line 2788 "seclang-parser.yy"
+#line 2789 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 5154 "seclang-parser.cc"
+#line 5155 "seclang-parser.cc"
     break;
 
   case 380: // act: "Proxy"
-#line 2792 "seclang-parser.yy"
+#line 2793 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 5162 "seclang-parser.cc"
+#line 5163 "seclang-parser.cc"
     break;
 
   case 381: // act: "Redirect" run_time_string
-#line 2796 "seclang-parser.yy"
+#line 2797 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5170 "seclang-parser.cc"
+#line 5171 "seclang-parser.cc"
     break;
 
   case 382: // act: "Rev"
-#line 2800 "seclang-parser.yy"
+#line 2801 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
       }
-#line 5178 "seclang-parser.cc"
+#line 5179 "seclang-parser.cc"
     break;
 
   case 383: // act: "SanitiseArg"
-#line 2804 "seclang-parser.yy"
+#line 2805 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
       }
-#line 5186 "seclang-parser.cc"
+#line 5187 "seclang-parser.cc"
     break;
 
   case 384: // act: "SanitiseMatched"
-#line 2808 "seclang-parser.yy"
+#line 2809 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
       }
-#line 5194 "seclang-parser.cc"
+#line 5195 "seclang-parser.cc"
     break;
 
   case 385: // act: "SanitiseMatchedBytes"
-#line 2812 "seclang-parser.yy"
+#line 2813 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
       }
-#line 5202 "seclang-parser.cc"
+#line 5203 "seclang-parser.cc"
     break;
 
   case 386: // act: "SanitiseRequestHeader"
-#line 2816 "seclang-parser.yy"
+#line 2817 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
       }
-#line 5210 "seclang-parser.cc"
+#line 5211 "seclang-parser.cc"
     break;
 
   case 387: // act: "SanitiseResponseHeader"
-#line 2820 "seclang-parser.yy"
+#line 2821 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
       }
-#line 5218 "seclang-parser.cc"
+#line 5219 "seclang-parser.cc"
     break;
 
   case 388: // act: "SetEnv" run_time_string
-#line 2824 "seclang-parser.yy"
+#line 2825 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5226 "seclang-parser.cc"
+#line 5227 "seclang-parser.cc"
     break;
 
   case 389: // act: "SetRsc" run_time_string
-#line 2828 "seclang-parser.yy"
+#line 2829 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5234 "seclang-parser.cc"
+#line 5235 "seclang-parser.cc"
     break;
 
   case 390: // act: "SetSid" run_time_string
-#line 2832 "seclang-parser.yy"
+#line 2833 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5242 "seclang-parser.cc"
+#line 5243 "seclang-parser.cc"
     break;
 
   case 391: // act: "SetUID" run_time_string
-#line 2836 "seclang-parser.yy"
+#line 2837 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5250 "seclang-parser.cc"
+#line 5251 "seclang-parser.cc"
     break;
 
   case 392: // act: "SetVar" setvar_action
-#line 2840 "seclang-parser.yy"
+#line 2841 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
       }
-#line 5258 "seclang-parser.cc"
+#line 5259 "seclang-parser.cc"
     break;
 
   case 393: // act: "Severity"
-#line 2844 "seclang-parser.yy"
+#line 2845 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
       }
-#line 5266 "seclang-parser.cc"
+#line 5267 "seclang-parser.cc"
     break;
 
   case 394: // act: "Skip"
-#line 2848 "seclang-parser.yy"
+#line 2849 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
       }
-#line 5274 "seclang-parser.cc"
+#line 5275 "seclang-parser.cc"
     break;
 
   case 395: // act: "SkipAfter"
-#line 2852 "seclang-parser.yy"
+#line 2853 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
       }
-#line 5282 "seclang-parser.cc"
+#line 5283 "seclang-parser.cc"
     break;
 
   case 396: // act: "Status"
-#line 2856 "seclang-parser.yy"
+#line 2857 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
       }
-#line 5290 "seclang-parser.cc"
+#line 5291 "seclang-parser.cc"
     break;
 
   case 397: // act: "Tag" run_time_string
-#line 2860 "seclang-parser.yy"
+#line 2861 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5298 "seclang-parser.cc"
+#line 5299 "seclang-parser.cc"
     break;
 
   case 398: // act: "Ver"
-#line 2864 "seclang-parser.yy"
+#line 2865 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
       }
-#line 5306 "seclang-parser.cc"
+#line 5307 "seclang-parser.cc"
     break;
 
   case 399: // act: "xmlns"
-#line 2868 "seclang-parser.yy"
+#line 2869 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
       }
-#line 5314 "seclang-parser.cc"
+#line 5315 "seclang-parser.cc"
     break;
 
   case 400: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
-#line 2872 "seclang-parser.yy"
+#line 2873 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5322 "seclang-parser.cc"
+#line 5323 "seclang-parser.cc"
     break;
 
   case 401: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
-#line 2876 "seclang-parser.yy"
+#line 2877 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5330 "seclang-parser.cc"
+#line 5331 "seclang-parser.cc"
     break;
 
   case 402: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
-#line 2880 "seclang-parser.yy"
+#line 2881 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5338 "seclang-parser.cc"
+#line 5339 "seclang-parser.cc"
     break;
 
   case 403: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
-#line 2884 "seclang-parser.yy"
+#line 2885 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5346 "seclang-parser.cc"
+#line 5347 "seclang-parser.cc"
     break;
 
   case 404: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
-#line 2888 "seclang-parser.yy"
+#line 2889 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
       }
-#line 5354 "seclang-parser.cc"
+#line 5355 "seclang-parser.cc"
     break;
 
   case 405: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
-#line 2892 "seclang-parser.yy"
+#line 2893 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
       }
-#line 5362 "seclang-parser.cc"
+#line 5363 "seclang-parser.cc"
     break;
 
   case 406: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
-#line 2896 "seclang-parser.yy"
+#line 2897 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
       }
-#line 5370 "seclang-parser.cc"
+#line 5371 "seclang-parser.cc"
     break;
 
   case 407: // act: "ACTION_TRANSFORMATION_CMD_LINE"
-#line 2900 "seclang-parser.yy"
+#line 2901 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
       }
-#line 5378 "seclang-parser.cc"
+#line 5379 "seclang-parser.cc"
     break;
 
   case 408: // act: "ACTION_TRANSFORMATION_SHA1"
-#line 2904 "seclang-parser.yy"
+#line 2905 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
       }
-#line 5386 "seclang-parser.cc"
+#line 5387 "seclang-parser.cc"
     break;
 
   case 409: // act: "ACTION_TRANSFORMATION_MD5"
-#line 2908 "seclang-parser.yy"
+#line 2909 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
       }
-#line 5394 "seclang-parser.cc"
+#line 5395 "seclang-parser.cc"
     break;
 
   case 410: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
-#line 2912 "seclang-parser.yy"
+#line 2913 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5402 "seclang-parser.cc"
+#line 5403 "seclang-parser.cc"
     break;
 
   case 411: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
-#line 2916 "seclang-parser.yy"
+#line 2917 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5410 "seclang-parser.cc"
+#line 5411 "seclang-parser.cc"
     break;
 
   case 412: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
-#line 2920 "seclang-parser.yy"
+#line 2921 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5418 "seclang-parser.cc"
+#line 5419 "seclang-parser.cc"
     break;
 
   case 413: // act: "ACTION_TRANSFORMATION_LOWERCASE"
-#line 2924 "seclang-parser.yy"
+#line 2925 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5426 "seclang-parser.cc"
+#line 5427 "seclang-parser.cc"
     break;
 
   case 414: // act: "ACTION_TRANSFORMATION_UPPERCASE"
-#line 2928 "seclang-parser.yy"
+#line 2929 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5434 "seclang-parser.cc"
+#line 5435 "seclang-parser.cc"
     break;
 
   case 415: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
-#line 2932 "seclang-parser.yy"
+#line 2933 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
       }
-#line 5442 "seclang-parser.cc"
+#line 5443 "seclang-parser.cc"
     break;
 
   case 416: // act: "ACTION_TRANSFORMATION_URL_DECODE"
-#line 2936 "seclang-parser.yy"
+#line 2937 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5450 "seclang-parser.cc"
+#line 5451 "seclang-parser.cc"
     break;
 
   case 417: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
-#line 2940 "seclang-parser.yy"
+#line 2941 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5458 "seclang-parser.cc"
+#line 5459 "seclang-parser.cc"
     break;
 
   case 418: // act: "ACTION_TRANSFORMATION_NONE"
-#line 2944 "seclang-parser.yy"
+#line 2945 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
       }
-#line 5466 "seclang-parser.cc"
+#line 5467 "seclang-parser.cc"
     break;
 
   case 419: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
-#line 2948 "seclang-parser.yy"
+#line 2949 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5474 "seclang-parser.cc"
+#line 5475 "seclang-parser.cc"
     break;
 
   case 420: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
-#line 2952 "seclang-parser.yy"
+#line 2953 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5482 "seclang-parser.cc"
+#line 5483 "seclang-parser.cc"
     break;
 
   case 421: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
-#line 2956 "seclang-parser.yy"
+#line 2957 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5490 "seclang-parser.cc"
+#line 5491 "seclang-parser.cc"
     break;
 
   case 422: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
-#line 2960 "seclang-parser.yy"
+#line 2961 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5498 "seclang-parser.cc"
+#line 5499 "seclang-parser.cc"
     break;
 
   case 423: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
-#line 2964 "seclang-parser.yy"
+#line 2965 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5506 "seclang-parser.cc"
+#line 5507 "seclang-parser.cc"
     break;
 
   case 424: // act: "ACTION_TRANSFORMATION_JS_DECODE"
-#line 2968 "seclang-parser.yy"
+#line 2969 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5514 "seclang-parser.cc"
+#line 5515 "seclang-parser.cc"
     break;
 
   case 425: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
-#line 2972 "seclang-parser.yy"
+#line 2973 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5522 "seclang-parser.cc"
+#line 5523 "seclang-parser.cc"
     break;
 
   case 426: // act: "ACTION_TRANSFORMATION_TRIM"
-#line 2976 "seclang-parser.yy"
+#line 2977 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
       }
-#line 5530 "seclang-parser.cc"
+#line 5531 "seclang-parser.cc"
     break;
 
   case 427: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
-#line 2980 "seclang-parser.yy"
+#line 2981 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
       }
-#line 5538 "seclang-parser.cc"
+#line 5539 "seclang-parser.cc"
     break;
 
   case 428: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
-#line 2984 "seclang-parser.yy"
+#line 2985 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
       }
-#line 5546 "seclang-parser.cc"
+#line 5547 "seclang-parser.cc"
     break;
 
   case 429: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
-#line 2988 "seclang-parser.yy"
+#line 2989 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
       }
-#line 5554 "seclang-parser.cc"
+#line 5555 "seclang-parser.cc"
     break;
 
   case 430: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
-#line 2992 "seclang-parser.yy"
+#line 2993 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
       }
-#line 5562 "seclang-parser.cc"
+#line 5563 "seclang-parser.cc"
     break;
 
   case 431: // act: "ACTION_TRANSFORMATION_LENGTH"
-#line 2996 "seclang-parser.yy"
+#line 2997 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
       }
-#line 5570 "seclang-parser.cc"
+#line 5571 "seclang-parser.cc"
     break;
 
   case 432: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
-#line 3000 "seclang-parser.yy"
+#line 3001 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
       }
-#line 5578 "seclang-parser.cc"
+#line 5579 "seclang-parser.cc"
     break;
 
   case 433: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
-#line 3004 "seclang-parser.yy"
+#line 3005 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
       }
-#line 5586 "seclang-parser.cc"
+#line 5587 "seclang-parser.cc"
     break;
 
   case 434: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
-#line 3008 "seclang-parser.yy"
+#line 3009 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5594 "seclang-parser.cc"
+#line 5595 "seclang-parser.cc"
     break;
 
   case 435: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
-#line 3012 "seclang-parser.yy"
+#line 3013 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5602 "seclang-parser.cc"
+#line 5603 "seclang-parser.cc"
     break;
 
   case 436: // setvar_action: "NOT" var
-#line 3019 "seclang-parser.yy"
+#line 3020 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5610 "seclang-parser.cc"
+#line 5611 "seclang-parser.cc"
     break;
 
   case 437: // setvar_action: var
-#line 3023 "seclang-parser.yy"
+#line 3024 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5618 "seclang-parser.cc"
+#line 5619 "seclang-parser.cc"
     break;
 
   case 438: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
-#line 3027 "seclang-parser.yy"
+#line 3028 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5626 "seclang-parser.cc"
+#line 5627 "seclang-parser.cc"
     break;
 
   case 439: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
-#line 3031 "seclang-parser.yy"
+#line 3032 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5634 "seclang-parser.cc"
+#line 5635 "seclang-parser.cc"
     break;
 
   case 440: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
-#line 3035 "seclang-parser.yy"
+#line 3036 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5642 "seclang-parser.cc"
+#line 5643 "seclang-parser.cc"
     break;
 
   case 441: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3042 "seclang-parser.yy"
+#line 3043 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5651 "seclang-parser.cc"
+#line 5652 "seclang-parser.cc"
     break;
 
   case 442: // run_time_string: run_time_string var
-#line 3047 "seclang-parser.yy"
+#line 3048 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5660 "seclang-parser.cc"
+#line 5661 "seclang-parser.cc"
     break;
 
   case 443: // run_time_string: "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3052 "seclang-parser.yy"
+#line 3053 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5670 "seclang-parser.cc"
+#line 5671 "seclang-parser.cc"
     break;
 
   case 444: // run_time_string: var
-#line 3058 "seclang-parser.yy"
+#line 3059 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5680 "seclang-parser.cc"
+#line 5681 "seclang-parser.cc"
     break;
 
 
-#line 5684 "seclang-parser.cc"
+#line 5685 "seclang-parser.cc"
 
             default:
               break;
@@ -7195,51 +7196,51 @@ namespace yy {
   const short
   seclang_parser::yyrline_[] =
   {
-       0,   715,   715,   719,   720,   723,   728,   734,   740,   744,
-     748,   754,   760,   766,   772,   777,   782,   788,   795,   799,
-     803,   809,   813,   817,   822,   827,   832,   837,   841,   848,
-     852,   859,   865,   875,   884,   894,   903,   916,   920,   924,
-     928,   932,   936,   940,   944,   948,   952,   957,   961,   965,
-     969,   973,   977,   982,   987,   991,   995,   999,  1003,  1007,
-    1011,  1015,  1019,  1023,  1027,  1031,  1035,  1039,  1043,  1047,
-    1051,  1055,  1059,  1063,  1077,  1078,  1108,  1127,  1146,  1174,
-    1231,  1238,  1242,  1246,  1250,  1254,  1258,  1262,  1266,  1275,
-    1279,  1284,  1287,  1292,  1297,  1302,  1307,  1310,  1315,  1318,
-    1323,  1328,  1331,  1336,  1341,  1346,  1351,  1356,  1361,  1366,
-    1369,  1374,  1379,  1384,  1389,  1392,  1397,  1402,  1407,  1420,
-    1433,  1446,  1459,  1472,  1498,  1526,  1538,  1558,  1585,  1590,
-    1596,  1601,  1606,  1615,  1620,  1624,  1628,  1632,  1636,  1640,
-    1644,  1649,  1654,  1666,  1672,  1676,  1680,  1691,  1700,  1701,
-    1708,  1713,  1718,  1772,  1779,  1787,  1824,  1828,  1835,  1840,
-    1846,  1852,  1858,  1865,  1875,  1879,  1883,  1887,  1891,  1895,
-    1899,  1903,  1907,  1911,  1915,  1919,  1923,  1927,  1931,  1935,
-    1939,  1943,  1947,  1951,  1955,  1959,  1963,  1967,  1971,  1975,
-    1979,  1983,  1987,  1991,  1995,  1999,  2003,  2007,  2011,  2015,
-    2019,  2023,  2027,  2031,  2035,  2039,  2043,  2047,  2051,  2055,
-    2059,  2063,  2067,  2071,  2075,  2079,  2083,  2087,  2091,  2095,
-    2099,  2103,  2107,  2111,  2115,  2119,  2123,  2127,  2131,  2135,
-    2139,  2143,  2147,  2151,  2155,  2159,  2163,  2167,  2171,  2175,
-    2179,  2183,  2187,  2191,  2195,  2199,  2203,  2207,  2211,  2215,
-    2219,  2223,  2227,  2231,  2235,  2239,  2243,  2248,  2252,  2256,
-    2261,  2265,  2269,  2274,  2279,  2283,  2287,  2291,  2295,  2299,
-    2303,  2307,  2311,  2315,  2319,  2323,  2327,  2331,  2335,  2339,
-    2343,  2347,  2351,  2355,  2359,  2363,  2367,  2371,  2375,  2379,
-    2383,  2387,  2391,  2395,  2399,  2403,  2407,  2411,  2415,  2419,
-    2423,  2427,  2431,  2435,  2439,  2443,  2447,  2451,  2455,  2459,
-    2463,  2467,  2471,  2475,  2479,  2483,  2487,  2491,  2495,  2499,
-    2503,  2507,  2511,  2515,  2519,  2527,  2534,  2541,  2548,  2555,
-    2562,  2569,  2576,  2583,  2590,  2597,  2604,  2614,  2618,  2622,
-    2626,  2630,  2634,  2638,  2642,  2647,  2651,  2656,  2660,  2664,
-    2668,  2672,  2677,  2682,  2686,  2690,  2694,  2698,  2702,  2706,
-    2710,  2714,  2718,  2722,  2726,  2730,  2734,  2739,  2743,  2747,
-    2751,  2755,  2759,  2763,  2767,  2771,  2775,  2779,  2783,  2787,
-    2791,  2795,  2799,  2803,  2807,  2811,  2815,  2819,  2823,  2827,
-    2831,  2835,  2839,  2843,  2847,  2851,  2855,  2859,  2863,  2867,
-    2871,  2875,  2879,  2883,  2887,  2891,  2895,  2899,  2903,  2907,
-    2911,  2915,  2919,  2923,  2927,  2931,  2935,  2939,  2943,  2947,
-    2951,  2955,  2959,  2963,  2967,  2971,  2975,  2979,  2983,  2987,
-    2991,  2995,  2999,  3003,  3007,  3011,  3018,  3022,  3026,  3030,
-    3034,  3041,  3046,  3051,  3057
+       0,   716,   716,   720,   721,   724,   729,   735,   741,   745,
+     749,   755,   761,   767,   773,   778,   783,   789,   796,   800,
+     804,   810,   814,   818,   823,   828,   833,   838,   842,   849,
+     853,   860,   866,   876,   885,   895,   904,   917,   921,   925,
+     929,   933,   937,   941,   945,   949,   953,   958,   962,   966,
+     970,   974,   978,   983,   988,   992,   996,  1000,  1004,  1008,
+    1012,  1016,  1020,  1024,  1028,  1032,  1036,  1040,  1044,  1048,
+    1052,  1056,  1060,  1064,  1078,  1079,  1109,  1128,  1147,  1175,
+    1232,  1239,  1243,  1247,  1251,  1255,  1259,  1263,  1267,  1276,
+    1280,  1285,  1288,  1293,  1298,  1303,  1308,  1311,  1316,  1319,
+    1324,  1329,  1332,  1337,  1342,  1347,  1352,  1357,  1362,  1367,
+    1370,  1375,  1380,  1385,  1390,  1393,  1398,  1403,  1408,  1421,
+    1434,  1447,  1460,  1473,  1499,  1527,  1539,  1559,  1586,  1591,
+    1597,  1602,  1607,  1616,  1621,  1625,  1629,  1633,  1637,  1641,
+    1645,  1650,  1655,  1667,  1673,  1677,  1681,  1692,  1701,  1702,
+    1709,  1714,  1719,  1773,  1780,  1788,  1825,  1829,  1836,  1841,
+    1847,  1853,  1859,  1866,  1876,  1880,  1884,  1888,  1892,  1896,
+    1900,  1904,  1908,  1912,  1916,  1920,  1924,  1928,  1932,  1936,
+    1940,  1944,  1948,  1952,  1956,  1960,  1964,  1968,  1972,  1976,
+    1980,  1984,  1988,  1992,  1996,  2000,  2004,  2008,  2012,  2016,
+    2020,  2024,  2028,  2032,  2036,  2040,  2044,  2048,  2052,  2056,
+    2060,  2064,  2068,  2072,  2076,  2080,  2084,  2088,  2092,  2096,
+    2100,  2104,  2108,  2112,  2116,  2120,  2124,  2128,  2132,  2136,
+    2140,  2144,  2148,  2152,  2156,  2160,  2164,  2168,  2172,  2176,
+    2180,  2184,  2188,  2192,  2196,  2200,  2204,  2208,  2212,  2216,
+    2220,  2224,  2228,  2232,  2236,  2240,  2244,  2249,  2253,  2257,
+    2262,  2266,  2270,  2275,  2280,  2284,  2288,  2292,  2296,  2300,
+    2304,  2308,  2312,  2316,  2320,  2324,  2328,  2332,  2336,  2340,
+    2344,  2348,  2352,  2356,  2360,  2364,  2368,  2372,  2376,  2380,
+    2384,  2388,  2392,  2396,  2400,  2404,  2408,  2412,  2416,  2420,
+    2424,  2428,  2432,  2436,  2440,  2444,  2448,  2452,  2456,  2460,
+    2464,  2468,  2472,  2476,  2480,  2484,  2488,  2492,  2496,  2500,
+    2504,  2508,  2512,  2516,  2520,  2528,  2535,  2542,  2549,  2556,
+    2563,  2570,  2577,  2584,  2591,  2598,  2605,  2615,  2619,  2623,
+    2627,  2631,  2635,  2639,  2643,  2648,  2652,  2657,  2661,  2665,
+    2669,  2673,  2678,  2683,  2687,  2691,  2695,  2699,  2703,  2707,
+    2711,  2715,  2719,  2723,  2727,  2731,  2735,  2740,  2744,  2748,
+    2752,  2756,  2760,  2764,  2768,  2772,  2776,  2780,  2784,  2788,
+    2792,  2796,  2800,  2804,  2808,  2812,  2816,  2820,  2824,  2828,
+    2832,  2836,  2840,  2844,  2848,  2852,  2856,  2860,  2864,  2868,
+    2872,  2876,  2880,  2884,  2888,  2892,  2896,  2900,  2904,  2908,
+    2912,  2916,  2920,  2924,  2928,  2932,  2936,  2940,  2944,  2948,
+    2952,  2956,  2960,  2964,  2968,  2972,  2976,  2980,  2984,  2988,
+    2992,  2996,  3000,  3004,  3008,  3012,  3019,  3023,  3027,  3031,
+    3035,  3042,  3047,  3052,  3058
   };
 
   void
@@ -7271,9 +7272,9 @@ namespace yy {
 
 
 } // yy
-#line 7275 "seclang-parser.cc"
+#line 7276 "seclang-parser.cc"
 
-#line 3064 "seclang-parser.yy"
+#line 3065 "seclang-parser.yy"
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -319,7 +319,8 @@ using namespace modsecurity::operators;
 %initial-action
 {
   // Initialize the initial location.
-  @$.begin.filename = @$.end.filename = new std::string(driver.file);
+  driver.m_filenames.push_back(driver.file);
+  @$.begin.filename = @$.end.filename = &(driver.m_filenames.back());
 };
 %define parse.trace
 %define parse.error verbose

--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -5106,7 +5106,7 @@ static const flex_int16_t yy_rule_linenum[544] =
      1177, 1178, 1179, 1180, 1182, 1183, 1184, 1185, 1187, 1188,
      1189, 1190, 1192, 1194, 1195, 1197, 1198, 1199, 1200, 1202,
      1207, 1208, 1209, 1213, 1214, 1215, 1220, 1222, 1223, 1224,
-     1243, 1271, 1301
+     1243, 1272, 1303
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -8546,7 +8546,8 @@ YY_RULE_SETUP
         std::string err;
         std::string f = modsecurity::utils::find_resource(s, *driver.loc.back()->end.filename, &err);
         driver.loc.push_back(new yy::location());
-        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = new std::string(f);
+        driver.m_filenames.push_back(f);
+        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
         yyin = fopen(f.c_str(), "r" );
         if (!yyin) {
             BEGIN(INITIAL);
@@ -8560,7 +8561,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 542:
 YY_RULE_SETUP
-#line 1271 "seclang-scanner.ll"
+#line 1272 "seclang-scanner.ll"
 {
     std::string err;
     const char *tmpStr = yytext + strlen("include");
@@ -8577,7 +8578,8 @@ YY_RULE_SETUP
     for (auto& s: files) {
         std::string f = modsecurity::utils::find_resource(s, *driver.loc.back()->end.filename, &err);
         driver.loc.push_back(new yy::location());
-        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = new std::string(f);
+        driver.m_filenames.push_back(f);
+        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
 
         yyin = fopen(f.c_str(), "r" );
         if (!yyin) {
@@ -8594,7 +8596,7 @@ YY_RULE_SETUP
 case 543:
 /* rule 543 can match eol */
 YY_RULE_SETUP
-#line 1301 "seclang-scanner.ll"
+#line 1303 "seclang-scanner.ll"
 {
     HttpsClient c;
     std::string key;
@@ -8610,7 +8612,8 @@ YY_RULE_SETUP
     c.setKey(key);
 
     driver.loc.push_back(new yy::location());
-    driver.loc.back()->begin.filename = driver.loc.back()->end.filename = new std::string(url);
+    driver.m_filenames.push_back(url);
+    driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
     YY_BUFFER_STATE temp = YY_CURRENT_BUFFER;
     yypush_buffer_state(temp);
 
@@ -8632,10 +8635,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 544:
 YY_RULE_SETUP
-#line 1337 "seclang-scanner.ll"
+#line 1340 "seclang-scanner.ll"
 ECHO;
 	YY_BREAK
-#line 8639 "seclang-scanner.cc"
+#line 8642 "seclang-scanner.cc"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -9740,7 +9743,7 @@ void yyfree (void * ptr )
 
 /* %ok-for-header */
 
-#line 1337 "seclang-scanner.ll"
+#line 1340 "seclang-scanner.ll"
 
 
 namespace modsecurity {

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -1255,7 +1255,8 @@ EQUALS_MINUS                            (?i:=\-)
         std::string err;
         std::string f = modsecurity::utils::find_resource(s, *driver.loc.back()->end.filename, &err);
         driver.loc.push_back(new yy::location());
-        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = new std::string(f);
+        driver.m_filenames.push_back(f);
+        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
         yyin = fopen(f.c_str(), "r" );
         if (!yyin) {
             BEGIN(INITIAL);
@@ -1283,7 +1284,8 @@ EQUALS_MINUS                            (?i:=\-)
     for (auto& s: files) {
         std::string f = modsecurity::utils::find_resource(s, *driver.loc.back()->end.filename, &err);
         driver.loc.push_back(new yy::location());
-        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = new std::string(f);
+        driver.m_filenames.push_back(f);
+        driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
 
         yyin = fopen(f.c_str(), "r" );
         if (!yyin) {
@@ -1312,7 +1314,8 @@ EQUALS_MINUS                            (?i:=\-)
     c.setKey(key);
 
     driver.loc.push_back(new yy::location());
-    driver.loc.back()->begin.filename = driver.loc.back()->end.filename = new std::string(url);
+    driver.m_filenames.push_back(url);
+    driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
     YY_BUFFER_STATE temp = YY_CURRENT_BUFFER;
     yypush_buffer_state(temp);
 

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -60,7 +60,7 @@ ctunullpointer:src/rule_with_operator.cc:135
 ctunullpointer:src/rule_with_operator.cc:95
 passedByValue:src/variables/global.h:109
 passedByValue:src/variables/global.h:110
-passedByValue:src/parser/driver.cc:45
+passedByValue:src/parser/driver.cc:46
 passedByValue:test/common/modsecurity_test.cc:49
 passedByValue:test/common/modsecurity_test.cc:98
 unreadVariable:src/rule_with_operator.cc:219


### PR DESCRIPTION
This is a proposed fix to address the most prominent remaining memory leak that can occur when doing nginx reload (but not restart).

The size of the memory leak is proportional to the number of '.conf' filenames being read in by the bison parser.
