### PR TITLE
Set TX:MSC_PCRE_LIMITS_EXCEEDED variable is limits exceeded

### DIFF
--- a/src/operators/rx.cc
+++ b/src/operators/rx.cc
@@ -74,6 +74,8 @@ bool Rx::evaluate(Transaction *transaction, RuleWithActions *rule,
         if (regex_result == Utils::RegexResult::ErrorMatchLimit) {
             regex_error_str = "MATCH_LIMIT";
             transaction->m_variableMscPcreLimitsExceeded.set("1", transaction->m_variableOffset);
+            transaction->m_collections.m_tx_collection->storeOrUpdateFirst("MSC_PCRE_LIMITS_EXCEEDED", "1");
+            ms_dbg_a(transaction, 7, "Set TX.MSC_PCRE_LIMITS_EXCEEDED to 1");
         }
 
         ms_dbg_a(transaction, 1, "rx: regex error '" + regex_error_str + "' for pattern '" + re->pattern + "'");

--- a/src/operators/rx_global.cc
+++ b/src/operators/rx_global.cc
@@ -68,6 +68,8 @@ bool RxGlobal::evaluate(Transaction *transaction, RuleWithActions *rule,
         if (regex_result == Utils::RegexResult::ErrorMatchLimit) {
             regex_error_str = "MATCH_LIMIT";
             transaction->m_variableMscPcreLimitsExceeded.set("1", transaction->m_variableOffset);
+            transaction->m_collections.m_tx_collection->storeOrUpdateFirst("MSC_PCRE_LIMITS_EXCEEDED", "1");
+            ms_dbg_a(transaction, 7, "Set TX.MSC_PCRE_LIMITS_EXCEEDED to 1");
         }
 
         ms_dbg_a(transaction, 1, "rxGlobal: regex error '" + regex_error_str + "' for pattern '" + re->pattern + "'");

--- a/test/test-cases/regression/operator-rx.json
+++ b/test/test-cases/regression/operator-rx.json
@@ -217,5 +217,50 @@
       "SecRule ARGS:rxtest \"@rx (w+)+$\" \"id:1,phase:1,pass,t:trim,block\"",
       "SecRule MSC_PCRE_LIMITS_EXCEEDED \"@streq 1\" \"id:2,phase:1,pass,t:trim,block\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Operator :: @rx with PCRE match limits exceeded",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length": "27",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri":"/?rxtest=wwwwwwwwwwwwwwwwwwwwwowwwwwwwwwww",
+      "method":"HEAD",
+      "body": [ ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "debug_log":"rx: regex error 'MATCH_LIMIT' for pattern",
+      "error_log":"Matched \"Operator `StrEq' with parameter `1' against variable `TX:MSC_PCRE_LIMITS_EXCEEDED'"
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecPcreMatchLimit 2",
+      "SecRule ARGS:rxtest \"@rx (w+)+$\" \"id:1,phase:1,pass,t:trim,block\"",
+      "SecRule TX:MSC_PCRE_LIMITS_EXCEEDED \"@streq 1\" \"id:2,phase:1,pass,t:trim,block\""
+    ]
   }
 ]


### PR DESCRIPTION
There was a PR ([#2737](https://github.com/SpiderLabs/ModSecurity/pull/2736)) which fixes an earlier shortcoming, namely that the `@rx` (and `@rxGlobal`) operator(s) do not handle PCRE limit issues.

I didn't follow it, but unfortunately seems it implements a different behavior from the other engine (mod_security2).

In mod_security2's [reference](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#tx) the relevant behavior is explained as:

> MSC_PCRE_LIMITS_EXCEEDED: Set to nonzero if PCRE match limits are exceeded. See SecPcreMatchLimit and SecPcreMatchLimitRecursion for more information. 

May be the documentation is a bit ambiguous, but it means the `TX.MSC_PCRE_LIMITS_EXCEEDED` will be set, not the "regular" `MSC_PCRE_LIMITS_EXCEEDED` variable.

This patch corrects this behavior.

Please note, that the introduced variable is not mentioned in v3's [documentation](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v3.x)).

**Why is this important?**

The OWASP Core Rule Set team has a plan for the rule set to handle these types of errors. Without the compatibility, we can't do that.
