### PR TITLE
Fix: lmdb regex match on non-null-terminated string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Fix: lmdb regex match on non-null terminated string
+    [Issue #2985 - @martinhsv]
   - Fix memory leaks in lmdb code (new'd strings)
     [Issue #2983 - @martinhsv]
   - Configure: add additional name to pcre2 pkg-config list

--- a/src/collection/backend/lmdb.cc
+++ b/src/collection/backend/lmdb.cc
@@ -473,12 +473,11 @@ void LMDB::resolveRegularExpression(const std::string& var,
     }
 
     while ((rc = mdb_cursor_get(cursor, &key, &data, MDB_NEXT)) == 0) {
-        char *a = reinterpret_cast<char *>(key.mv_data);
-        int ret = Utils::regex_search(a, r);
+        std::string key_to_insert(reinterpret_cast<char *>(key.mv_data), key.mv_size);
+        int ret = Utils::regex_search(key_to_insert, r);
         if (ret <= 0) {
             continue;
         }
-        std::string key_to_insert(reinterpret_cast<char *>(key.mv_data), key.mv_size);
         if (ke.toOmit(key_to_insert)) {
             continue;
         }

--- a/test/test-cases/regression/collection-regular_expression_selection.json
+++ b/test/test-cases/regression/collection-regular_expression_selection.json
@@ -25,7 +25,7 @@
         "Pragma":"no-cache",
         "Cache-Control":"no-cache"
       },
-      "uri":"\/test.pl?id_a=   test   &id_b=test2&nah=nops",
+      "uri":"\/test.pl?id_a=test&nah=nops",
       "method":"GET",
       "http_version":1.1,
       "body":""
@@ -48,12 +48,15 @@
     },
     "expected":{  
       "audit_log":"",
-      "debug_log":"T \\(0\\) t:lowercase: \"test2\"",
-      "error_log":""
+      "debug_log":"Saving variable: IP:nah with value: nops",
+      "error_log":"",
+      "http_code":200
     },
     "rules":[  
       "SecRuleEngine On",
-      "SecRule ARGS:/^id_/ \"@contains nops\" \"id:1,t:lowercase,block,status:404\""
+      "SecRule ARGS:/^id_/ \"@contains test\" \"id:1,phase:2,t:lowercase,initcol:ip=%{REMOTE_ADDR}\"",
+      "SecRule ARGS:/^id_/ \"@contains test\" \"id:2,phase:2,t:lowercase,setvar:IP.nah=nops\"",
+      "SecRule IP:/id_a$/ \"rx .\" \"id:3,phase:2,deny,status:403\""
     ]
   },
   {
@@ -82,7 +85,7 @@
         "Pragma":"no-cache",
         "Cache-Control":"no-cache"
       },
-      "uri":"\/test.pl?id_a=   test   &id_b=test2&nah=nops",
+      "uri":"\/test.pl?id_a=test&nah=nops",
       "method":"GET",
       "http_version":1.1,
       "body":""
@@ -105,15 +108,14 @@
     },
     "expected":{  
       "audit_log":"",
-      "debug_log":"Saving variable: IP:nah with value: nops",
-      "error_log":""
+      "debug_log":"Saving variable: IP:id_a with value: nops",
+      "http_code":403
     },
     "rules":[  
       "SecRuleEngine On",
-      "SecRule ARGS:/^id_/ \"@contains test\" \"id:1,t:lowercase,initcol:ip=%{REMOTE_ADDR},setvar:IP.id_a=test\"",
-      "SecRule ARGS:/^id_/ \"@contains test\" \"id:3,t:lowercase,setvar:IP.nah=nops\"",
-      "SecRule IP:/^id_/ \"@contains test\" \"id:2,t:lowercase,initcol:ip=%{REMOTE_ADDR}\"",
-      "SecRule IP:/^id_/ \"@contains nops\" \"id:4,t:lowercase,block,status:404\""
+      "SecRule ARGS:/^id_/ \"@contains test\" \"id:11,phase:2,t:lowercase,initcol:ip=%{REMOTE_ADDR}\"",
+      "SecRule ARGS:/^id_/ \"@contains test\" \"id:12,phase:2,t:lowercase,setvar:IP.id_a=nops\"",
+      "SecRule IP:/id_a$/ \"@contains nops\" \"id:13,phase:2,deny,status:403\""
     ]
   }
 ]


### PR DESCRIPTION
The old code was providing the pointer from the lmdb API directly to the regex search function. The pointer points to a correct sequence of bytes for the key, but it is not null terminated.

This issue would primarily affect lmdb match scenarios where the ending of the key would affect the search -- for example if the regular expression used an end-anchor ('$').
