### PR TITLE
test: Logical, syntax and cosmetic fixes on test cases

### DIFF
--- a/test/test-cases/regression/action-ctl_rule_remove_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_by_id.json
@@ -18,7 +18,7 @@
         "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
         "Content-Type": "text/xml"
       },
-      "uri":"/wp-login.php?whee&pwd=lhebs",
+      "uri":"/wp-login.php?whee=something&pwd=lhebs",
       "method":"GET",
       "body": [ ]
     },
@@ -28,7 +28,7 @@
     },
     "rules":[
         "SecRule REQUEST_FILENAME \"@endsWith /wp-login.php\" \"id:9002100,phase:2,t:none,nolog,pass,ctl:ruleRemoveById=1\"",
-        "SecRule ARGS \"@contais whe\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS'\""
+        "SecRule ARGS_NAMES \"@contains whee\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS'\""
     ]
   },
   {
@@ -36,7 +36,7 @@
     "version_min":300000,
     "title":"Testing CtlRuleRemoteById (2)",
     "expected":{
-      "debug_log": "Target value: .*Variable: ARGS:pwd"
+      "debug_log": "Target value: .*Variable: ARGS_NAMES:whee"
     },
     "client":{
       "ip":"200.249.12.31",
@@ -50,7 +50,7 @@
         "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
         "Content-Type": "text/xml"
       },
-      "uri":"/wp-login.php?whee&pwd=lhebs",
+      "uri":"/wp-login.php?whee=something&pwd=lhebs",
       "method":"GET",
       "body": [ ]
     },
@@ -60,7 +60,7 @@
     },
     "rules":[
         "SecRule REQUEST_FILENAME \"@endsWith /wp-login.php\" \"id:9002100,phase:2,t:none,nolog,pass,ctl:ruleRemoveById=123\"",
-        "SecRule ARGS \"@contais whe\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
+        "SecRule ARGS_NAMES \"@contains whee\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
     ]
   }
 ]

--- a/test/test-cases/regression/action-ctl_rule_remove_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_by_id.json
@@ -4,7 +4,8 @@
     "version_min":300000,
     "title":"Testing CtlRuleRemoteById (1)",
     "expected":{
-      "debug_log": "Rule id: 1 was skipped due to a ruleRemoveById action..."
+      "debug_log": "Rule id: 1 was skipped due to a ruleRemoveById action...",
+      "http_code": 200
     },
     "client":{
       "ip":"200.249.12.31",

--- a/test/test-cases/regression/action-ctl_rule_remove_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_by_id.json
@@ -4,8 +4,7 @@
     "version_min":300000,
     "title":"Testing CtlRuleRemoteById (1)",
     "expected":{
-      "debug_log": "Rule id: 1 was skipped due to a ruleRemoveById action...",
-      "http_code": 200
+      "debug_log": "Rule id: 1 was skipped due to a ruleRemoveById action..."
     },
     "client":{
       "ip":"200.249.12.31",

--- a/test/test-cases/regression/action-ctl_rule_remove_by_tag.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_by_tag.json
@@ -34,7 +34,7 @@
       "debug_log":"Skipped rule id '2'. Skipped due to a ruleRemoveByTag action."
     },
     "rules":[
-      "SecRule ARGS:key \".\" \"id:4,ctl:ruleRemoveByTag=tag123",
+      "SecRule ARGS:key \".\" \"id:4,ctl:ruleRemoveByTag=tag123\"",
       "SecRule ARGS \"@contains test1\" \"id:1,pass,t:trim\"",
       "SecRule ARGS \"@contains test2\" \"id:2,pass,t:trim,tag:tag123\"",
       "SecRule ARGS \"@contains test3\" \"id:3,pass,t:trim\""

--- a/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
@@ -37,7 +37,7 @@
     "version_min":300000,
     "title":"Testing CtlRuleRemoveTargetById (2)",
     "expected":{
-      "debug_log": "Target value: .*Variable: ARGS:pwd"
+      "debug_log": "Target value: .*Variable: ARGS_NAMES:whee"
     },
     "client":{
       "ip":"200.249.12.31",
@@ -51,7 +51,7 @@
         "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
         "Content-Type": "text/xml"
       },
-      "uri":"/wp-login.php?whee&pwd=lhebs",
+      "uri":"/wp-login.php?whee=something&pwd=lhebs",
       "method":"GET",
       "body": [ ]
     },
@@ -61,7 +61,7 @@
     },
     "rules":[
         "SecRule REQUEST_FILENAME \"@endsWith /wp-login.php\" \"id:9002100,phase:2,t:none,nolog,pass,ctl:ruleRemoveTargetById=123;ARGS:pwd\"",
-        "SecRule ARGS \"@contais whe\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
+        "SecRule ARGS_NAMES \"@contains whee\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
     ]
   },
   {
@@ -83,7 +83,7 @@
         "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
         "Content-Type": "text/xml"
       },
