### PR TITLE
Clean up 'return' never will be executed.

### DIFF
--- a/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
+++ b/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
@@ -102,7 +102,7 @@ struct data_ms {
         delete modsecTransaction;
     }
 
-    pthread_exit(NULL);
+    pthread_exit(nullptr);
 }
 
 

--- a/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
+++ b/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
@@ -103,7 +103,6 @@ static void *process_request(void *data) {
     }
 
     pthread_exit(NULL);
-    return NULL;
 }
 
 
@@ -165,7 +164,6 @@ class ReadingLogsViaRuleMessage {
 
         delete rules;
         delete modsec;
-        pthread_exit(NULL);
         return 0;
     }
 

--- a/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
+++ b/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
@@ -73,7 +73,7 @@ struct data_ms {
 };
 
 
-static void *process_request(void *data) {
+[[noreturn]] static void *process_request(void *data) {
     struct data_ms *a = (struct data_ms *)data;
     modsecurity::ModSecurity *modsec = a->modsec;
     modsecurity::RulesSet *rules = a->rules;

--- a/examples/reading_logs_via_rule_message/simple_request.cc
+++ b/examples/reading_logs_via_rule_message/simple_request.cc
@@ -35,8 +35,5 @@ int main(int argc, char **argv) {
         response_headers, response_body, ip, rules);
     rlvrm.process();
 
-
-
-    pthread_exit(NULL);
     return 0;
 }


### PR DESCRIPTION
Issue reference: https://sonarcloud.io/project/issues?open=AY1CfKFNrsSpWCKX0w9c&id=owasp-modsecurity_ModSecurity

There are three occurrences of this issue. I deleted pthread_exit(NULL) calls, because these execution points are not in
pthread execution scope. In process_request() I kept pthread_exit(NULL) and deleted return(NULL), because here we are
in pthread execution context. 
(FYI: 11.5 Thread Termination in [Advanced Programming in the UNIX® Environment, Third Edition](https://learning.oreilly.com/library/view/advanced-programming-in/9780321638014/))