### PR TITLE
Don't spray XML parser errors to stderr

### DIFF
--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -19,6 +19,9 @@ xml_unload_external_entity(const char *URI, xmlCharEncoding enc)    {
     return NULL;
 }
 
+static void xml_error_func(void *ctx, const char *msg, ...) {
+    //modsec_rec *msr = (modsec_rec *)ctx;
+}
 
 /**
  * Initialise XML parser.
@@ -31,6 +34,8 @@ int xml_init(modsec_rec *msr, char **error_msg) {
 
     msr->xml = apr_pcalloc(msr->mp, sizeof(xml_data));
     if (msr->xml == NULL) return -1;
+
+    xmlSetGenericErrorFunc(msr, xml_error_func);
 
     if(msr->txcfg->xml_external_entity == 0)    {
         entity = xmlParserInputBufferCreateFilenameDefault(xml_unload_external_entity);


### PR DESCRIPTION
Currently, all XML parser errors are written to stderr, which in case of Apache means that the messages end up randomly in error_log, unformatted. 

This pull request adds custom XML error handling function, which just discards all the messages at the moment.