### PR TITLE
fix: makes uri decode platform independent

### DIFF
--- a/src/utils/decode.cc
+++ b/src/utils/decode.cc
@@ -99,8 +99,8 @@ std::string uri_decode(const std::string & sSrc) {
     while (pSrc < SRC_LAST_DEC) {
         if (*pSrc == '%') {
             char dec1, dec2;
-            if (-1 != (dec1 = string::HEX2DEC[*(pSrc + 1)])
-                && -1 != (dec2 = string::HEX2DEC[*(pSrc + 2)])) {
+            if ((char)-1 != (dec1 = string::HEX2DEC[*(pSrc + 1)])
+                && (char)-1 != (dec2 = string::HEX2DEC[*(pSrc + 2)])) {
                 *pEnd++ = (dec1 << 4) + dec2;
                 pSrc += 3;
                 continue;


### PR DESCRIPTION
`REQUEST_URI` variable content goes automatically through a URL decoding transformation process:
https://github.com/SpiderLabs/ModSecurity/blob/5b094c0ce9044044f740e135df2a60c5f0858d4d/src/transaction.cc#L466
Internally the transformation is based on the `HEX2DEC` array mapping.
https://github.com/SpiderLabs/ModSecurity/blob/5b094c0ce9044044f740e135df2a60c5f0858d4d/src/utils/string.h#L34-L55
`HEX2DEC` array returns `(char)-1` when the conversion fails. The result is then compared with `-1`:

https://github.com/SpiderLabs/ModSecurity/blob/5b094c0ce9044044f740e135df2a60c5f0858d4d/src/utils/decode.cc#L102-L103

[The C/C++ standard is not strict about the `char` implementation](https://stackoverflow.com/a/46463173/16481581), allowing it to be `signed` or `unsigned`. Because of that, if an environment interprets the `char` as an `unsigned char` the conversion is never considered as failed (`(char)-1` overflows to `255` and is compared against `-1`).

This PR proposes to make the comparison more portable, forcing the comparison between a platform-dependant value (`(char)-1`).

Discovered running the [`owasp/modsecurity-crs:nginx` image](https://hub.docker.com/layers/owasp/modsecurity-crs/nginx/images/sha256-fd4b1bc39a84872d32a8054194058be26f14b3075d8289454fa668f1d32d233e?context=explore) on Apple silicon processors.
Example Rule that is failing:
```
SecRule REQUEST_URI "@rx \x25" \
    "id:920220,\
    phase:1,\
    deny,\
    t:none"
```
Request:
```
curl -v "http://localhost:80/?x=%w20"
```
`%w` should not be interpreted as a valid encoded sequence, therefore % should still be present in the REQUEST_URI and the regex should match. 

Variables affected: `REQUEST_URI`, `REQUEST_FILENAME`
Dug into it with: @theseion, @theMiddleBlue, @airween