### PR TITLE
ctl:ruleRemoveByTag isn't executed if no rule id is present in the rule

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -575,7 +575,6 @@ int msre_ruleset_rule_matches_exception(msre_rule *rule, rule_exception *re)   {
                                     &my_error_msg);
                             if (rc >= 0)    {
                                 match = 1;
-                                break;
                             }
                         }
                     }
@@ -2132,7 +2131,6 @@ static int msre_ruleset_phase_rule_remove_with_exception(msre_ruleset *ruleset, 
                                             &my_error_msg);
                                     if (rc >= 0)    {
                                         remove_rule = 1;
-                                        break;
                                     }
                                 }
                             }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -76,7 +76,7 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
     if(rule->actionset == NULL)
         return 0;
 
-    if(rule->actionset->id !=NULL)    {
+    {
 
         myvar = apr_pstrdup(msr->mp, var->name);
 

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -2132,6 +2132,7 @@ static int msre_ruleset_phase_rule_remove_with_exception(msre_ruleset *ruleset, 
                                             &my_error_msg);
                                     if (rc >= 0)    {
                                         remove_rule = 1;
+                                        break;
                                     }
                                 }
                             }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -575,6 +575,7 @@ int msre_ruleset_rule_matches_exception(msre_rule *rule, rule_exception *re)   {
                                     &my_error_msg);
                             if (rc >= 0)    {
                                 match = 1;
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
There's a check for (rule->actionset->id != NULL) that doesn't check for target exceptions in case a rule has no id. This must be a copy-paste from the code checking exceptions by id.
This PR removes that check.
A little enhancement could be to remove the "id=NULL" from the debug log, but this wasn't done here.