### PR TITLE
build: don't directly use the .libs directory

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -42,6 +42,7 @@ noinst_HEADERS = \
 
 
 unit_tests_LDADD = \
+	$(top_builddir)/src/libmodsecurity.la \
 	$(CURL_LDADD) \
 	$(GEOIP_LDADD) \
 	$(MAXMIND_LDADD) \
@@ -56,9 +57,7 @@ unit_tests_LDADD = \
 
 
 unit_tests_LDFLAGS = \
-	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
-	-lmodsecurity \
 	-lpthread \
 	-lm \
 	-lstdc++ \
@@ -98,6 +97,7 @@ regression_tests_SOURCES = \
         regression/custom_debug_log.cc
 
 regression_tests_LDADD = \
+	$(top_builddir)/src/libmodsecurity.la \
 	$(CURL_LDADD) \
 	$(GEOIP_LDADD) \
 	$(MAXMIND_LDADD) \
@@ -112,9 +112,7 @@ regression_tests_LDADD = \
 
 
 regression_tests_LDFLAGS = \
-	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
-	-lmodsecurity \
 	-lpthread \
 	-lm \
 	-lstdc++ \
@@ -153,6 +151,7 @@ rules_optimization_SOURCES = \
         optimization/optimization.cc
 
 rules_optimization_LDADD = \
+	$(top_builddir)/src/libmodsecurity.la \
 	$(CURL_LDADD) \
 	$(GEOIP_LDADD) \
 	$(MAXMIND_LDADD) \
@@ -166,9 +165,7 @@ rules_optimization_LDADD = \
 	$(YAJL_LDADD)
 
 rules_optimization_LDFLAGS = \
-	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
-	-lmodsecurity \
 	-lpthread \
 	-lm \
 	-lstdc++ \

--- a/test/benchmark/Makefile.am
+++ b/test/benchmark/Makefile.am
@@ -6,6 +6,7 @@ benchmark_SOURCES = \
         benchmark.cc
 
 benchmark_LDADD = \
+	$(top_builddir)/src/libmodsecurity.la \
 	$(CURL_LDADD) \
 	$(GEOIP_LDADD) \
 	$(MAXMIND_LDADD) \
@@ -18,9 +19,7 @@ benchmark_LDADD = \
 	$(GLOBAL_LDADD)
 
 benchmark_LDFLAGS = \
-	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
-	-lmodsecurity \
 	-lpthread \
 	-lm \
 	-lstdc++ \

--- a/test/fuzzer/Makefile.am
+++ b/test/fuzzer/Makefile.am
@@ -24,7 +24,7 @@ afl_fuzzer_LDADD = \
 	$(SSDEEP_LDFLAGS) $(SSDEEP_LDADD) \
 	$(LUA_LDFLAGS) $(LUA_LDADD) \
 	$(LIBXML2_LDADD) \
-	$(top_builddir)/src/.libs/libmodsecurity.a \
+	$(top_builddir)/src/libmodsecurity.la \
 	$(top_builddir)/others/libinjection.la \
 	$(top_builddir)/others/libmbedtls.la
 

--- a/tools/rules-check/Makefile.am
+++ b/tools/rules-check/Makefile.am
@@ -6,7 +6,7 @@ modsec_rules_check_SOURCES = \
         rules-check.cc
 
 modsec_rules_check_LDADD = \
-	$(top_builddir)/src/.libs/libmodsecurity.la \
+	$(top_builddir)/src/libmodsecurity.la \
 	$(CURL_LDADD) \
 	$(GEOIP_LDADD) \
 	$(MAXMIND_LDADD) \


### PR DESCRIPTION
This is a duplicate of PR https://github.com/owasp-modsecurity/ModSecurity/pull/2980 to try to trigger the CI regression tests.

The build system should not directly use the `.libs` directory which is intended for internal use by the libtool implementation. Additionally when linking with internal a library the `.la` file should be used as this provides all the information required by the libtool implementation.

When using Slibtool instead of GNU Libtool the build fails because Slibtool is more strict about this and fails to find the required files to link with.

Gentoo Bug: https://bugs.gentoo.org/913484