### PR TITLE
Ep/scoped for: second pr

### DIFF
--- a/src/actions/transformations/hex_decode.cc
+++ b/src/actions/transformations/hex_decode.cc
@@ -58,13 +58,13 @@ std::string HexDecode::evaluate(const std::string &value,
 
 int HexDecode::inplace(unsigned char *data, int len) {
     unsigned char *d = data;
-    int i, count = 0;
+    int count = 0;
 
     if ((data == NULL) || (len == 0)) {
         return 0;
     }
 
-    for (i = 0; i <= len - 2; i += 2) {
+    for (int i = 0;i <= len - 2;i += 2) {
         *d++ = utils::string::x2c(&data[i]);
         count++;
     }

--- a/src/operators/verify_cc.cc
+++ b/src/operators/verify_cc.cc
@@ -59,7 +59,6 @@ int VerifyCC::luhnVerify(const char *ccnumber, int len) {
     int sum[2] = { 0, 0 };
     int odd = 0;
     int digits = 0;
-    int i;
 
     /* Weighted lookup table which is just a precalculated (i = index):
      *   i*2 + (( (i*2) > 9 ) ? -9 : 0)
@@ -71,7 +70,7 @@ int VerifyCC::luhnVerify(const char *ccnumber, int len) {
     /* Add up only digits (weighted digits via lookup table)
      * for both odd and even CC numbers to avoid 2 passes.
      */
-    for (i = 0; i < len; i++) {
+    for (int i = 0;i < len;i++) {
         if (ccnumber[i] >= (0 + 48) && ccnumber[i] <= (9 + 48)) {
             sum[0] += (!odd ? wtable[ccnumber[i] - '0'] : (ccnumber[i] - '0'));
             sum[1] += (odd ? wtable[ccnumber[i] - '0'] : (ccnumber[i] - '0'));

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -231,7 +231,7 @@ int Multipart::boundary_characters_valid(const char *boundary) {
 
 
 void Multipart::validate_quotes(const char *data, char quote)  {
-    int i, len;
+    int len;
 
     if (data == NULL)
         return;
@@ -244,7 +244,7 @@ void Multipart::validate_quotes(const char *data, char quote)  {
 
     len = strlen(data);
 
-    for (i = 0; i < len; i++)   {
+    for (int i = 0;i < len;i++)   {
         if (data[i] == '\'') {
             ms_dbg_a(m_transaction, 9,
                 "Multipart: Invalid quoting detected: " \

--- a/src/utils/acmp.cc
+++ b/src/utils/acmp.cc
@@ -190,10 +190,9 @@ static size_t acmp_strlen(ACMP *parser, const char *str) {
  *       len - length of input string
  */
 static void acmp_strtoucs(ACMP *parser, const char *str, long *ucs_chars, int len) {
-    int i;
     const char *c = str;
 
-    for (i = 0; i < len; i++) {
+    for (int i = 0;i < len;i++) {
         *(ucs_chars++) = *(c++);
     }
 }


### PR DESCRIPTION
this is the second request to do a merge for this topic of reducing the scope of variables in a for loop. Compared to the previous PR, the modification to the seclang-parser.cc file has been eliminated, as this is a file generated by lex.