### PR TITLE
Centralized function to get user name

### DIFF
--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -234,15 +234,7 @@ static char *construct_auditlog_filename(apr_pool_t *mp, const char *uniqueid) {
      * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
      * It also changes the return statement.
      */
-    char *userinfo;
-    apr_status_t rc;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, mp);
-    rc = apr_uid_name_get(&userinfo, uid, mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(mp, "%u", uid);
-    }
+    char *userinfo = get_username(mp);
 
     apr_time_exp_lt(&t, apr_time_now());
 

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -2843,3 +2843,14 @@ char* strtok_r(
 }
 #endif
 
+// Function compatible with Linux & Windows, also with mpm-itk & mod_ruid2
+char* get_username(apr_pool_t* mp) {
+  	char* username;
+  	apr_uid_t uid;
+  	apr_gid_t gid;
+  	int rc = apr_uid_current(&uid, &gid, mp);
+  	if (rc != APR_SUCCESS) return "apache";
+   rc = apr_uid_name_get(&username, uid, mp);
+   if (rc != APR_SUCCESS) return "apache";
+   return username;
+}

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -2843,14 +2843,3 @@ char* strtok_r(
 }
 #endif
 
-// Function compatible with Linux & Windows, also with mpm-itk & mod_ruid2
-char* get_username(apr_pool_t* mp) {
-	char* username;
-	apr_uid_t uid;
-	apr_gid_t gid;
-	int rc = apr_uid_current(&uid, &gid, mp);
-	if (rc != APR_SUCCESS) return "apache";
- rc = apr_uid_name_get(&username, uid, mp);
- if (rc != APR_SUCCESS) return "apache";
- return username;
-}

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -2843,3 +2843,14 @@ char* strtok_r(
 }
 #endif
 
+// Function compatible with Linux & Windows, also with mpm-itk & mod_ruid2
+char* get_username(apr_pool_t* mp) {
+	char* username;
+	apr_uid_t uid;
+	apr_gid_t gid;
+	int rc = apr_uid_current(&uid, &gid, mp);
+	if (rc != APR_SUCCESS) return "apache";
+ rc = apr_uid_name_get(&username, uid, mp);
+ if (rc != APR_SUCCESS) return "apache";
+ return username;
+}

--- a/apache2/msc_util.h
+++ b/apache2/msc_util.h
@@ -159,8 +159,6 @@ int DSOLOCAL tree_contains_ip(apr_pool_t *mp, TreeRoot *rtree,
 int DSOLOCAL ip_tree_from_param(apr_pool_t *pool,
     char *param, TreeRoot **rtree, char **error_msg);
 
-char DSOLOCAL *get_username(apr_pool_t* mp);
-
 #ifdef WITH_CURL
 int ip_tree_from_uri(TreeRoot **rtree, char *uri,
     apr_pool_t *mp, char **error_msg);

--- a/apache2/msc_util.h
+++ b/apache2/msc_util.h
@@ -159,6 +159,8 @@ int DSOLOCAL tree_contains_ip(apr_pool_t *mp, TreeRoot *rtree,
 int DSOLOCAL ip_tree_from_param(apr_pool_t *pool,
     char *param, TreeRoot **rtree, char **error_msg);
 
+char DSOLOCAL *get_username(apr_pool_t* mp);
+
 #ifdef WITH_CURL
 int ip_tree_from_uri(TreeRoot **rtree, char *uri,
     apr_pool_t *mp, char **error_msg);

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -334,7 +334,7 @@ cleanup:
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
         apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
-ÿ nd罎
+#endif
     }
 
     return NULL;

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -100,7 +100,18 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
     apr_table_entry_t *te;
     int expired = 0;
     int i;
-    char *userinfo = get_username(msr->mp);
+
+    /**
+     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
+     */
+    char *userinfo;
+    apr_uid_t uid;
+    apr_gid_t gid;
+    apr_uid_current(&uid, &gid, msr->mp);
+    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(msr->mp, "%u", uid);
+    }
 
     if (msr->txcfg->data_dir == NULL) {
         msr_log(msr, 1, "collection_retrieve_ex: Unable to retrieve collection (name \"%s\", key \"%s\"). Use "
@@ -334,7 +345,7 @@ cleanup:
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
         apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
-ÿ nd罎
+#endif
     }
 
     return NULL;
@@ -373,7 +384,18 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
     int i;
     const apr_table_t *stored_col = NULL;
     const apr_table_t *orig_col = NULL;
-    char *userinfo = get_username(msr->mp);
+
+    /**
+     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
+     */
+    char *userinfo;
+    apr_uid_t uid;
+    apr_gid_t gid;
+    apr_uid_current(&uid, &gid, msr->mp);
+    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(msr->mp, "%u", uid);
+    }
 
     var_name = (msc_string *)apr_table_get(col, "__name");
     if (var_name == NULL) {
@@ -655,7 +677,18 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
     char **keys;
     apr_time_t now = apr_time_sec(msr->request_time);
     int i;
-    char *userinfo = get_username(msr->mp);
+
+    /**
+     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
+     */
+    char *userinfo;
+    apr_uid_t uid;
+    apr_gid_t gid;
+    apr_uid_current(&uid, &gid, msr->mp);
+    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
+    if (rc != APR_SUCCESS) {
+      userinfo = apr_psprintf(msr->mp, "%u", uid);
+    }
 
     if (msr->txcfg->data_dir == NULL) {
         /* The user has been warned about this problem enough times already by now.

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -100,18 +100,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
     apr_table_entry_t *te;
     int expired = 0;
     int i;
-
-    /**
-     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
-     */
-    char *userinfo;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, msr->mp);
-    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(msr->mp, "%u", uid);
-    }
+    char *userinfo = get_username(msr->mp);
 
     if (msr->txcfg->data_dir == NULL) {
         msr_log(msr, 1, "collection_retrieve_ex: Unable to retrieve collection (name \"%s\", key \"%s\"). Use "
@@ -345,7 +334,7 @@ cleanup:
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
         apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
-#endif
+ÿ nd罎
     }
 
     return NULL;
@@ -384,18 +373,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
     int i;
     const apr_table_t *stored_col = NULL;
     const apr_table_t *orig_col = NULL;
-
-    /**
-     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
-     */
-    char *userinfo;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, msr->mp);
-    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(msr->mp, "%u", uid);
-    }
+    char *userinfo = get_username(msr->mp);
 
     var_name = (msc_string *)apr_table_get(col, "__name");
     if (var_name == NULL) {
@@ -677,18 +655,7 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
     char **keys;
     apr_time_t now = apr_time_sec(msr->request_time);
     int i;
-
-    /**
-     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
-     */
-    char *userinfo;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, msr->mp);
-    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(msr->mp, "%u", uid);
-    }
+    char *userinfo = get_username(msr->mp);
 
     if (msr->txcfg->data_dir == NULL) {
         /* The user has been warned about this problem enough times already by now.


### PR DESCRIPTION
Centralized function to get user name, compatible with Linux & Windows (also with mpm-itk & mod_ruid2).
Current implementation is buggy under certain environments, like Windows.
Here, we check all return codes to ensure maximum safety.

Possible enhancement: as we have a centralized function, we could cache the name once it was retrieved; this function is often called, so it may worth to do it (I can create another PR if this one is merged)