### PR TITLE
Set the minimum security protocol version for SecRemoteRules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Set the minimum security protocol version for SecRemoteRules
+   [Issue security/code-scanning/2 - @airween]
  * Allow lua version 5.4
    [Issue #2996 - @3eka, @martinhsv]
  * Configure: do not check for pcre1 if pcre2 requested

--- a/apache2/msc_remote_rules.c
+++ b/apache2/msc_remote_rules.c
@@ -331,8 +331,8 @@ int msc_remote_download_content(apr_pool_t *mp, const char *uri, const char *key
             headers_chunk = curl_slist_append(headers_chunk, header_key);
         }
 
-        /* Make it TLS 1.x only. */
-        curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+        /* Make it TLS 1.2 at least. */
+        curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
 #ifdef WIN32
         res_len = SearchPathA(NULL, "curl-ca-bundle.crt", NULL, (2048 + 1), buf, &ptr);


### PR DESCRIPTION
See Sonarcloud [report](https://github.com/owasp-modsecurity/ModSecurity/security/code-scanning/2) - this PR fixes it in v2.