### PR TITLE
V2/fixbuildissue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,34 +1,6 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
- * Support for PCRE2 in Windows
-   [PR #2931, @leancz]
- * Fix ; incorrectly replaced by space in t:cmdline
-   [PR #3051, @marcstern]
- * Add some syntax validation 
-   [PR #2994, @marcstern]
- * Optimize macro processing
-   [PR #2992/3004, @marcstern]
- * Add detailed error message when writing collections
-   [PR #3050, @marcstern]
- * Add context info to error message
-   [PR #2997, @marcstern]
- * Fix ctl:ruleRemoveByTag that isn't executed if no rule id is present
-   [PR #3012, @marcstern]
- * Ignore empty action instead of storing it
-   [PR #3003, @marcstern]
- * Fixed memory leak if builded modsecurity with --enable-pcre-study
-   [Issue #610, @marcstern]
- * Remove useless code
-   [PR #2953/2954, @marcstern]
- * Centralized function to get user name, compatible with Linux & Windows
-   [PR #2956, @marcstern]
- * Compatibility with libyajl decoding the buffer inline
-   [PR #2957, @marcstern]
- * Fixed memory leaks
-   [PR #2960/2963/2969, @marcstern]
- * Fixed uninitialized variable
-   [PR #2987, @marcstern]
  * Set the minimum security protocol version for SecRemoteRules
    [Issue security/code-scanning/2 - @airween]
  * Allow lua version 5.4

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -1545,10 +1545,10 @@ static const char *gsb_replace_tpath(apr_pool_t *pool, const char *domain, int l
     url = apr_palloc(pool, len + 1);
     data = apr_palloc(pool, len + 1);
 
-    data[0] = '\0';
-    
+    memset(data, 0, len+1);
+    memset(url, 0, len+1);
+
     memcpy(url, domain, len);
-    url[len] = 0;
 
     while(( pos = strstr(url , "/./" )) != NULL) {
         match = 1;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -751,6 +751,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
     char *my_error_msg = NULL;
     int ovector[33];
     int rc;
+    const char *pattern = NULL;
     #ifdef WITH_PCRE_STUDY
        #ifdef WITH_PCRE_JIT
     int jit;
@@ -780,8 +781,8 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
 
             expand_macros(msr, re_pattern, rule, msr->mp);
 
+            pattern = log_escape_re(msr->mp, re_pattern->value);
             if (msr->txcfg->debuglog_level >= 6) {
-                const char *pattern = log_escape_re(msr->mp, re_pattern->value);
                 msr_log(msr, 6, "Escaping pattern [%s]",pattern);
             }
 

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -630,13 +630,18 @@ nextround:
     }
 
     if(msr->stream_input_data != NULL && input_body == 1) {
+        memset(msr->stream_input_data, 0x0, msr->stream_input_length);
         free(msr->stream_input_data);
         msr->stream_input_data = NULL;
         msr->stream_input_length = 0;
 #ifdef MSC_LARGE_STREAM_INPUT
         msr->stream_input_allocated_length  = 0;
-#endif
+
+        msr->stream_input_data = (char *)malloc(size);
+#else
         msr->stream_input_data = (char *)malloc(size+1);
+#endif
+
         if(msr->stream_input_data == NULL)  {
             return -1;
         }
@@ -644,11 +649,16 @@ nextround:
         msr->stream_input_length = size;
 #ifdef MSC_LARGE_STREAM_INPUT
         msr->stream_input_allocated_length = size;
+        memset(msr->stream_input_data, 0x0, size);
+#else
+        memset(msr->stream_input_data, 0x0, size+1);
 #endif
         msr->if_stream_changed = 1;
 
         memcpy(msr->stream_input_data, data, size);
+#ifndef MSC_LARGE_STREAM_INPUT
         msr->stream_input_data[size] = '\0';
+#endif
 
         var->value_len = size;
         var->value = msr->stream_input_data;

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -780,8 +780,8 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
 
             expand_macros(msr, re_pattern, rule, msr->mp);
 
-            const char *pattern = log_escape_re(msr->mp, re_pattern->value);
             if (msr->txcfg->debuglog_level >= 6) {
+                const char *pattern = log_escape_re(msr->mp, re_pattern->value);
                 msr_log(msr, 6, "Escaping pattern [%s]",pattern);
             }
 


### PR DESCRIPTION
We took over this project without any CI/CD.

Not suprisingly, a recent commit made the source code uncompilable.

We decided to roll everything back, to setup at least a minimal CI/CD and then to apply the changes again.

Details: The problem was [@26d2b0](https://github.com/owasp-modsecurity/ModSecurity/commit/26d2b0d069d09b07d73ac8c67040f0c3bd7199e2) via #2954. We decided to go back to [@6a3dc9](https://github.com/owasp-modsecurity/ModSecurity/commit/6a3dc9) via #3043 which is the last known stable state (PR 2954 was merged after PR 3043).

There were some other commits what came from directly (without PR) or earlier committed and Github wasn't able to revert them. 

This PR contains these modifications.