### PR TITLE
Align "reference" field value in JSON transaction log with standard log.

### DIFF
--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1806,7 +1806,7 @@ std::string Transaction::toJSON(int parts) {
                 strlen("details"));
             yajl_gen_map_open(g);
             LOGFY_ADD("match", a.m_match.c_str());
-            LOGFY_ADD("reference", a.m_reference.c_str());
+            LOGFY_ADD("reference", utils::string::limitTo(200, a.m_reference).c_str());
             LOGFY_ADD("ruleId", std::to_string(a.m_ruleId).c_str());
             LOGFY_ADD("file", a.m_ruleFile->c_str());
             LOGFY_ADD("lineNumber", std::to_string(a.m_ruleLine).c_str());


### PR DESCRIPTION
Transaction JSON log of "reference" is too verbose for some rules. There is a limit for "ref" field in "standard" log.

file: **rule_message.cc**
```
...
msg.append(" [ref \"" + utils::string::limitTo(200, rm->m_reference) + "\"]");
...
```

but there is no such limit in file: **transaction.cc**
```
...
LOGFY_ADD("reference", a.m_reference.c_str());
...
```

With this fix JSON out will be truncated as standard log.

Before:

```
...
"messages": [
      {
        ....
        "details": {
          "match": "Matched \"Operator `Gt' with parameter `10000' against variable `ARGS_COMBINED_SIZE' (Value: `971714.000000' )",
          "reference": "v0,31v32,32v0,31v32,74v0,32v33,166v0,33v34,5v0,31v32,32v0,30v31,165v0,33v34,193v0,33v34,227v0,33v34,41v0,33v34,47v0,33v34,222v0,35v36,9v0,28v29,10v0,25v26,237v0,35v36,62v0,31v32,20v0,31v32,20v0,31v32,20v0,31v32,19v0,31v32,19v0,31v32,20v0,31v32,20v0,31v32,20v0,31v32,19v0,32v33,19v0,25v26,26v0,25v26,39v0,25v26,321v0,25v26,216v0,25v26,147v0,25v26,229v0,25v26,295v0,25v26,147v0,25v26,219v0,26v27,412v0,26v27,357v0,26v27,254v0,26v27,232v0,26v27,309v0,26v27,76v0,26v27,116v0,26v27,32v0,26v27,346v0,26v27,211v0,26v27,467v0,26v27,363v0,26v27,79v0,26v27,190v0,26v27,205v0,26v27,217v0,33v34,17v0,33v34,17v0,33v34,16v0,33v34,17v0,33v34,17v0,33v34,17v0,33v34,16v0,33v34,17v0,33v34,17v0,34v35,17v0,..... 75 kilobytes of text here,
          "ruleId": "1100",
          "file": "/etc/nginx/modsec/owasp-modsecurity-crs/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf",
          "lineNumber": "209",
         ...
        }
      }
...
```

after the fix:
```
...
"reference":"v0,31v32,32v0,31v32,74v0,32v33,166v0,33v34,5v0,31v32,32v0,30v31,165v0,33v34,193v0,33v34,227v0,33v34,41v0,33v34,47v0,33v34,222v0,35v36,9v0,28v29,10v0,25v26,237v0,35v36,62v0,31v32,20v0,31v32,20v0,31v32, (79218 characters omitted)",
...
```

As long as there is no way to disable the "reference" field in JSON transaction log and the information it contains doesn't look useful in production logs please approve this change. I think the JSON log approach may be reworked later but meanwhile, we need a way to truncate it.



