### PR TITLE
build: Avoid bashisms

### DIFF
--- a/build/find_pcre2.m4
+++ b/build/find_pcre2.m4
@@ -25,7 +25,7 @@ AS_CASE(["${with_pcre2}"],
   [yes], [test_paths="/usr/local/libpcre2 /usr/local/pcre2 /usr/local /opt/libpcre2 /opt/pcre2 /opt /usr"],
   [test_paths="${with_pcre2}"])
 
-if test "x${with_pcre2}" == "x" || test "x${with_pcre2}" == "xno"; then
+if test "x${with_pcre2}" = "x" || test "x${with_pcre2}" = "xno"; then
     AC_MSG_NOTICE([pcre2 not specified; omitting check])
 else
 

--- a/configure.ac
+++ b/configure.ac
@@ -696,7 +696,7 @@ AC_ARG_ENABLE(large-stream-input,
               AS_HELP_STRING([--enable-large-stream-input],
                              [Enable optimization for large stream input]),
 [
-  if test "$enableval" == "yes"; then
+  if test "$enableval" = "yes"; then
     large_stream_input="-DMSC_LARGE_STREAM_INPUT"
     MODSEC_EXTRA_CFLAGS="$MODSEC_EXTRA_CFLAGS $large_stream_input"
   else


### PR DESCRIPTION
otherwise configure fails to find pcre2 when /bin/sh does not point to bash:

```
  configure: using pcre v8.45
  ./configure: 16601: test: xno: unexpected operator
  ./configure: 16601: test: xno: unexpected operator
  checking for libpcre2 config script... no
  configure: *** pcre2 library not found.
  configure: error: pcre2 library is required
```