### PR TITLE
Add editorconfig to help OSS contributors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_style = space
+# Scripts without suffixes in the project root tend to indent by two spaces
+indent_size = 2
+
+# Most of the project files indent by four spaces
+[*/**]
+indent_size = 4
+
+# Test files indent by two spaces
+[test/**]
+indent_size = 2
+
+# The config parser file indents by both two and four spaces,
+# so we choose to indent by two spaces as a common denominator.
+[*.yy]
+indent_size = 2
+
+[{Makefile,Makefile.am}]
+indent_style = tab
+


### PR DESCRIPTION
When switching between many different open source code bases, it can be cumbersome to constantly change editor settings in order to respect a given project's basic style preferences. EditorConfig is a popular format for representing those preferences so editors can automatically respect them.

Many editors support EditorConfig out of the box, and many others have EditorConfig plugins:
https://editorconfig.org/#pre-installed

This commit adds an EditorConfig to the ModSecurity project. It is most likely not perfect because the chosen indentation varies a bit throughout the project, but hopefully it provides a good basis for most ModSecurity editing.