### PR TITLE
Ignore (consistently) empty actions

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -1054,6 +1054,12 @@ int msre_parse_generic(apr_pool_t *mp, const char *text, apr_table_t *vartable,
         /* ignore whitespace */
         while(isspace(*p)) p++;
         if (*p == '\0') return count;
+ 
+        /* ignore empty action */
+        if (*p == ',') {
+          	p++;
+           continue;
+        }
 
         /* we are at the beginning of the name */
         name = p;


### PR DESCRIPTION
In case we write a rule with an empty action, like the following
`SecRule {pattern} {target} "action1,action2,,action3"`
the behaviour is not consistent.

Preliminary explanation: although having empty actions is abnormal, it may happen very easily when using mod_macro, mod_define or <IfDefine> to activate some actions or not depending on the context.

Behaviour:
- An empty action is added to the actions table
- When parsing the actions, sometimes the empty action is ignored, sometimes we get an error "Unknown action" (I'm not sure why, potentially if you have only one empty action or more)
- When we get an error "Unknown action", we have absolutely no context (because the parsing only knows about the individual action at this time, which renders any troubleshooting almost impossible without enabling debug logs

This PR adds a trivial check to not store empty actions in the table and have a consistent behaviour.