### PR TITLE
Allow to store only the length of ARGS values in ARGS_COMBINED_SIZE

### DIFF
--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -154,7 +154,9 @@ static int var_args_combined_size_generate(modsec_rec *msr, msre_var *var, msre_
     te = (apr_table_entry_t *)arr->elts;
     for (i = 0; i < arr->nelts; i++) {
         msc_arg *arg = (msc_arg *)te[i].val;
+#ifndef ARGS_COMBINED_SIZE_VALUE_ONLY
         combined_size += arg->name_len;
+#endif
         combined_size += arg->value_len;
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -546,19 +546,19 @@ AC_ARG_ENABLE(server-context-logging,
   log_server_context=''
 ])
 
-# Disable logging of server context
-AC_ARG_ENABLE(server-context-logging,
+# Store only length of ARGS values in ARGS_COMBINED_SIZE
+AC_ARG_ENABLE(args-combined-size-value-only,
               AS_HELP_STRING([--enable-args-combined-size-value-only],
                              [Store only the length of ARGS values in ARGS_COMBINED_SIZE. The default is to also store length of ARGS names.]),
 [
   if test "$enableval" != "no"; then
-    log_server_context=
+    args_size_value=
   else
-    log_server_context="-DARGS_COMBINED_SIZE_VALUE_ONLY"
+    args_size_value="-DARGS_COMBINED_SIZE_VALUE_ONLY"
   fi
 ],
 [
-  log_server_context=''
+  args_size_value=''
 ])
 
 
@@ -844,7 +844,7 @@ else
   fi
 fi
 
-MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $collection_global_lock $large_stream_input"
+MODSEC_EXTRA_CFLAGS="$pcre_study $pcre_match_limit $pcre_match_limit_recursion $pcre_jit $request_early $htaccess_config $lua_cache $debug_conf $debug_cache $debug_acmp $debug_mem $perf_meas $modsec_api $cpu_type $unique_id $log_filename $log_server $log_collection_delete_problem $log_dechunk $log_stopwatch $log_handler $log_server_context $args_size_value $collection_global_lock $large_stream_input"
 
 APXS_WRAPPER=build/apxs-wrapper
 APXS_EXTRA_CFLAGS=""

--- a/configure.ac
+++ b/configure.ac
@@ -546,6 +546,21 @@ AC_ARG_ENABLE(server-context-logging,
   log_server_context=''
 ])
 
+# Disable logging of server context
+AC_ARG_ENABLE(server-context-logging,
+              AS_HELP_STRING([--enable-args-combined-size-value-only],
+                             [Store only the length of ARGS values in ARGS_COMBINED_SIZE. The default is to also store length of ARGS names.]),
+[
+  if test "$enableval" != "no"; then
+    log_server_context=
+  else
+    log_server_context="-DARGS_COMBINED_SIZE_VALUE_ONLY"
+  fi
+],
+[
+  log_server_context=''
+])
+
 
 # Enable collection's global lock
 AC_ARG_ENABLE(collection-global-lock,


### PR DESCRIPTION
Allow to store only the length of ARGS values in ARGS_COMBINED_SIZE.
The default is to also store length of ARGS names.
This can be a problem, especially with JSON with deep nesting, where ARGS_COMBINED_SIZE may be huge while the total of the ARGS values is low.
This change implements a configuration option to choose between both behaviours.