### PR TITLE
Optimization: Avoid last loop and storing an empty value in case nothing after last %{..} macro

### DIFF
--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -283,11 +283,9 @@ int expand_macros(modsec_rec *msr, msc_string *var, msre_rule *rule, apr_pool_t 
         }
     } while (p != NULL && *next_text_start);
 
-    /* If there's more than one member of the array that
-     * means there was at least one macro present. Combine
-     * text parts into a single string now.
+    /* Combine text parts into a single string now.
+     * If no macro was present, we already returned
      */
-    if (arr->nelts > 1) {
         /* Figure out the required size for the string. */
         var->value_len = 0;
         for(i = 0; i < arr->nelts; i++) {
@@ -307,7 +305,6 @@ int expand_macros(modsec_rec *msr, msc_string *var, msre_rule *rule, apr_pool_t 
             offset += part->value_len;
         }
         var->value[offset] = '\0';
-    }
 
     return 1;
 }

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -228,18 +228,20 @@ int expand_macros(modsec_rec *msr, msc_string *var, msre_rule *rule, apr_pool_t 
                 msre_var *var_resolved = NULL;
 
                 /* Add the text part before the macro to the array. */
+                if (p != text_start) {
                 part = (msc_string *)apr_pcalloc(mptmp, sizeof(msc_string));
                 if (part == NULL) return -1;
                 part->value_len = p - text_start;
                 part->value = apr_pstrmemdup(mptmp, text_start, part->value_len);
                 *(msc_string **)apr_array_push(arr) = part;
+                }
 
                 /* Resolve the macro and add that to the array. */
                 var_resolved = msre_create_var_ex(mptmp, msr->modsecurity->msre, var_name, var_value,
                     msr, &my_error_msg);
                 if (var_resolved != NULL) {
                     var_generated = generate_single_var(msr, var_resolved, NULL, rule, mptmp);
-                    if (var_generated != NULL) {
+                    if (var_generated != NULL && var_generated->value_len) {
                         part = (msc_string *)apr_pcalloc(mptmp, sizeof(msc_string));
                         if (part == NULL) return -1;
                         part->value_len = var_generated->value_len;

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -279,7 +279,7 @@ int expand_macros(modsec_rec *msr, msc_string *var, msre_rule *rule, apr_pool_t 
             part->value_len = strlen(part->value);
             *(msc_string **)apr_array_push(arr) = part;
         }
-    } while (p != NULL);
+    } while (p != NULL && *next_text_start);
 
     /* If there's more than one member of the array that
      * means there was at least one macro present. Combine


### PR DESCRIPTION
In case of macro replacement, when we have a string like this (quite common) "something %{..}", after the macro replacement, we process the next part, which is an empty string, and we store it in the array used to build the final result.
Same for "%{...} something" for the empty string before.
We also store an empty string if the replacement is empty.
This PR fixes these useless code & storage.