### PR TITLE
Removed redundant processing for "sanitizeXXX" actions

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -972,7 +972,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
     #endif
 
     /* Add rule to the recipe. */
-    if (msre_ruleset_rule_add(dcfg->ruleset, rule, rule->actionset->phase) < 0) {
+    if (rule->actionset && msre_ruleset_rule_add(dcfg->ruleset, rule, rule->actionset->phase) < 0) {
         return "Internal Error: Failed to add rule to the ruleset.";
     }
 

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -34,7 +34,7 @@ static const char* id_log(msre_rule* rule) {
     const char* id = "";
     if (rule->actionset) {
         id = rule->actionset->id;
-        if (!id || id == (const char* )0xffffffffffffffff || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
+        if (!id || id == NOT_SET_P || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
     }
     return id;
 }

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -239,7 +239,7 @@ static void copy_rules_phase(apr_pool_t *mp,
 
             if (copy > 0) {
 #ifdef DEBUG_CONF
-                ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Copy rule %pp [id \"%s\"]", rule, rule->actionset && rule->actionset->id ? rule->actionset->id) : "";
+                ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Copy rule %pp [id \"%s\"]", rule, rule->actionset && rule->actionset->id ? rule->actionset->id : "");
 #endif
 
                 /* Copy the rule. */

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -931,7 +931,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
         }
     }
 
-    if (rule->actionset->is_chained != 1) {
+    if (rule->actionset && rule->actionset->is_chained != 1) {
         /* If this rule is part of the chain but does
          * not want more rules to follow in the chain
          * then cut it (the chain).

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -239,7 +239,12 @@ static void copy_rules_phase(apr_pool_t *mp,
 
             if (copy > 0) {
 #ifdef DEBUG_CONF
-                ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Copy rule %pp [id \"%s\"]", rule, rule->actionset->id);
+                const char* id = "";
+				if (rule->actionset) {
+					rule->actionset->id;
+					if (!id) id = rule->actionset->rule->unparsed;
+				}
+				ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Copy rule %pp [id \"%s\"]", rule, id);
 #endif
 
                 /* Copy the rule. */

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -30,6 +30,15 @@
     APLOG_USE_MODULE(security2);
 #endif
 
+static const char* id_log(msre_rule* rule) {
+    const char* id = "";
+    if (rule->actionset) {
+        id = rule->actionset->id;
+        if (!id || id == (const char* )0xffffffffffffffff || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
+    }
+    return id;
+}
+
 /* -- Directory context creation and initialisation -- */
 
 /**
@@ -239,7 +248,7 @@ static void copy_rules_phase(apr_pool_t *mp,
 
             if (copy > 0) {
 #ifdef DEBUG_CONF
-                ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Copy rule %pp [id \"%s\"]", rule, rule->actionset->id);
+                ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, mp, "Copy rule %pp [id \"%s\"]", rule, id_log(rule));
 #endif
 
                 /* Copy the rule. */
@@ -967,8 +976,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
 
     #ifdef DEBUG_CONF
     ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, cmd->pool,
-        "Adding rule %pp phase=%d id=\"%s\".", rule, rule->actionset->phase, (rule->actionset->id == NOT_SET_P
-        ? "(none)" : rule->actionset->id));
+        "Adding rule %pp phase=%d id=\"%s\".", rule, rule->actionset->phase, id_log(rule));
     #endif
 
     /* Add rule to the recipe. */
@@ -985,7 +993,7 @@ static const char *add_rule(cmd_parms *cmd, directory_config *dcfg, int type,
 
         #ifdef DEBUG_CONF
         ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, cmd->pool,
-            "Adding placeholder %pp for rule %pp id=\"%s\".", phrule, rule, rule->actionset->id);
+            "Adding placeholder %pp for rule %pp id=\"%s\".", phrule, rule, id_log(rule));
         #endif
 
         /* shallow copy of original rule with placeholder marked as target */
@@ -1042,8 +1050,7 @@ static const char *add_marker(cmd_parms *cmd, directory_config *dcfg,
     for (p = PHASE_FIRST; p <= PHASE_LAST; p++) {
         #ifdef DEBUG_CONF
         ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, cmd->pool,
-            "Adding marker %pp phase=%d id=\"%s\".", rule, p, (rule->actionset->id == NOT_SET_P
-            ? "(none)" : rule->actionset->id));
+            "Adding marker %pp phase=%d id=\"%s\".", rule, p, id_log(rule));
         #endif
 
         if (msre_ruleset_rule_add(dcfg->ruleset, rule, p) < 0) {
@@ -1117,9 +1124,7 @@ static const char *update_rule_action(cmd_parms *cmd, directory_config *dcfg,
         char *actions = msre_actionset_generate_action_string(ruleset->mp, rule->actionset);
         ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, cmd->pool,
             "Update rule %pp id=\"%s\" old action: \"%s\"",
-            rule,
-            (rule->actionset->id == NOT_SET_P ? "(none)" : rule->actionset->id),
-            actions);
+            rule, id_log(rule), actions);
     }
     #endif
 
@@ -1137,9 +1142,7 @@ static const char *update_rule_action(cmd_parms *cmd, directory_config *dcfg,
         char *actions = msre_actionset_generate_action_string(ruleset->mp, rule->actionset);
         ap_log_perror(APLOG_MARK, APLOG_STARTUP|APLOG_NOERRNO, 0, cmd->pool,
             "Update rule %pp id=\"%s\" new action: \"%s\"",
-            rule,
-            (rule->actionset->id == NOT_SET_P ? "(none)" : rule->actionset->id),
-            actions);
+            rule, id_log(rule), actions);
     }
     #endif
 

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -31,11 +31,8 @@
 #endif
 
 static const char* id_log(msre_rule* rule) {
-    const char* id = "";
-    if (rule->actionset) {
-        id = rule->actionset->id;
-        if (!id || id == NOT_SET_P || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
-    }
+    const char* id = rule->actionset->id;
+    if (id == NOT_SET_P || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
     return id;
 }
 

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1746,6 +1746,10 @@ char *parser_conn_limits_operator(apr_pool_t *mp, const char *p2,
 
     config_orig_path = apr_pstrndup(mp, filename,
         strlen(filename) - strlen(apr_filepath_name_get(filename)));
+    //MST
+    if (config_orig_path == NULL) {
+        return apr_psprintf(mp, "ModSecurity: failed to duplicate filename in parser_conn_limits_operator");
+    }
 
     apr_filepath_merge(&file, config_orig_path, param, APR_FILEPATH_TRUENAME,
         mp);

--- a/apache2/apache2_io.c
+++ b/apache2/apache2_io.c
@@ -1029,7 +1029,7 @@ apr_status_t output_filter(ap_filter_t *f, apr_bucket_brigade *bb_in) {
 
             bucket_ci = apr_bucket_heap_create(msr->content_append,
                     msr->content_append_len, NULL, f->r->connection->bucket_alloc);
-            APR_BUCKET_INSERT_BEFORE(eos_bucket, bucket_ci);
+            if (eos_bucket) APR_BUCKET_INSERT_BEFORE(eos_bucket, bucket_ci);
 
             if (msr->txcfg->debuglog_level >= 9) {
                 msr_log(msr, 9, "Content-Injection (b): Added content to bottom: %s",

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -30,6 +30,8 @@ apr_status_t send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status) {
 
     /* Set the status line explicitly for the error document */
     f->r->status_line = ap_get_status_line(status);
+    /* Clear previously set response code to make clear that this is not a recursive error */
+    f->r->status = 200;
 
     brigade = apr_brigade_create(f->r->pool, f->r->connection->bucket_alloc);
     if (brigade == NULL) return APR_EGENERAL;

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -30,6 +30,7 @@ apr_status_t send_error_bucket(modsec_rec *msr, ap_filter_t *f, int status) {
 
     /* Set the status line explicitly for the error document */
     f->r->status_line = ap_get_status_line(status);
+    f->r->status = 200; //MST: needed for custom error messages
 
     brigade = apr_brigade_create(f->r->pool, f->r->connection->bucket_alloc);
     if (brigade == NULL) return APR_EGENERAL;

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -660,6 +660,7 @@ static const char *modsec_var_log_handler(request_rec *r, char *name) {
 
     msr = retrieve_tx_context(r);
     if (msr == NULL) return NULL;
+    if (msr->msc_rule_mptmp == NULL) return NULL;
 
     return construct_single_var(msr, name);
 }

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -851,6 +851,8 @@ static int hook_request_early(request_rec *r) {
     modsec_rec *msr = NULL;
     int rc = DECLINED;
 
+    apr_table_set(r->subprocess_env, "ModSecVersion", MODSEC_MODULE_VERSION);
+
     /* This function needs to run only once per transaction
      * (i.e. subrequests and redirects are excluded).
      */

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -771,7 +771,7 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
     /* Log our presence to the error log. */
     if (first_time) {
         ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, s,
-                "%s configured.", MODSEC_MODULE_NAME_FULL);
+                "%s configured.", MODSEC_MODULE_NAME_FULL2);
 
         version(mp);
 
@@ -786,11 +786,13 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
         if (status_engine_state != STATUS_ENGINE_DISABLED) {
             msc_status_engine_call();
         }
+/*MST
         else {
             ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
                     "ModSecurity: Status engine is currently disabled, enable " \
                     "it by set SecStatusEngine to On.");
         }
+*/
 #endif
     }
 

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -327,6 +327,7 @@ static apr_status_t modsecurity_tx_cleanup(void *data) {
             msr->msc_full_request_buffer != NULL) {
         msr->msc_full_request_length = 0;
         free(msr->msc_full_request_buffer);
+        msr->msc_full_request_buffer = NULL;
     }
 
 #if defined(WITH_LUA)

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -126,6 +126,12 @@ msc_engine *modsecurity_create(apr_pool_t *mp, int processing_mode) {
 int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     apr_status_t rc;
 
+    // MST
+    msce->auditlog_lock = msce->geo_lock = NULL;
+#ifdef GLOBAL_COLLECTION_LOCK
+    msce->geo_lock = NULL;
+#endif
+
     /**
      * Notice that curl is initialized here but never cleaned up. First version
      * of this implementation curl was initialized and cleaned for every

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -364,7 +364,7 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
 	if (msr->json->depth_limit_exceeded) {
            *error_msg = "JSON depth limit exceeded";
 	} else {
-           char *yajl_err = yajl_get_error(msr->json->handle, 0, buf, size);
+           char *yajl_err = yajl_get_error(msr->json->handle, 0, base_offset, size);
            *error_msg = apr_pstrdup(msr->mp, yajl_err);
            yajl_free_error(msr->json->handle, yajl_err);
 	}

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -354,7 +354,9 @@ int json_init(modsec_rec *msr, char **error_msg) {
 int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char **error_msg) {
     if (error_msg == NULL) return -1;
     *error_msg = NULL;
-    base_offset=buf;
+    // Take a copy in case libyajl decodes the buffer inline
+    base_offset = apr_pstrmemdup(msr->mp, buf, size);
+    if (!base_offset) return -1;
 
     /* Feed our parser and catch any errors */
     msr->json->status = yajl_parse(msr->json->handle, buf, size);

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -359,7 +359,7 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
     if (!base_offset) return -1;
 
     /* Feed our parser and catch any errors */
-    msr->json->status = yajl_parse(msr->json->handle, buf, size);
+    msr->json->status = yajl_parse(msr->json->handle, (unsigned char*)base_offset, size);
     if (msr->json->status != yajl_status_ok) {
 	if (msr->json->depth_limit_exceeded) {
            *error_msg = "JSON depth limit exceeded";

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1459,7 +1459,8 @@ void sec_audit_logger_json(modsec_rec *msr) {
      * as it does not need an index file.
      */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-
+      if (!msr->modsecurity->auditlog_lock) msr_log(msr, 1, "Audit log: Global mutex was not created"); // MST
+		    else {
         /* Unlock the mutex we used to serialise access to the audit log file. */
         rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
         if (rc != APR_SUCCESS) {
@@ -1468,6 +1469,7 @@ void sec_audit_logger_json(modsec_rec *msr) {
         }
 
         return;
+      }
     }
 
     /* From here on only concurrent-style processing. */

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -234,15 +234,7 @@ static char *construct_auditlog_filename(apr_pool_t *mp, const char *uniqueid) {
      * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
      * It also changes the return statement.
      */
-    char *userinfo;
-    apr_status_t rc;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, mp);
-    rc = apr_uid_name_get(&userinfo, uid, mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(mp, "%u", uid);
-    }
+    char *userinfo = get_username(mp);
 
     apr_time_exp_lt(&t, apr_time_now());
 

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1459,13 +1459,13 @@ void sec_audit_logger_json(modsec_rec *msr) {
      * as it does not need an index file.
      */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-      if (!msr->modsecurity->auditlog_lock) msr_log(msr, 1, "Audit log: Global mutex was not created"); // MST
+      if (!msr->modsecurity->auditlog_lock) msr_log(msr, 1, "Audit log: Global mutex was not created");
 		    else {
         /* Unlock the mutex we used to serialise access to the audit log file. */
         rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
         if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s",
-                    get_apr_error(msr->mp, rc));
+            msr_log(msr, 1, "Audit log: Failed to unlock global mutex '%s': %s",
+			apr_global_mutex_lockfile(msr->modsecurity->auditlog_lock), get_apr_error(msr->mp, rc));
         }
 
         return;
@@ -2245,8 +2245,8 @@ void sec_audit_logger_native(modsec_rec *msr) {
         /* Unlock the mutex we used to serialise access to the audit log file. */
         rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
         if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s",
-                    get_apr_error(msr->mp, rc));
+            msr_log(msr, 1, "Audit log: Failed to unlock global mutex '%s': %s",
+                    apr_global_mutex_lockfile(msr->modsecurity->auditlog_lock), get_apr_error(msr->mp, rc));
         }
 
         return;

--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -85,6 +85,7 @@ static char *multipart_construct_filename(modsec_rec *msr) {
  */
 static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value) {
     char *p = NULL, *t = NULL;
+    int filenamestar = 0;
 
     /* accept only what we understand */
     if (strncmp(c_d_value, "form-data", 9) != 0) {
@@ -210,6 +211,7 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
 
             validate_quotes(msr, value, quote);
 
+            if (filenamestar) continue;
             msr->multipart_filename = apr_pstrdup(msr->mp, value);
 
             if (msr->mpd->mpp->filename != NULL) {
@@ -221,6 +223,22 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
 
             if (msr->txcfg->debuglog_level >= 9) {
                 msr_log(msr, 9, "Multipart: Content-Disposition filename: %s",
+                    log_escape_nq(msr->mp, value));
+            }
+        }
+        else if (strcmp(name, "filename*") == 0) {
+            if (strncasecmp(value, "UTF-8''", 7) && strncasecmp(value, "ISO-8859-1''", 12)) {
+                msr_log(msr, 4, "Multipart: filename* must contain encoding: %s",
+                    log_escape_nq(msr->mp, value));
+                msr->mpd->flag_error = 1;
+                return -16;
+            }
+            filenamestar = 1;
+            value = strstr(value, "''") + 2;
+            msr->multipart_filename = apr_pstrdup(msr->mp, value);
+            msr->mpd->mpp->filename = value;
+            if (msr->txcfg->debuglog_level >= 9) {
+                msr_log(msr, 9, "Multipart: Content-Disposition filename*: %s",
                     log_escape_nq(msr->mp, value));
             }
         }

--- a/apache2/msc_pcre.c
+++ b/apache2/msc_pcre.c
@@ -31,11 +31,7 @@ static apr_status_t msc_pcre_cleanup(msc_regex_t *regex) {
         }
 #else
         if (regex->pe != NULL) {
-#if defined(VERSION_NGINX)
             pcre_free(regex->pe);
-#else
-            free(regex->pe);
-#endif
             regex->pe = NULL;
         }
         if (regex->re != NULL) {
@@ -152,19 +148,15 @@ void *msc_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
 
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
-                pe = pcre_study(regex->re, PCRE_STUDY_JIT_COMPILE, &errptr);
+                pe = pcre_study(regex->re, PCRE_STUDY_EXTRA_NEEDED|PCRE_STUDY_JIT_COMPILE, &errptr);
         #else
-                pe = pcre_study(regex->re, 0, &errptr);
+                pe = pcre_study(regex->re, PCRE_STUDY_EXTRA_NEEDED, &errptr);
         #endif
     #endif
 
     /* Setup the pcre_extra record if pcre_study did not already do it */
     if (pe == NULL) {
-#if defined(VERSION_NGINX)
-        pe = pcre_malloc(sizeof(pcre_extra));
-#else
-        pe = malloc(sizeof(pcre_extra));
-#endif
+        pe = (pcre_extra*)pcre_malloc(sizeof(pcre_extra));
         if (pe == NULL) {
             return NULL;
         }

--- a/apache2/msc_release.h
+++ b/apache2/msc_release.h
@@ -64,6 +64,7 @@
 #endif
 #define MODSEC_MODULE_VERSION MODSEC_VERSION
 #define MODSEC_MODULE_NAME_FULL MODSEC_MODULE_NAME "/" MODSEC_MODULE_VERSION " (http://www.modsecurity.org/)"
+#define MODSEC_MODULE_NAME_FULL2 MODSEC_MODULE_NAME "/" MODSEC_MODULE_VERSION ".1 (Approach " __DATE__ ")" //MST
 
 int DSOLOCAL get_modsec_build_type(const char *name);
 

--- a/apache2/msc_release.h
+++ b/apache2/msc_release.h
@@ -64,7 +64,7 @@
 #endif
 #define MODSEC_MODULE_VERSION MODSEC_VERSION
 #define MODSEC_MODULE_NAME_FULL MODSEC_MODULE_NAME "/" MODSEC_MODULE_VERSION " (http://www.modsecurity.org/)"
-#define MODSEC_MODULE_NAME_FULL2 MODSEC_MODULE_NAME "/" MODSEC_MODULE_VERSION ".1 (Approach " __DATE__ ")" //MST
+#define MODSEC_MODULE_NAME_FULL2 MODSEC_MODULE_NAME "/" MODSEC_MODULE_VERSION ".2 (Approach " __DATE__ ")" //MST
 
 int DSOLOCAL get_modsec_build_type(const char *name);
 

--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -735,7 +735,7 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
                 msr->msc_reqbody_error = 1;
                 msr->msc_reqbody_error_msg = *error_msg;
                 msr_log(msr, 2, "%s", *error_msg);
-                return -1;
+                return -2; // -1 leads to status 500, -2 leads to status 400
             }
         }
     } else if (msr->txcfg->reqbody_buffering != REQUEST_BODY_FORCEBUF_OFF) {

--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -697,7 +697,7 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
                 if (msr->txcfg->debuglog_level >= 4) {
                     msr_log(msr, 4, "%s", *error_msg);
                 }
-                return -1;
+                return -2; // -1 leads to status 500, -2 leads to status 400 
             }
 
             if (multipart_get_arguments(msr, "BODY", msr->arguments) < 0) {
@@ -705,7 +705,7 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
                 msr->msc_reqbody_error = 1;
                 msr->msc_reqbody_error_msg = *error_msg;
                 msr_log(msr, 2, "%s", *error_msg);
-                return -1;
+                return -2; // -1 leads to status 500, -2 leads to status 400 
             }
         }
         else if (strcmp(msr->msc_reqbody_processor, "JSON") == 0) {
@@ -715,7 +715,7 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
                 msr->msc_reqbody_error = 1;
                 msr->msc_reqbody_error_msg = *error_msg;
                 msr_log(msr, 2, "%s", *error_msg);
-                 return -1;
+                return -2; // -1 leads to status 500, -2 leads to status 400 
              }
 #else
             *error_msg = apr_psprintf(msr->mp, "JSON support was not enabled");

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -2843,3 +2843,14 @@ char* strtok_r(
 }
 #endif
 
+// Function compatible with Linux & Windows, also with mpm-itk & mod_ruid2
+char* get_username(apr_pool_t* mp) {
+  	char* username;
+  	apr_uid_t uid;
+  	apr_gid_t gid;
+  	int rc = apr_uid_current(&uid, &gid, mp);
+  	if (rc != APR_SUCCESS) return "apache";
+   rc = apr_uid_name_get(&username, uid, mp);
+   if (rc != APR_SUCCESS) return "apache";
+   return username;
+}

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -2384,6 +2384,8 @@ char *construct_single_var(modsec_rec *msr, char *name) {
     msre_var *vx = NULL;
     char *my_error_msg = NULL;
 
+    if (msr->msc_rule_mptmp == NULL) return NULL; //MST
+
     /* Extract variable name and its parameter from the script. */
     varname = apr_pstrdup(msr->mp, name);
     param = strchr(varname, '.');

--- a/apache2/msc_util.h
+++ b/apache2/msc_util.h
@@ -159,6 +159,8 @@ int DSOLOCAL tree_contains_ip(apr_pool_t *mp, TreeRoot *rtree,
 int DSOLOCAL ip_tree_from_param(apr_pool_t *pool,
     char *param, TreeRoot **rtree, char **error_msg);
 
+char DSOLOCAL *get_username(apr_pool_t* mp);
+
 #ifdef WITH_CURL
 int ip_tree_from_uri(TreeRoot **rtree, char *uri,
     apr_pool_t *mp, char **error_msg);

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -334,7 +334,7 @@ cleanup:
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
         apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
-ÿ nd罎
+#endif
     }
 
     return NULL;

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -100,18 +100,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
     apr_table_entry_t *te;
     int expired = 0;
     int i;
-
-    /**
-     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
-     */
-    char *userinfo;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, msr->mp);
-    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(msr->mp, "%u", uid);
-    }
+    char *userinfo = get_username(msr->mp);
 
     if (msr->txcfg->data_dir == NULL) {
         msr_log(msr, 1, "collection_retrieve_ex: Unable to retrieve collection (name \"%s\", key \"%s\"). Use "
@@ -345,7 +334,7 @@ cleanup:
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
         apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
-#endif
+ÿ nd罎
     }
 
     return NULL;
@@ -384,18 +373,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
     int i;
     const apr_table_t *stored_col = NULL;
     const apr_table_t *orig_col = NULL;
-
-    /**
-     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
-     */
-    char *userinfo;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, msr->mp);
-    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(msr->mp, "%u", uid);
-    }
+    char *userinfo = get_username(msr->mp);
 
     var_name = (msc_string *)apr_table_get(col, "__name");
     if (var_name == NULL) {
@@ -677,18 +655,7 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
     char **keys;
     apr_time_t now = apr_time_sec(msr->request_time);
     int i;
-
-    /**
-     * This is required for mpm-itk & mod_ruid2, though should be harmless for other implementations 
-     */
-    char *userinfo;
-    apr_uid_t uid;
-    apr_gid_t gid;
-    apr_uid_current(&uid, &gid, msr->mp);
-    rc = apr_uid_name_get(&userinfo, uid, msr->mp);
-    if (rc != APR_SUCCESS) {
-      userinfo = apr_psprintf(msr->mp, "%u", uid);
-    }
+    char *userinfo = get_username(msr->mp);
 
     if (msr->txcfg->data_dir == NULL) {
         /* The user has been warned about this problem enough times already by now.

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -378,7 +378,7 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
                     }
 #if !defined(MSC_TEST)
                     else {
-                        ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, " ModSecurity: Cannot find varibale to replace");
+                        ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, " ModSecurity: Cannot find variable to replace");
                     }
 #endif
                     goto end;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -2763,7 +2763,7 @@ static int execute_operator(msre_var *var, msre_rule *rule, modsec_rec *msr,
         }
 
         /* Keep track of the highest severity matched so far */
-        if ((acting_actionset->severity > 0) && (acting_actionset->severity < msr->highest_severity)
+        if (msr && (acting_actionset->severity > 0) && (acting_actionset->severity < msr->highest_severity)
             && !rule->actionset->is_chained)   {
             msr->highest_severity = acting_actionset->severity;
         }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1044,10 +1044,11 @@ static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, c
 	char pattern[200];
 	sprintf(pattern, "(?:^|,)%.185s(?:,|$)", value);
 
-	const char* errptr = NULL;
-	int erroffset;
-	const pcre* regex = pcre_compile(pattern, 0, &errptr, &erroffset, NULL);
-	return !pcre_exec(regex, NULL, vars, strlen(vars), 0, 0, 0, 0);
+ char *error_msg = NULL;
+ msc_regex_t *regex = msc_pregcomp(p, pattern, 0, NULL, NULL);
+ if (regex == NULL) return 0; // we could log an error here
+
+ return (msc_regexec(regex, vars, strlen(vars), &error_msg) > 0);
 }
 
 // Return 1 if "name=value" is present in table for tags, logdata (and others)

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -386,8 +386,13 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
             } else {
 
                 target = strdup(p);
-                if(target == NULL)
-                    return NULL;
+                if(target == NULL) {
+                   if(target_list != NULL)
+                       free(target_list);
+                   if(replace != NULL)
+                       free(replace);
+                   return NULL;
+                  }
 
                 is_negated = is_counting = 0;
                 param = name = value = NULL;
@@ -421,6 +426,8 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
                         free(target_list);
                     if(replace != NULL)
                         free(replace);
+                    if(target != NULL)
+                        free(target);
                     if(msr) {
                         msr_log(msr, 9, "Error to update target - [%s] is not valid target", name);
                     }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1122,13 +1122,13 @@ int msre_parse_generic(apr_pool_t *mp, const char *text, apr_table_t *vartable,
                     return -1;
                 } else
                     if (*p == '\\') {
-                        if ( (*(p + 1) == '\0') || ((*(p + 1) != '\'')&&(*(p + 1) != '\\')) ) {
+                        if ((*(p + 1) == '\0')) {
                             *error_msg = apr_psprintf(mp, "Invalid quoted pair at position %d: %s",
                                     (int)(p - text), text);
                             free(value);
                             return -1;
                         }
-                        p++;
+                        if ((*(p + 1) == '\'') || (*(p + 1) == '\\')) p++; // compatibility with previous behaviour
                         *(d++) = *(p++);
                     } else
                         if (*p == '\'') {

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1067,10 +1067,15 @@ static int action_exists(apr_pool_t* p, const apr_table_t* vartable, const char*
 	if (apr_table_action_exists(p, vartable, "logdata", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitizeArg", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitizeMatched", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitizeMatchedBytes", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitizeRequestHeader", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitizeResponseHeader", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "setrsc", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "setsid", name, value)) return 1;
 	if (apr_table_action_exists(p, vartable, "setuid", name, value)) return 1;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1566,7 +1566,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         saw_starter = 0;
 
                         if (msr->txcfg->debuglog_level >= 9) {
-                            msr_log(msr, 9, "Current rule is id=\"%s\" [chained %d] is trying to find the SecMarker=\"%s\" [stater %d]",rule->actionset->id,last_rule->actionset->is_chained,skip_after,saw_starter);
+                            msr_log(msr, 9, "Current rule is id=\"%s\" [chained %d] is trying to find the SecMarker=\"%s\" [stater %d]",rule->actionset->id,last_rule && last_rule->actionset ? last_rule->actionset->is_chained : 0,skip_after,saw_starter);
                         }
 
                     }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1566,7 +1566,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         saw_starter = 0;
 
                         if (msr->txcfg->debuglog_level >= 9) {
-                            msr_log(msr, 9, "Current rule is id=\"%s\" [chained %d] is trying to find the SecMarker=\"%s\" [stater %d]",rule->actionset->id,last_rule && last_rule->actionset ? last_rule->actionset->is_chained : 0,skip_after,saw_starter);
+                            msr_log(msr, 9, "Current rule is id=\"%s\" [chained %d] is trying to find the SecMarker=\"%s\" [stater %d]",rule->actionset && rule->actionset->id ? rule->actionset->id : "",last_rule && last_rule->actionset ? last_rule->actionset->is_chained : 0,skip_after,saw_starter);
                         }
 
                     }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1479,7 +1479,7 @@ apr_status_t msre_ruleset_process_phase(msre_ruleset *ruleset, modsec_rec *msr) 
         if (rule->placeholder == RULE_PH_MARKER) continue;
 
         msr_log(msr, 1, "Rule %pp [id \"%s\"][file \"%s\"][line \"%d\"]: %u usec", rule,
-                rule->actionset->id,
+                (rule->actionset->id != NOT_SET_P) ? rule->actionset->id : "-",
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,
                 (rule->execution_time / PERFORMANCE_MEASUREMENT_LOOP));
@@ -1566,7 +1566,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         saw_starter = 0;
 
                         if (msr->txcfg->debuglog_level >= 9) {
-				msr_log(msr, 9, "Current rule is id=\"%s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->id, last_rule && last_rule->actionset && last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
+                            msr_log(msr, 9, "Current rule is id=\"%s\" [chained %d] is trying to find the SecMarker=\"%s\" [stater %d]",(rule->actionset->id != NOT_SET_P) ? rule->actionset->id : "-",last_rule->actionset->is_chained,skip_after,saw_starter);
                         }
 
                     }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1566,7 +1566,10 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         saw_starter = 0;
 
                         if (msr->txcfg->debuglog_level >= 9) {
-                            msr_log(msr, 9, "Current rule is id=\"%s\" [chained %d] is trying to find the SecMarker=\"%s\" [stater %d]",rule->actionset->id,last_rule->actionset->is_chained,skip_after,saw_starter);
+                     						if (rule->actionset->id)
+                     							msr_log(msr, 9, "Current rule is id=\"%s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->id, last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
+                     						else
+                     							msr_log(msr, 9, "Current rule is \"%.50s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->rule->unparsed, last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
                         }
 
                     }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1635,7 +1635,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             }
 
             /* Check if this rule was removed at runtime */
-        if (((rule->actionset->id !=NULL) && !apr_is_empty_array(msr->removed_rules)) ||
+        if ((rule->actionset && (rule->actionset->id !=NULL) && !apr_is_empty_array(msr->removed_rules)) ||
                  (apr_is_empty_array(msr->removed_rules_tag)==0) || (apr_is_empty_array(msr->removed_rules_msg)==0)) {
             int j, act, rc;
             int do_process = 1;
@@ -1785,7 +1785,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
         }
 
         if (rc == RULE_NO_MATCH) {
-            if (rule->actionset->is_chained) {
+            if (rule->actionset && rule->actionset->is_chained) {
                 /* If the current rule is part of a chain then
                  * we need to skip over all the rules in the chain.
                  */
@@ -1874,7 +1874,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
              * determine how many rules/chains we need to
              * skip and configure the counter accordingly.
              */
-            if (rule->actionset->is_chained == 0) {
+            if (rule->actionset && rule->actionset->is_chained == 0) {
                 apr_table_clear(msr->matched_vars);
                 if (rule->chain_starter != NULL) {
                     if (rule->chain_starter->actionset->skip_count > 0) {
@@ -1884,7 +1884,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         }
                     }
                 }
-                else if (rule->actionset->skip_count > 0) {
+                else if (rule->actionset && rule->actionset->skip_count > 0) {
                     skip = rule->actionset->skip_count;
                     if (msr->txcfg->debuglog_level >= 4) {
                         msr_log(msr, 4, "Skipping %d rules/chains.", skip);
@@ -1896,10 +1896,10 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             const char *id = "";
             const char *msg = "";
             if (rule->actionset) {
-                if (rule->actionset->id) {
+                if (rule->actionset && rule->actionset->id) {
                     id = rule->actionset->id;
                 }
-                if (rule->actionset->msg) {
+                if (rule->actionset && rule->actionset->msg) {
                     msg = rule->actionset->msg;
                 }
             }
@@ -2696,7 +2696,7 @@ static int execute_operator(msre_var *var, msre_rule *rule, modsec_rec *msr,
         apr_time_t rule_time = 0;
         const char *rt_time = NULL;
 
-        if(rule->actionset->id != NULL) {
+        if(rule->actionset && rule->actionset->id != NULL) {
             rt_time = apr_table_get(msr->perf_rules, rule->actionset->id);
             if(rt_time == NULL) {
                 rt_time = apr_psprintf(msr->mp, "%" APR_TIME_T_FMT, (t1 - time_before_op));
@@ -2764,7 +2764,7 @@ static int execute_operator(msre_var *var, msre_rule *rule, modsec_rec *msr,
 
         /* Keep track of the highest severity matched so far */
         if (msr && (acting_actionset->severity > 0) && (acting_actionset->severity < msr->highest_severity)
-            && !rule->actionset->is_chained)   {
+            && rule->actionset && !rule->actionset->is_chained)   {
             msr->highest_severity = acting_actionset->severity;
         }
 
@@ -2775,7 +2775,7 @@ static int execute_operator(msre_var *var, msre_rule *rule, modsec_rec *msr,
         /* Perform disruptive actions, but only if
          * this rule is not part of a chain.
          */
-        if (rule->actionset->is_chained == 0) {
+        if (rule->actionset && rule->actionset->is_chained == 0) {
             msre_perform_disruptive_actions(msr, rule, acting_actionset, mptmp, my_error_msg);
         }
 

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1033,6 +1033,42 @@ msre_action *msre_create_action(msre_engine *engine, apr_pool_t *mp, const char 
     return action;
 }
 
+// Remove redundant actions (tags, logdata, ...)
+// Return 1 if "name=value" is present in table (for supplied action)
+static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* action, const char* name, const char* value) {
+	if (strcmp(name, action) != 0) return 0;
+
+	const char* vars = apr_table_getm(p, vartable, name);
+	if (!vars) return 0;
+
+	char pattern[200];
+	sprintf(pattern, "(?:^|,)%.185s(?:,|$)", value);
+
+	const char* errptr = NULL;
+	int erroffset;
+	const pcre* regex = pcre_compile(pattern, 0, &errptr, &erroffset, NULL);
+	return !pcre_exec(regex, NULL, vars, strlen(vars), 0, 0, 0, 0);
+}
+
+// Return 1 if "name=value" is present in table for tags, logdata (and others)
+static int action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* name, const char* value) {
+	if (apr_table_action_exists(p, vartable, "capture", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "chain", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "initcol", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "logdata", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setrsc", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setsid", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setuid", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "tag", name, value)) return 1;
+	return 0;
+}
+
 /**
  * Generic parser that is used as basis for target and action parsing.
  * It breaks up the input string into name-parameter pairs and places
@@ -1150,9 +1186,11 @@ int msre_parse_generic(apr_pool_t *mp, const char *text, apr_table_t *vartable,
             value = apr_pstrmemdup(mp, value, p - value);
         }
 
-        /* add to table */
-        apr_table_addn(vartable, name, value);
-        count++;
+        /* add to table (only if not already present) */
+        if (!action_exists(mp, vartable, name, value)) {
+			        apr_table_addn(vartable, name, value);
+			        count++;
+	      	}
 
         /* move to the first character of the next name-value pair */
         while(isspace(*p)||(*p == ',')||(*p == '|')) p++;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -519,18 +519,12 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
     }
 
 end:
-    if(target_list != NULL) {
+    if(target_list != NULL)
         free(target_list);
-        target_list = NULL;
-    }
-    if(replace != NULL) {
+    if(replace != NULL)
         free(replace);
-        replace = NULL;
-    }
-    if(target != NULL)  {
+    if(target != NULL)
         free(target);
-        target = NULL;
-    }
     return NULL;
 }
 

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -637,7 +637,10 @@ static char *msre_generate_target_string(apr_pool_t *pool, msre_rule *rule)  {
 /**
  * Generate an action string from an actionset.
  */
-static char *msre_actionset_generate_action_string(apr_pool_t *pool, const msre_actionset *actionset)  {
+#ifndef DEBUG_CONF
+ static 
+#endif
+char *msre_actionset_generate_action_string(apr_pool_t *pool, const msre_actionset *actionset)  {
     const apr_array_header_t *tarr = NULL;
     const apr_table_entry_t *telts = NULL;
     char *actions = NULL;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1635,7 +1635,8 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             }
 
             /* Check if this rule was removed at runtime */
-        if ((rule->actionset && (rule->actionset->id !=NULL) && !apr_is_empty_array(msr->removed_rules)) ||
+        if (rule->actionset)
+           if (((rule->actionset->id !=NULL) && !apr_is_empty_array(msr->removed_rules)) ||
                  (apr_is_empty_array(msr->removed_rules_tag)==0) || (apr_is_empty_array(msr->removed_rules_msg)==0)) {
             int j, act, rc;
             int do_process = 1;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1844,7 +1844,7 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                 return 1;
             }
 
-            if (rule->actionset->skip_after != NULL) {
+            if (rule->actionset != NULL && rule->actionset->skip_after != NULL) {
                 skip_after = rule->actionset->skip_after;
                 mode = SKIP_RULES;
                 saw_starter = 1;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -499,7 +499,7 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
         if(var_appended == 1)  {
             current_targets = msre_generate_target_string(ruleset->mp, rule);
             rule->unparsed = msre_rule_generate_unparsed(ruleset->mp, rule, current_targets, NULL, NULL);
-            rule->p1 = apr_pstrdup(ruleset->mp, current_targets);
+            rule->p1 = current_targets;
             if(msr) {
                 msr_log(msr, 9, "Successfully appended variable");
             }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1567,9 +1567,9 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
 
                         if (msr->txcfg->debuglog_level >= 9) {
                      						if (rule->actionset->id)
-                     							msr_log(msr, 9, "Current rule is id=\"%s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->id, last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
+                     							msr_log(msr, 9, "Current rule is id=\"%s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->id, last_rule && last_rule->actionset && last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
                      						else
-                     							msr_log(msr, 9, "Current rule is \"%.50s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->rule->unparsed, last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
+                     							msr_log(msr, 9, "Current rule is \"%.50s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->rule->unparsed, last_rule && last_rule->actionset && last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
                         }
 
                     }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -94,7 +94,9 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
 
         if(targets != NULL) {
             if (msr->txcfg->debuglog_level >= 9) {
-                msr_log(msr, 9, "fetch_target_exception: Found exception target list [%s] for rule id %s", targets, rule->actionset->id);
+		const char* id = rule->actionset->id;
+		if (!id) id = rule->actionset->rule->unparsed;
+                msr_log(msr, 9, "fetch_target_exception: Found exception target list [%s] for rule id %.50s", targets, id);
             }
             target = apr_strtok((char *)targets, ",", &savedptr);
 
@@ -139,7 +141,9 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
             }
         } else  {
             if (msr->txcfg->debuglog_level >= 9) {
-                msr_log(msr, 9, "fetch_target_exception: No exception target found for rule id %s.", rule->actionset->id);
+		const char* id = rule->actionset->id;
+		if (!id) id = rule->actionset->rule->unparsed;
+		msr_log(msr, 9, "fetch_target_exception: No exception target found for rule id %.50s.", id);
 
             }
         }
@@ -1478,8 +1482,10 @@ apr_status_t msre_ruleset_process_phase(msre_ruleset *ruleset, modsec_rec *msr) 
         /* Ignore markers, which are never processed. */
         if (rule->placeholder == RULE_PH_MARKER) continue;
 
+	const char* id = rule->actionset->rule->unparsed;
+	if (rule->actionset && rule->actionset->id) id = rule->actionset->id;
         msr_log(msr, 1, "Rule %pp [id \"%s\"][file \"%s\"][line \"%d\"]: %u usec", rule,
-                ((rule->actionset != NULL)&&(rule->actionset->id != NULL)) ? rule->actionset->id : "-",
+                id,
                 rule->filename != NULL ? rule->filename : "-",
                 rule->line_num,
                 (rule->execution_time / PERFORMANCE_MEASUREMENT_LOOP));
@@ -1566,10 +1572,9 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
                         saw_starter = 0;
 
                         if (msr->txcfg->debuglog_level >= 9) {
-                     						if (rule->actionset->id)
-                     							msr_log(msr, 9, "Current rule is id=\"%s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->id, last_rule && last_rule->actionset && last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
-                     						else
-                     							msr_log(msr, 9, "Current rule is \"%.50s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", rule->actionset->rule->unparsed, last_rule && last_rule->actionset && last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
+				const char* id = rule->actionset->id;
+				if (!id) id = rule->actionset->rule->unparsed;
+				msr_log(msr, 9, "Current rule is id=\"%.50s\" %sis trying to find the SecMarker=\"%s\" [stater %d]", id, last_rule && last_rule->actionset && last_rule->actionset->is_chained?"(chained) ":"", skip_after, saw_starter);
                         }
 
                     }
@@ -1723,10 +1728,12 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             /* Go to the next rule if this one has been removed. */
             if (do_process == 0) {
                 if (msr->txcfg->debuglog_level >= 5) {
-                    msr_log(msr, 5, "Not processing %srule id=\"%s\": "
+			const char* id = rule->actionset->id;
+			if (!id) id = rule->actionset->rule->unparsed;
+			msr_log(msr, 5, "Not processing %srule id=\"%.50s\": "
                             "removed by ctl action",
                             rule->actionset->is_chained ? "chained " : "",
-                            rule->actionset->id);
+                            id);
                 }
 
                 /* Skip the whole chain, if this is a chained rule */
@@ -1901,7 +1908,9 @@ static apr_status_t msre_ruleset_process_phase_(msre_ruleset *ruleset, modsec_re
             if (rule->actionset) {
                 if (rule->actionset->id) {
                     id = rule->actionset->id;
-                }
+                } else {
+			id = rule->actionset->rule->unparsed;
+		}
                 if (rule->actionset->msg) {
                     msg = rule->actionset->msg;
                 }

--- a/apache2/re.h
+++ b/apache2/re.h
@@ -75,6 +75,10 @@ int DSOLOCAL rule_id_in_range(int ruleid, const char *range);
 msre_var DSOLOCAL *generate_single_var(modsec_rec *msr, msre_var *var, apr_array_header_t *tfn_arr,
     msre_rule *rule, apr_pool_t *mptmp);
 
+#ifdef DEBUG_CONF
+ char DSOLOCAL* msre_actionset_generate_action_string(apr_pool_t* pool, const msre_actionset* actionset);
+#endif
+
 #if defined(WITH_LUA)
 apr_table_t DSOLOCAL *generate_multi_var(modsec_rec *msr, msre_var *var, apr_array_header_t *tfn_arr,
     msre_rule *rule, apr_pool_t *mptmp);

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -32,8 +32,7 @@ static void msre_engine_action_register(msre_engine *engine, const char *name,
     if (metadata == NULL) return;
 
     metadata->name = name;
-    if (strcmpi(name, "sanitizeMatched"     ) == 0) metadata->name = "sanitiseMatched";
-    if (strcmpi(name, "sanitizeMatchedBytes") == 0) metadata->name = "sanitiseMatchedBytes";
+    if (strncasecmp(name, "sanitize", 8) == 0) ((char*)metadata->name)[6] = 's';
     metadata->type = type;
     metadata->argc_min = argc_min;
     metadata->argc_max = argc_max;

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1561,8 +1561,7 @@ apr_status_t msre_action_setvar_execute(modsec_rec *msr, apr_pool_t *mptmp,
 
     /* Figure out the collection name. */
     target_col = msr->tx_vars;
-    s = strstr(var_name, ".");
-    if (s == NULL) {
+    if (var_name == NULL || (s = strstr(var_name, ".")) == NULL) {
         if (msr->txcfg->debuglog_level >= 3) {
             msr_log(msr, 3, "Asked to set variable \"%s\", but no collection name specified. ",
                 log_escape(msr->mp, var_name));

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -32,6 +32,8 @@ static void msre_engine_action_register(msre_engine *engine, const char *name,
     if (metadata == NULL) return;
 
     metadata->name = name;
+    if (strcmpi(name, "sanitizeMatched"     ) == 0) metadata->name = "sanitiseMatched";
+    if (strcmpi(name, "sanitizeMatchedBytes") == 0) metadata->name = "sanitiseMatchedBytes";
     metadata->type = type;
     metadata->argc_min = argc_min;
     metadata->argc_max = argc_max;

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1254,26 +1254,32 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         p1 = apr_strtok(value,";",&savedptr);
 
         p2 = apr_strtok(NULL,";",&savedptr);
+      		if (p2 == NULL) {
+      			msr_log(msr, 1, "ModSecurity: Missing target for tag \"%s\"", p1);
+      			return -1;
+      		}
+
+        // Expand macros
+        msc_string* str = (msc_string*)apr_pcalloc(msr->mp, sizeof(msc_string));
+        str->value = apr_pstrdup(msr->mp, p2);
+        str->value_len = strlen(p2);
+        expand_macros(msr, str, rule, msr->mp);
 
         if (msr->txcfg->debuglog_level >= 4) {
-            msr_log(msr, 4, "Ctl: ruleRemoveTargetByTag tag=%s targets=%s", p1, p2);
+            msr_log(msr, 4, "Ctl: ruleRemoveTargetByTag tag=%s targets=%s", p1, str->value);
         }
-        if (p2 == NULL) {
-            msr_log(msr, 1, "ModSecurity: Missing target for tag \"%s\"", p1);
+ 
+        re = apr_pcalloc(msr->mp, sizeof(rule_exception));
+        re->type = RULE_EXCEPTION_REMOVE_TAG;
+        re->param = (const char *)apr_pstrdup(msr->mp, p1);
+        re->param_data = msc_pregcomp(msr->mp, p1, 0, NULL, NULL);
+        if (re->param_data == NULL) {
+            msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", p1);
             return -1;
-        }
-
-    re = apr_pcalloc(msr->mp, sizeof(rule_exception));
-    re->type = RULE_EXCEPTION_REMOVE_TAG;
-    re->param = (const char *)apr_pstrdup(msr->mp, p1);
-    re->param_data = msc_pregcomp(msr->mp, p1, 0, NULL, NULL);
-    if (re->param_data == NULL) {
-        msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", p1);
-        return -1;
     }
-    apr_table_addn(msr->removed_targets, apr_pstrdup(msr->mp, p2), (void *)re);
-    return 1;
-    } else
+
+    apr_table_addn(msr->removed_targets, str->value, (void *)re);
+    return 1;    } else
     if (strcasecmp(name, "ruleRemoveTargetByMsg") == 0)  {
         rule_exception *re = NULL;
         char *p1 = NULL, *p2 = NULL;
@@ -1282,25 +1288,32 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         p1 = apr_strtok(value,";",&savedptr);
 
         p2 = apr_strtok(NULL,";",&savedptr);
-
-        if (msr->txcfg->debuglog_level >= 4) {
-            msr_log(msr, 4, "Ctl: ruleRemoveTargetByMsg msg=%s targets=%s", p1, p2);
-        }
         if (p2 == NULL) {
             msr_log(msr, 1, "ModSecurity: Missing target for msg \"%s\"", p1);
             return -1;
         }
 
-    re = apr_pcalloc(msr->mp, sizeof(rule_exception));
-    re->type = RULE_EXCEPTION_REMOVE_MSG;
-    re->param = apr_pstrdup(msr->mp, p1);
-    re->param_data = msc_pregcomp(msr->mp, p1, 0, NULL, NULL);
-    if (re->param_data == NULL) {
-        msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", p1);
-        return -1;
-    }
-    apr_table_addn(msr->removed_targets, apr_pstrdup(msr->mp, p2), (void *)re);
-    return 1;
+       if (msr->txcfg->debuglog_level >= 4) {
+            msr_log(msr, 4, "Ctl: ruleRemoveTargetByMsg msg=%s targets=%s", p1, p2);
+       }
+ 
+   	   re = apr_pcalloc(msr->mp, sizeof(rule_exception));
+   	   re->type = RULE_EXCEPTION_REMOVE_MSG;
+   	   re->param = apr_pstrdup(msr->mp, p1);
+   	   re->param_data = msc_pregcomp(msr->mp, p1, 0, NULL, NULL);
+   	   if (re->param_data == NULL) {
+   		   msr_log(msr, 1, "ModSecurity: Invalid regular expression \"%s\"", p1);
+   		   return -1;
+   	   }
+
+   	   // MST: Expand macros
+   	   msc_string* str = (msc_string*)apr_pcalloc(msr->mp, sizeof(msc_string));
+   	   str->value = apr_pstrdup(msr->mp, p2);
+   	   str->value_len = strlen(p2);
+   	   expand_macros(msr, str, rule, msr->mp);
+
+   	   apr_table_addn(msr->removed_targets, str->value, (void*)re);
+   	   return 1;
     }
     else {
         /* Should never happen, but log if it does. */

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -183,9 +183,9 @@ int expand_macros(modsec_rec *msr, msc_string *var, msre_rule *rule, apr_pool_t 
      *      no macros in the input data.
      */
 
-    data = apr_pstrdup(mptmp, var->value); /* IMP1 Are we modifying data anywhere? */
+    data = var->value;
     arr = apr_array_make(mptmp, 16, sizeof(msc_string *));
-    if ((data == NULL)||(arr == NULL)) return -1;
+    if (arr == NULL) return -1;
 
     text_start = next_text_start = data;
     do {

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -2084,7 +2084,7 @@ static apr_status_t init_collection(modsec_rec *msr, const char *real_col_name,
     apr_table_setn(msr->collections, apr_pstrdup(msr->mp, col_name), (void *)table);
 
     if (msr->txcfg->debuglog_level >= 4) {
-        if (strcmp(col_name, real_col_name) != 0) {
+        if (col_name && real_col_name && strcmp(col_name, real_col_name) != 0) {
             msr_log(msr, 4, "Added collection \"%s\" to the list as \"%s\".",
                 log_escape(msr->mp, real_col_name), log_escape(msr->mp, col_name));
         } else {

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -436,26 +436,18 @@ static apr_status_t msre_action_logdata_init(msre_engine *engine, apr_pool_t *mp
 static apr_status_t msre_action_sanitizeMatchedBytes_init(msre_engine *engine, apr_pool_t *mp,
         msre_actionset *actionset, msre_action *action)
 {
-    char *parse_parm = NULL;
-    char *ac_param = NULL;
-    char *savedptr = NULL;
-    int arg_min = 0;
-    int arg_max = 0;
+    // init in case no bytes are provided
+    actionset->arg_min = actionset->arg_max = 0;
+    if (!action->param) return 1;
 
-    if (action->param != NULL && strlen(action->param) == 3)   {
-
-        ac_param = apr_pstrdup(mp, action->param);
-        parse_parm = apr_strtok(ac_param,"/",&savedptr);
-
-        if(apr_isdigit(*parse_parm) && apr_isdigit(*savedptr))    {
-            arg_max = atoi(parse_parm);
-            arg_min = atoi(savedptr);
-        }
+    char* endptr = NULL;
+    actionset->arg_max = (int)strtol(action->param, &endptr, 0);
+    if (actionset->arg_max < 0 || actionset->arg_max == LONG_MAX) actionset->arg_max = 0;
+    if (*endptr == '/') {
+        actionset->arg_min = (int)strtol(++endptr, NULL, 0);
+        if (actionset->arg_min < 0 || actionset->arg_min == LONG_MAX) actionset->arg_min = 0;
     }
-
-    actionset->arg_min = arg_min;
-    actionset->arg_max = arg_max;
-
+    
     return 1;
 }
 

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -273,6 +273,7 @@ int expand_macros(modsec_rec *msr, msc_string *var, msre_rule *rule, apr_pool_t 
                 next_text_start = p + 1;
             }
         } else {
+            if (arr->nelts == 0) return 0; /* no macro */
             /* Text part. */
             part = (msc_string *)apr_pcalloc(mptmp, sizeof(msc_string));
             part->value = apr_pstrdup(mptmp, text_start);

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -31,8 +31,12 @@ static void msre_engine_action_register(msre_engine *engine, const char *name,
         sizeof(msre_action_metadata));
     if (metadata == NULL) return;
 
-    metadata->name = name;
-    if (strncasecmp(name, "sanitize", 8) == 0) ((char*)metadata->name)[6] = 's';
+    if (strncasecmp(name, "sanitize", 8) == 0) {
+    	char *buf = apr_pstrdup(engine->mp, name);
+    	buf[6] = 's';
+    	metadata->name = buf;
+    }
+    else metadata->name = name;
     metadata->type = type;
     metadata->argc_min = argc_min;
     metadata->argc_max = argc_max;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -630,18 +630,13 @@ nextround:
     }
 
     if(msr->stream_input_data != NULL && input_body == 1) {
-        memset(msr->stream_input_data, 0x0, msr->stream_input_length);
         free(msr->stream_input_data);
         msr->stream_input_data = NULL;
         msr->stream_input_length = 0;
 #ifdef MSC_LARGE_STREAM_INPUT
         msr->stream_input_allocated_length  = 0;
-
-        msr->stream_input_data = (char *)malloc(size);
-#else
-        msr->stream_input_data = (char *)malloc(size+1);
 #endif
-
+        msr->stream_input_data = (char *)malloc(size+1);
         if(msr->stream_input_data == NULL)  {
             return -1;
         }
@@ -649,16 +644,11 @@ nextround:
         msr->stream_input_length = size;
 #ifdef MSC_LARGE_STREAM_INPUT
         msr->stream_input_allocated_length = size;
-        memset(msr->stream_input_data, 0x0, size);
-#else
-        memset(msr->stream_input_data, 0x0, size+1);
 #endif
         msr->if_stream_changed = 1;
 
         memcpy(msr->stream_input_data, data, size);
-#ifndef MSC_LARGE_STREAM_INPUT
         msr->stream_input_data[size] = '\0';
-#endif
 
         var->value_len = size;
         var->value = msr->stream_input_data;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1109,6 +1109,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
     }
 
     /* Are we supposed to capture subexpressions? */
+    if (rule->actionset) { //MST
     capture = apr_table_get(rule->actionset->actions, "capture") ? 1 : 0;
     matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
     if(!matched_bytes)
@@ -1117,6 +1118,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
     matched = apr_table_get(rule->actionset->actions, "sanitizeMatched") ? 1 : 0;
     if(!matched)
         matched = apr_table_get(rule->actionset->actions, "sanitiseMatched") ? 1 : 0;
+    }
 
     /* Show when the regex captures but "capture" is not set */
     if (msr->txcfg->debuglog_level >= 6) {

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1099,11 +1099,11 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
     }
 
     /* Are we supposed to capture subexpressions? */
-    if (rule->actionset) { //MST
-    capture = apr_table_get(rule->actionset->actions, "capture") ? 1 : 0;
-    matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
-
-    matched = apr_table_get(rule->actionset->actions, "sanitiseMatched") ? 1 : 0;
+    if (rule->actionset) {
+        capture = apr_table_get(rule->actionset->actions, "capture") ? 1 : 0;
+        matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
+        matched = apr_table_get(rule->actionset->actions, "sanitiseMatched") ? 1 : 0;
+    }
 
     /* Show when the regex captures but "capture" is not set */
     if (msr->txcfg->debuglog_level >= 6) {

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -2947,10 +2947,9 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
 
             if (rule->actionset) {
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
+                if (!matched_bytes)
+                    matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
             }
-            if(!matched_bytes)
-                matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
-
 
             if (apr_table_get(rule->actionset->actions, "capture")) {
                 for(; i < rc; i++) {
@@ -3277,9 +3276,9 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
 
             if (rule->actionset) {
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
+                if (!matched_bytes)
+                    matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
             }
-            if(!matched_bytes)
-                matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
 
             if (apr_table_get(rule->actionset->actions, "capture")) {
                 for(; i < rc; i++) {
@@ -3591,9 +3590,9 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
 
             if (rule->actionset) {
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
+                if (!matched_bytes)
+                    matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
             }
-            if(!matched_bytes)
-                matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
 
             if (apr_table_get(rule->actionset->actions, "capture")) {
                 for(; i < rc; i++) {

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -782,7 +782,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
             expand_macros(msr, re_pattern, rule, msr->mp);
 
             if (msr->txcfg->debuglog_level >= 6) {
-                const char *pattern = log_escape_re(msr->mp, re_pattern->value);
+                pattern = log_escape_re(msr->mp, re_pattern->value);
                 msr_log(msr, 6, "Escaping pattern [%s]",pattern);
             }
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -4312,6 +4312,9 @@ static int msre_op_validateByteRange_execute(modsec_rec *msr, msre_rule *rule, m
 
     /* Check every byte of the target to detect characters that are not allowed. */
 
+    /* Handle capture as tx.1=char */
+    int capture = apr_table_get(rule->actionset->actions, "capture") ? 1 : 0;
+    
     count = 0;
     for(i = 0; i < var->value_len; i++) {
         int x = ((unsigned char *)var->value)[i];
@@ -4320,6 +4323,17 @@ static int msre_op_validateByteRange_execute(modsec_rec *msr, msre_rule *rule, m
                 msr_log(msr, 9, "Value %d in %s outside range: %s", x, var->name, rule->op_param);
             }
             count++;
+            /* Handle capture as tx.1=char */
+         			if (capture) {
+           				msc_string* s = (msc_string*)apr_pcalloc(msr->mp, sizeof(msc_string));
+           				s->name = apr_psprintf(msr->mp, "%d", count);
+           				s->name_len = strlen(s->name);
+           				s->value = apr_pcalloc(msr->mp, 2);
+           				s->value[0] = var->value[i];
+           				s->value[1] = '\0';
+           				s->value_len = 1;
+           				apr_table_setn(msr->tx_vars, s->name, (void*)s);
+         			}
         }
     }
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -2949,8 +2949,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
                 if (!matched_bytes)
                     matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
-            }
-
+            
             if (apr_table_get(rule->actionset->actions, "capture")) {
                 for(; i < rc; i++) {
                     msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
@@ -2993,6 +2992,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
                     }
 
                 }
+            }
             }
 
             /* Unset the remaining TX vars (from previous invocations). */

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -3278,7 +3278,6 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
                 if (!matched_bytes)
                     matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
-            }
 
             if (apr_table_get(rule->actionset->actions, "capture")) {
                 for(; i < rc; i++) {
@@ -3332,6 +3331,7 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
             }
 
             break;
+        }
         }
     }
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -761,7 +761,6 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
     char *my_error_msg = NULL;
     int ovector[33];
     int rc;
-    const char *pattern = NULL;
     #ifdef WITH_PCRE_STUDY
        #ifdef WITH_PCRE_JIT
     int jit;
@@ -780,7 +779,8 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
             *error_msg = "Internal Error: regex data is null.";
             return -1;
         } else  {
-
+            const char *pattern = NULL;
+            
             if(re_pattern == NULL)  {
                 *error_msg = "Internal Error: regex variable data is null.";
                 return -1;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -3592,8 +3592,7 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
                 if (!matched_bytes)
                     matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
-            }
-
+            
             if (apr_table_get(rule->actionset->actions, "capture")) {
                 for(; i < rc; i++) {
                     msc_string *s = (msc_string *)apr_pcalloc(msr->mp, sizeof(msc_string));
@@ -3637,6 +3636,8 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
 
                 }
             }
+            }
+
 
             /* Unset the remaining TX vars (from previous invocations). */
             for(; i <= 9; i++) {

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -751,7 +751,6 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
     char *my_error_msg = NULL;
     int ovector[33];
     int rc;
-    const char *pattern = NULL;
     #ifdef WITH_PCRE_STUDY
        #ifdef WITH_PCRE_JIT
     int jit;
@@ -781,8 +780,8 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
 
             expand_macros(msr, re_pattern, rule, msr->mp);
 
-            pattern = log_escape_re(msr->mp, re_pattern->value);
             if (msr->txcfg->debuglog_level >= 6) {
+                const char *pattern = log_escape_re(msr->mp, re_pattern->value);
                 msr_log(msr, 6, "Escaping pattern [%s]",pattern);
             }
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1535,10 +1535,10 @@ static const char *gsb_replace_tpath(apr_pool_t *pool, const char *domain, int l
     url = apr_palloc(pool, len + 1);
     data = apr_palloc(pool, len + 1);
 
-    memset(data, 0, len+1);
-    memset(url, 0, len+1);
-
+    data[0] = '\0';
+    
     memcpy(url, domain, len);
+    url[len] = 0;
 
     while(( pos = strstr(url , "/./" )) != NULL) {
         match = 1;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1110,13 +1110,9 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
 
     /* Are we supposed to capture subexpressions? */
     capture = apr_table_get(rule->actionset->actions, "capture") ? 1 : 0;
-    matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
-    if(!matched_bytes)
-        matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
+    matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
 
-    matched = apr_table_get(rule->actionset->actions, "sanitizeMatched") ? 1 : 0;
-    if(!matched)
-        matched = apr_table_get(rule->actionset->actions, "sanitiseMatched") ? 1 : 0;
+    matched = apr_table_get(rule->actionset->actions, "sanitiseMatched") ? 1 : 0;
 
     /* Show when the regex captures but "capture" is not set */
     if (msr->txcfg->debuglog_level >= 6) {
@@ -2944,9 +2940,6 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
              */
 
             if (rule->actionset) {
-                matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
-            }
-            if(!matched_bytes)
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
 
 
@@ -3274,9 +3267,6 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
              */
 
             if (rule->actionset) {
-                matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
-            }
-            if(!matched_bytes)
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
 
             if (apr_table_get(rule->actionset->actions, "capture")) {
@@ -3588,9 +3578,6 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
              */
 
             if (rule->actionset) {
-                matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
-            }
-            if(!matched_bytes)
                 matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
 
             if (apr_table_get(rule->actionset->actions, "capture")) {

--- a/apache2/re_tfns.c
+++ b/apache2/re_tfns.c
@@ -57,7 +57,6 @@ static int msre_fn_cmdline_execute(apr_pool_t *mptmp, unsigned char *input,
                 /* replace some characters to space (only one) */
             case ' ':
             case ',':
-            case ';':
             case '\t':
             case '\r':
             case '\n':

--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -1131,7 +1131,7 @@ static int var_files_tmp_contents_generate(modsec_rec *msr, msre_var *var,
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
-    if (msr->mpd->parts == NULL) return 0; //MST
+    if (msr->mpd->parts == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for (i = 0; i < msr->mpd->parts->nelts; i++)
@@ -1229,7 +1229,7 @@ static int var_files_tmpnames_generate(modsec_rec *msr, msre_var *var, msre_rule
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
-    if (msr->mpd->parts == NULL) return 0; //MST
+    if (msr->mpd->parts == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1275,7 +1275,7 @@ static int var_files_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
-    if (msr->mpd->parts == NULL) return 0; //MST
+    if (msr->mpd->parts == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1321,7 +1321,7 @@ static int var_files_sizes_generate(modsec_rec *msr, msre_var *var, msre_rule *r
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
-    if (msr->mpd->parts == NULL) return 0; //MST
+    if (msr->mpd->parts == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1367,7 +1367,7 @@ static int var_files_names_generate(modsec_rec *msr, msre_var *var, msre_rule *r
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
-    if (msr->mpd->parts == NULL) return 0; //MST
+    if (msr->mpd->parts == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1423,7 +1423,7 @@ static int var_multipart_part_headers_generate(modsec_rec *msr, msre_var *var, m
     int i, j, count = 0;
 
     if (msr->mpd == NULL) return 0;
-    if (msr->mpd->parts == NULL) return 0; //MST
+    if (msr->mpd->parts == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {

--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -1131,6 +1131,7 @@ static int var_files_tmp_contents_generate(modsec_rec *msr, msre_var *var,
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
+    if (msr->mpd->parts == NULL) return 0; //MST
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for (i = 0; i < msr->mpd->parts->nelts; i++)
@@ -1228,6 +1229,7 @@ static int var_files_tmpnames_generate(modsec_rec *msr, msre_var *var, msre_rule
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
+    if (msr->mpd->parts == NULL) return 0; //MST
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1273,6 +1275,7 @@ static int var_files_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
+    if (msr->mpd->parts == NULL) return 0; //MST
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1318,6 +1321,7 @@ static int var_files_sizes_generate(modsec_rec *msr, msre_var *var, msre_rule *r
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
+    if (msr->mpd->parts == NULL) return 0; //MST
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1363,6 +1367,7 @@ static int var_files_names_generate(modsec_rec *msr, msre_var *var, msre_rule *r
     int i, count = 0;
 
     if (msr->mpd == NULL) return 0;
+    if (msr->mpd->parts == NULL) return 0; //MST
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {
@@ -1418,6 +1423,7 @@ static int var_multipart_part_headers_generate(modsec_rec *msr, msre_var *var, m
     int i, j, count = 0;
 
     if (msr->mpd == NULL) return 0;
+    if (msr->mpd->parts == NULL) return 0; //MST
 
     parts = (multipart_part **)msr->mpd->parts->elts;
     for(i = 0; i < msr->mpd->parts->nelts; i++) {


### PR DESCRIPTION
Store "sanitizeMatched" & "sanitizeMatchedBytes" as "sanitiseMatched" & "sanitiseMatchedBytes" to avoid double processing at run-time (only 1 table scan instead of 2).

It also fixes a potential NULL pointer problem (last 3 changes):
```
if (rule->actionset) {
                matched_bytes = apr_table_get(rule->actionset->actions, "sanitizeMatchedBytes") ? 1 : 0;
            }
            if(!matched_bytes)
                matched_bytes = apr_table_get(rule->actionset->actions, "sanitiseMatchedBytes") ? 1 : 0;
```
In case rule->actionset is NULL, last line uses NULL->actions