### PR TITLE
fix: Replace obsolete macros

### DIFF
--- a/build/lua.m4
+++ b/build/lua.m4
@@ -192,29 +192,30 @@ AC_DEFUN([CHECK_FOR_LUA_AT], [
            LUA_DISPLAY="${lua_lib_file}, ${lua_inc_path}"
 
         # Double checking version from lua.h...
-        AC_TRY_COMPILE([ #include <lua.h>> ],
-                         [ #if (LUA_VERSION_NUM < 502)
-                           return 0;
-                           #else
-                           #error Lua 5.1 not detected
-                           #endif ],
-                             [ LUA_VERSION=501 ], [ lua_5_1=0 ]
-                      )
-
-        AC_TRY_COMPILE([ #include <lua.h> ],
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <lua.h> ],
                          [ #if (LUA_VERSION_NUM == 502)
                            return 0;
                            #else
                            #error Lua 5.2 not detected
-                           #endif ],
+                           #endif ]])],
                              [ LUA_VERSION=502 ], [ lua_5_2=0 ]
                       )
-        AC_TRY_COMPILE([ #include <lua.h> ],
+
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <lua.h> ],
+                     [ #if (LUA_VERSION_NUM == 502)
+                           return 0;
+                           #else
+                           #error Lua 5.2 not detected
+                           #endif ]])],
+                             [ LUA_VERSION=502 ], [ lua_5_2=0 ]
+                      )
+
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <lua.h> ],
                          [ #if (LUA_VERSION_NUM == 504)
                            return 0;
                            #else
                            #error Lua 5.4 not detected
-                           #endif ],
+                           #endif ]])],
                              [ LUA_VERSION=504 ], [ lua_5_4=0 ]
                       )
 

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -77,9 +77,11 @@ else
         CFLAGS="${PCRE_CFLAGS} ${CFLAGS}"
         LDFLAGS="${PCRE_LDADD} ${LDFLAGS}"
         LIBS="${PCRE_LDADD} ${LIBS}"
-        AC_TRY_LINK([ #include <pcre.h> ],
-            [ pcre_jit_exec(NULL, NULL, NULL, 0, 0, 0, NULL, 0, NULL); ],
-            [ pcre_jit_available=yes ], [:]
+        AC_LINK_IFELSE(
+            [AC_LANG_PROGRAM([[ #include <pcre.h> ]],
+               [[ pcre_jit_exec(NULL, NULL, NULL, 0, 0, 0, NULL, 0, NULL); ]])],
+            [ pcre_jit_available=yes ],
+            [:]
         )
 
         if test "x$pcre_jit_available" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,6 @@ AM_CONDITIONAL([PCRE2_CFLAGS], [test "PCRE2_CFLAGS" != ""])
 
 
 # Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADERS([string])
 AC_CHECK_HEADERS([iostream])
 AC_CHECK_HEADERS([sys/utsname.h])
@@ -304,7 +303,7 @@ fi
 
 if test $buildParser = true; then
     AC_PROG_YACC
-    AC_PROG_LEX
+    AC_PROG_LEX(noyywrap)
     AC_PATH_PROG([FLEX], [flex])
     test "x$FLEX" = "x" && AC_MSG_ERROR([flex is needed to build ModSecurity])
 


### PR DESCRIPTION
There are some obsolete macros used by `autotools`, this PR fixes them.

See [this mail](https://sourceforge.net/p/mod-security/mailman/message/58731392/) on mailing list.