### PR TITLE
Revert "ctl:ruleRemoveByTag isn't executed if no rule id is present in the rule"

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -76,7 +76,7 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
     if(rule->actionset == NULL)
         return 0;
 
-    {
+    if(rule->actionset->id !=NULL)    {
 
         myvar = apr_pstrdup(msr->mp, var->name);
 


### PR DESCRIPTION
Reverts owasp-modsecurity/ModSecurity#3012