### PR TITLE
Avoid IP duplicates in tree

### DIFF
--- a/apache2/msc_tree.c
+++ b/apache2/msc_tree.c
@@ -293,6 +293,8 @@ int InsertNetmask(TreeNode *node, TreeNode *parent, TreeNode *new_node,
     return 0;
 }
 
+TreeNode* CPTRetriveNode(modsec_rec* msr, unsigned char* buffer, unsigned int ip_bitmask, TreeNode* node);
+
 TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree *tree, unsigned char netmask)   {
     unsigned char *buffer = NULL;
     unsigned char bitlen = 0;
@@ -322,6 +324,9 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
     }
 
     node = tree->head;
+    TreeNode* exists = CPTRetriveNode(NULL, ipdata, ip_bitmask, node);
+    if (exists) return exists;
+
     buffer = prefix->buffer;
     bitlen = prefix->bitlen;
 

--- a/apache2/msc_tree.c
+++ b/apache2/msc_tree.c
@@ -324,9 +324,6 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
     }
 
     node = tree->head;
-    TreeNode* exists = CPTRetriveNode(NULL, ipdata, ip_bitmask, node);
-    if (exists) return exists;
-
     buffer = prefix->buffer;
     bitlen = prefix->bitlen;
 
@@ -383,6 +380,12 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
 
     if (bit_validation < test_bit)
         test_bit = bit_validation;
+
+    TreeNode* exists = CPTRetriveNode(NULL, ipdata, ip_bitmask, node);
+    if (exists) return exists;
+
+    TreeNode* exists = CPTRetriveNode(NULL, ipdata, ip_bitmask, node);
+    if (exists) return exists;
 
     parent = node->parent;
 


### PR DESCRIPTION
When you merge shared configs or you use mod_define (or core Define) to combine several IP depending on the environment, you can easily have many redundant IP in the tree. This can sometimes lead to a huge number of IP, most of them being redundant.
This one-line PR (3 lines for clarity) simply checks if it exists before adding it to the tree.