### PR TITLE
Add 'Host' header value to 'hostname' in rule message field, if exists

### DIFF
--- a/headers/modsecurity/rule_message.h
+++ b/headers/modsecurity/rule_message.h
@@ -67,6 +67,7 @@ class RuleMessage {
         m_ruleLine(rule->getLineNumber()),
         m_saveMessage(true),
         m_serverIpAddress(trans->m_serverIpAddress),
+        m_requestHostName(trans->m_requestHostName),
         m_severity(0),
         m_uriNoQueryStringDecoded(trans->m_uri_no_query_string_decoded),
         m_ver(rule->m_ver),
@@ -92,6 +93,7 @@ class RuleMessage {
         m_ruleLine(rule->m_ruleLine),
         m_saveMessage(rule->m_saveMessage),
         m_serverIpAddress(rule->m_serverIpAddress),
+        m_requestHostName(rule->m_requestHostName),
         m_severity(rule->m_severity),
         m_uriNoQueryStringDecoded(rule->m_uriNoQueryStringDecoded),
         m_ver(rule->m_ver),
@@ -117,6 +119,7 @@ class RuleMessage {
         m_ruleLine(ruleMessage.m_ruleLine),
         m_saveMessage(ruleMessage.m_saveMessage),
         m_serverIpAddress(ruleMessage.m_serverIpAddress),
+        m_requestHostName(ruleMessage.m_requestHostName),
         m_severity(ruleMessage.m_severity),
         m_uriNoQueryStringDecoded(ruleMessage.m_uriNoQueryStringDecoded),
         m_ver(ruleMessage.m_ver),
@@ -142,6 +145,7 @@ class RuleMessage {
         m_ruleLine = ruleMessage.m_ruleLine;
         m_saveMessage = ruleMessage.m_saveMessage;
         m_serverIpAddress = ruleMessage.m_serverIpAddress;
+        m_requestHostName = ruleMessage.m_requestHostName;
         m_severity = ruleMessage.m_severity;
         m_uriNoQueryStringDecoded = ruleMessage.m_uriNoQueryStringDecoded;
         m_ver = ruleMessage.m_ver;
@@ -201,6 +205,7 @@ class RuleMessage {
     int m_ruleLine;
     bool m_saveMessage;
     std::shared_ptr<std::string> m_serverIpAddress;
+    std::shared_ptr<std::string> m_requestHostName;
     int m_severity;
     std::shared_ptr<std::string> m_uriNoQueryStringDecoded;
     std::string m_ver;

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -444,6 +444,11 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     std::shared_ptr<std::string> m_serverIpAddress;
 
     /**
+     * Holds the request's hostname
+     */
+    std::shared_ptr<std::string> m_requestHostName;
+
+    /**
      * Holds the raw URI that was requested.
      */
     std::string m_uri;

--- a/src/rule_message.cc
+++ b/src/rule_message.cc
@@ -42,8 +42,8 @@ std::string RuleMessage::_details(const RuleMessage *rm) {
         msg.append(" [tag \"" + utils::string::toHexIfNeeded(a, true) + "\"]");
     }
 
-    msg.append(" [hostname \"" + *rm->m_serverIpAddress.get() \
-        + "\"]");
+    msg.append(" [hostname \"" + *rm->m_requestHostName.get() + "\"]");
+
     msg.append(" [uri \"" + utils::string::limitTo(200, *rm->m_uriNoQueryStringDecoded.get()) + "\"]");
     msg.append(" [unique_id \"" + *rm->m_id + "\"]");
     msg.append(" [ref \"" + utils::string::limitTo(200, rm->m_reference) + "\"]");

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -104,6 +104,7 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, void *logCbData)
      m_clientIpAddress(std::make_shared<std::string>("")),
     m_httpVersion(""),
     m_serverIpAddress(std::make_shared<std::string>("")),
+    m_requestHostName(std::make_shared<std::string>("")),
     m_uri(""),
     m_uri_no_query_string_decoded(std::make_shared<std::string>("")),
     m_ARGScombinedSizeDouble(0),
@@ -180,6 +181,7 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, char *id, void *logCb
     m_clientIpAddress(std::make_shared<std::string>("")),
     m_httpVersion(""),
     m_serverIpAddress(std::make_shared<std::string>("")),
+    m_requestHostName(std::make_shared<std::string>("")),
     m_uri(""),
     m_uri_no_query_string_decoded(std::make_shared<std::string>("")),
     m_ARGScombinedSizeDouble(0),
@@ -316,6 +318,7 @@ int Transaction::processConnection(const char *client, int cPort,
     const char *server, int sPort) {
     m_clientIpAddress = std::unique_ptr<std::string>(new std::string(client));
     m_serverIpAddress = std::unique_ptr<std::string>(new std::string(server));
+    m_requestHostName = std::unique_ptr<std::string>(new std::string(server));
     this->m_clientPort = cPort;
     this->m_serverPort = sPort;
     ms_dbg(4, "Transaction context created.");
@@ -706,6 +709,7 @@ int Transaction::addRequestHeader(const std::string& key,
     if (keyl == "host") {
         std::vector<std::string> host = utils::string::split(value, ':');
         m_variableServerName.set(host[0], m_variableOffset);
+        m_requestHostName = std::unique_ptr<std::string>(new std::string(host[0]));
     }
     m_variableOffset = m_variableOffset + value.size() + 1;
 

--- a/test/test-cases/regression/rulemessage_host.json
+++ b/test/test-cases/regression/rulemessage_host.json
@@ -1,0 +1,42 @@
+[
+    {
+    "enabled":1,
+    "version_min":300000,
+    "version_max":0,
+    "title":"Testing 'hostname' field in rule message",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":2313
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"host.modsecurity.org"
+      },
+      "uri":"\/?q=/bin/bash",
+      "method":"GET",
+      "http_version":1.1,
+      "body":""
+    },
+    "response":{
+      "headers":{
+        "Content-Type":"text\/html; charset=utf-8\n\r",
+        "Content-Length":"10\n\r"
+      },
+      "body":[
+        "No answer."
+      ]
+    },
+    "expected":{
+      "http_code":403,
+      "error_log":"hostname \"host.modsecurity.org\""
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx bash\" \"id:1,t:none,deny\""
+    ]
+  }
+]


### PR DESCRIPTION
In case of libmodsecurity3 in the generated message the `hostname` field always contains the server's IP address.

I had a quick look at how it works in mod_security2 and if the request has a "Host" header it's there, otherwise the server IP is placed.

This field is important, because it shows what was the `Host` header of the request.

Normally Nginx's log contains the `host: ...` part, but in some very special cases, when the previous `request: ...` part is too long, the `host` part isn't there, because Nginx truncates the log line after [2048](https://github.com/nginx/nginx/blob/master/src/core/ngx_log.h#L76) bytes. If a user wants to avoid it, then he needs to recompile the whole Nginx. But in many cases, it's not possible.

With this patch we can provide (almost in all cases) that `hostname` will be presented.