### PR TITLE
Configure: use AS_ECHO_N instead echo -n

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
+  - Configure: use AS_ECHO_N instead echo -n
+    [Issue #2894 - @liudongmiao, @martinhsv]
   - Adjust position of memset from 2890
     [Issue #2891 - @mirkodziadzka-avi, @martinhsv]
   - Add test: empty lines in ipMatchFromFile test

--- a/configure.ac
+++ b/configure.ac
@@ -424,9 +424,9 @@ echo " "
 echo "ModSecurity - ${MSC_GIT_VERSION} for $PLATFORM"
 echo " "
 echo " Mandatory dependencies"
-echo -n "   + libInjection                                  ...."
+AS_ECHO_N("   + libInjection                                  ....")
 echo LIBINJECTION_VERSION
-echo -n "   + SecLang tests                                 ...."
+AS_ECHO_N("   + SecLang tests                                 ....")
 echo SECLANG_TEST_VERSION
 
 echo " "
@@ -439,7 +439,7 @@ if test "x$GEOIP_FOUND" = "x0" && test "x$MAXMIND_FOUND" = "x0"; then
     echo "   + GeoIP/MaxMind                                 ....not found"
 fi
 if test "x$GEOIP_FOUND" = "x1" || test "x$MAXMIND_FOUND" = "x1"; then
-    echo -n "   + GeoIP/MaxMind                                 ....found "
+    AS_ECHO_N("   + GeoIP/MaxMind                                 ....found ")
     echo ""
     if test "x$MAXMIND_FOUND" = "x1"; then
         echo "      * (MaxMind) v${MAXMIND_VERSION}"
@@ -460,7 +460,7 @@ if test "x$CURL_FOUND" = "x0"; then
     echo "   + LibCURL                                       ....not found"
 fi
 if test "x$CURL_FOUND" = "x1"; then
-    echo -n "   + LibCURL                                       ....found "
+    AS_ECHO_N("   + LibCURL                                       ....found ")
     if ! test "x$CURL_VERSION" = "x"; then
         echo "v${CURL_VERSION}"
     else
@@ -478,7 +478,7 @@ if test "x$YAJL_FOUND" = "x0"; then
     echo "   + YAJL                                          ....not found"
 fi
 if test "x$YAJL_FOUND" = "x1"; then
-    echo -n "   + YAJL                                          ....found "
+    AS_ECHO_N("   + YAJL                                          ....found ")
     if ! test "x$YAJL_VERSION" = "x"; then
         echo "v${YAJL_VERSION}"
     else
@@ -496,7 +496,7 @@ if test "x$LMDB_FOUND" = "x0"; then
     echo "   + LMDB                                          ....not found"
 fi
 if test "x$LMDB_FOUND" = "x1"; then
-    echo -n "   + LMDB                                          ....found "
+    AS_ECHO_N("   + LMDB                                          ....found ")
     if ! test "x$LMDB_VERSION" = "x"; then
         echo "v${LMDB_VERSION}"
     else
@@ -514,7 +514,7 @@ if test "x$LIBXML2_FOUND" = "x0"; then
     echo "   + LibXML2                                       ....not found"
 fi
 if test "x$LIBXML2_FOUND" = "x1"; then
-    echo -n "   + LibXML2                                       ....found "
+    AS_ECHO_N("   + LibXML2                                       ....found ")
     if ! test "x$LIBXML2_VERSION" = "x"; then
         echo "v${LIBXML2_VERSION}"
     else
@@ -532,7 +532,7 @@ if test "x$SSDEEP_FOUND" = "x0"; then
     echo "   + SSDEEP                                        ....not found"
 fi
 if test "x$SSDEEP_FOUND" = "x1"; then
-    echo -n "   + SSDEEP                                        ....found "
+    AS_ECHO_N("   + SSDEEP                                        ....found ")
     if ! test "x$SSDEEP_VERSION" = "x"; then
         echo "v${SSDEEP_VERSION}"
     else
@@ -549,7 +549,7 @@ if test "x$LUA_FOUND" = "x0"; then
     echo "   + LUA                                           ....not found"
 fi
 if test "x$LUA_FOUND" = "x1"; then
-    echo -n "   + LUA                                           ....found "
+    AS_ECHO_N("   + LUA                                           ....found ")
     if ! test "x$LUA_VERSION" = "x"; then
         echo "v${LUA_VERSION}"
     else
@@ -567,7 +567,7 @@ if test "x$PCRE2_FOUND" = "x0"; then
     echo "   + PCRE2                                          ....not found"
 fi
 if test "x$PCRE2_FOUND" = "x1"; then
-    echo -n "   + PCRE2                                          ....found "
+    AS_ECHO_N("   + PCRE2                                          ....found ")
     if ! test "x$PCRE2_VERSION" = "x"; then
         echo "v${PCRE2_VERSION}"
     else


### PR DESCRIPTION
This resolves a minor output issue in MacOS where 'echo -n' is not supported.