### PR TITLE
Fix possible segfault in collection_unpack

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 DD mmm YYYY - 2.9.x (to be released)
 -------------------
 
+ * Fix possible segfault in collection_unpack
+   [Issue #3072 - @twouters]
  * Set the minimum security protocol version for SecRemoteRules
    [Issue security/code-scanning/2 - @airween]
  * Allow lua version 5.4

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -59,7 +59,7 @@ static apr_table_t *collection_unpack(modsec_rec *msr, const unsigned char *blob
         }
 
         blob_offset += 2;
-        if (blob_offset + var->name_len > blob_size) return NULL;
+        if (var->name_len < 1 || blob_offset + var->name_len > blob_size) return NULL;
         var->name = apr_pstrmemdup(msr->mp, (const char *)blob + blob_offset, var->name_len - 1);
         blob_offset += var->name_len;
         var->name_len--;
@@ -67,7 +67,7 @@ static apr_table_t *collection_unpack(modsec_rec *msr, const unsigned char *blob
         var->value_len = (blob[blob_offset] << 8) + blob[blob_offset + 1];
         blob_offset += 2;
 
-        if (blob_offset + var->value_len > blob_size) return NULL;
+        if (var->value_len < 1 || blob_offset + var->value_len > blob_size) return NULL;
         var->value = apr_pstrmemdup(msr->mp, (const char *)blob + blob_offset, var->value_len - 1);
         blob_offset += var->value_len;
         var->value_len--;


### PR DESCRIPTION
When var->value_len somehow becomes 0, we risk wrapping around to 4294967295 due to it being an unsigned int.

Fixes #3082