-      "uri":"/wp-login.php?whee&pwd=lhebs",
+      "uri":"/wp-login.php?whee=something&pwd=lhebs",
       "method":"GET",
       "body": [ ]
     },

--- a/test/test-cases/regression/action-ctl_rule_remove_target_by_tag.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_target_by_tag.json
@@ -37,7 +37,7 @@
     "version_min":300000,
     "title":"Testing CtlRuleRemoteTargetByTag (2)",
     "expected":{
-      "debug_log": "Target value: .*Variable: ARGS:pwd"
+      "debug_log": "Target value: .*Variable: ARGS_NAMES:pwd"
     },
     "client":{
       "ip":"200.249.12.31",
@@ -61,7 +61,7 @@
     },
     "rules":[
         "SecRule REQUEST_FILENAME \"@endsWith /wp-login.php\" \"id:9002100,phase:2,t:none,nolog,pass,ctl:ruleRemoveTargetByTag=CRS;ARGS:pwd\"",
-        "SecRule ARGS \"@contais whe\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
+        "SecRule ARGS_NAMES \"@contains pwd\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
     ]
   },
   {
@@ -69,7 +69,7 @@
     "version_min":300000,
     "title":"Testing CtlRuleRemoteTargetByTag (3)",
     "expected":{
-      "debug_log": "Target value: .*Variable: ARGS:pwd"
+      "debug_log": "Target value: .*Variable: ARGS_NAMES:whee"
     },
     "client":{
       "ip":"200.249.12.31",
@@ -83,7 +83,7 @@
         "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
         "Content-Type": "text/xml"
       },
-      "uri":"/wp-login.php?whee&pwd=lhebs",
+      "uri":"/wp-login.php?whee=something&pwd=lhebs",
       "method":"GET",
       "body": [ ]
     },
@@ -93,7 +93,7 @@
     },
     "rules":[
         "SecRule REQUEST_FILENAME \"@endsWith /wp-login.php\" \"id:9002100,phase:2,t:none,nolog,pass,ctl:ruleRemoveTargetByTag=CRS;ARGS\"",
-        "SecRule ARGS \"@contais whe\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
+        "SecRule ARGS_NAMES \"@contains whee\" \"id:1,phase:3,t:none,nolog,pass,tag:'CRS2'\""
     ]
   }
 ]

--- a/test/test-cases/regression/issue-1850.json
+++ b/test/test-cases/regression/issue-1850.json
@@ -44,7 +44,7 @@
     "rules": [
       "SecRuleEngine On",
       "SecDefaultAction \"phase:1,status:404,deny\"",
-      "SecRule REQUEST_URI \"@contains /\" \"id:2000001,phase:1,log,redirect:'http://1.1.1.1/failed.html',t:none,msg:\"Unauthorized administrator request'\""
+      "SecRule REQUEST_URI \"@contains /\" \"id:2000001,phase:1,log,redirect:'http://1.1.1.1/failed.html',t:none,msg:'Unauthorized administrator request'\""
     ]
   }
 ]

--- a/test/test-cases/regression/misc-variable-under-quotes.json
+++ b/test/test-cases/regression/misc-variable-under-quotes.json
@@ -34,7 +34,7 @@
       "debug_log":"t:lowercase:"
     },
     "rules":[  
-      "SecRule \"REQUEST_LINE\" \"@contains index.php/admin/cms/wysiwyg/directive/\" \"id:1,t:lowercase,ctl:auditLogParts=+E\""
+      "SecRule \"REQUEST_LINE\" \"@contains index.php/admin/cms/wysiwyg/directive/\" \"id:1,phase:1,t:lowercase,ctl:auditLogParts=+E\""
     ]
   },
   {  

--- a/test/test-cases/regression/rule-920200.json
+++ b/test/test-cases/regression/rule-920200.json
@@ -18,7 +18,7 @@
         "Accept-Language":"en-us,en;q=0.5",
         "Accept":"*/*",
         "Keep-Alive":"300",
-	"Range": "bytes=1-10,11-20,21-30,31-40,41-50,51-60"
+        "Range": "bytes=1-10,11-20,21-30,31-40,41-50,51-60"
       },
       "uri":"/",
       "method":"GET"


### PR DESCRIPTION
Tests are a very important part of the library. While investigating an issue, I found some errors in the tests that could have led to false results, such as using a non-existent `@contais` operator instead of `@contains`. This PR fixes these and some other cases.