### PR TITLE
Set the minimum security protocol version for SecRemoteRules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v3.x.y - YYYY-MMM-DD (to be released)
 -------------------------------------
 
+  - Set the minimum security protocol version for SecRemoteRules
+    [Issue security/code-scanning/2 - @airween]
 
 v3.0.11 - 2023-Dec-06
 ---------------------

--- a/src/utils/https_client.cc
+++ b/src/utils/https_client.cc
@@ -87,8 +87,8 @@ bool HttpsClient::download(const std::string &uri) {
         headers_chunk = curl_slist_append(headers_chunk, m_key.c_str());
     }
 
-    /* Make it TLS 1.x only. */
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+    /* Make it TLS 1.2 at least. */
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
     /* those are the default options, but lets make sure */
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1);


### PR DESCRIPTION
See Sonarcloud [report](https://github.com/owasp-modsecurity/ModSecurity/security/code-scanning/2) - this PR fixes it in v3.