### PR TITLE
Revert "Compatibility with libyajl decoding the buffer inline"

### DIFF
--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -354,17 +354,15 @@ int json_init(modsec_rec *msr, char **error_msg) {
 int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char **error_msg) {
     if (error_msg == NULL) return -1;
     *error_msg = NULL;
-    // Take a copy in case libyajl decodes the buffer inline
-    base_offset = apr_pstrmemdup(msr->mp, buf, size);
-    if (!base_offset) return -1;
+    base_offset=buf;
 
     /* Feed our parser and catch any errors */
-    msr->json->status = yajl_parse(msr->json->handle, (unsigned char*)base_offset, size);
+    msr->json->status = yajl_parse(msr->json->handle, buf, size);
     if (msr->json->status != yajl_status_ok) {
 	if (msr->json->depth_limit_exceeded) {
            *error_msg = "JSON depth limit exceeded";
 	} else {
-           char *yajl_err = yajl_get_error(msr->json->handle, 0, base_offset, size);
+           char *yajl_err = yajl_get_error(msr->json->handle, 0, buf, size);
            *error_msg = apr_pstrdup(msr->mp, yajl_err);
            yajl_free_error(msr->json->handle, yajl_err);
 	}


### PR DESCRIPTION
Reverts owasp-modsecurity/ModSecurity#2957