### PR TITLE
Suppress useless loop on tag matching

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -2132,6 +2132,7 @@ static int msre_ruleset_phase_rule_remove_with_exception(msre_ruleset *ruleset, 
                                             &my_error_msg);
                                     if (rc >= 0)    {
                                         remove_rule = 1;
+                                        break;
                                     }
                                 }
                             }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -575,6 +575,7 @@ int msre_ruleset_rule_matches_exception(msre_rule *rule, rule_exception *re)   {
                                     &my_error_msg);
                             if (rc >= 0)    {
                                 match = 1;
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
When a match is found on tags, we continue the loop, which is useless.
This PR breaks the loop on the first match.