### PR TITLE
fix: Change 'SecEngineStatus' to Off by default

### DIFF
--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -281,5 +281,7 @@ SecUnicodeMapFile unicode.mapping 20127
 # The following information will be shared: ModSecurity version,
 # Web Server version, APR version, PCRE version, Lua version, Libxml2
 # version, Anonymous unique id for host.
+# NB: As of April 2022, there is no longer any advantage to turning this
+# setting On, as there is no active receiver for the information.
 SecStatusEngine Off
 

--- a/modsecurity.conf-recommended
+++ b/modsecurity.conf-recommended
@@ -281,5 +281,5 @@ SecUnicodeMapFile unicode.mapping 20127
 # The following information will be shared: ModSecurity version,
 # Web Server version, APR version, PCRE version, Lua version, Libxml2
 # version, Anonymous unique id for host.
-SecStatusEngine On
+SecStatusEngine Off
 


### PR DESCRIPTION
The default setting of `SecStatusEngine` is `Off` because there is no any advantage to turn that on.

This PR changes the value to `Off`.

Closes #3085.
