### PR TITLE
V3/remove this throw call transaction h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: build.sh
         run: ./build.sh
       - name: configure ${{ matrix.configure.label }}
-        run: ./configure ${{ matrix.configure.opt }}
+        run: ./configure ${{ matrix.configure.opt }} --enable-assertions=yes
       - uses: ammaraskar/gcc-problem-matcher@master
       - name: make
         run: make -j `nproc`
@@ -66,7 +66,7 @@ jobs:
       - name: build.sh
         run: ./build.sh
       - name: configure ${{ matrix.configure.label }}
-        run: ./configure ${{ matrix.configure.opt }}
+        run: ./configure ${{ matrix.configure.opt }} --enable-assertions=yes
       - uses: ammaraskar/gcc-problem-matcher@master
       - name: make
         run: make -j `sysctl -n hw.logicalcpu`

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ $ cd test
 $ ./regression-tests
 $ ./unit-tests
  ```
+Please take care that the '<path/to/modsecurity>/test/cppcheck_suppressions.txt'
+file contains hardcoded 'filename:line number' suppressions. If you modify a
+file with explicit suppressions, you must update the 'cppcheck_suppressions.txt'
+accordingly to ensure the suppression references remain aligned with the
+intended lines of code. Failing to do so might trigger 'make check-static' to
+break the build with errors that are logically unrelated to your modifications.
 
 ### Debugging
 
@@ -235,7 +241,12 @@ $ ./configure --enable-assertions=yes
 $ make
 $ sudo make install
 ```
+"Assertions allow us to document assumptions and to spot violations early in the
+development process. What is more, assertions allow us to spot violations with a
+minimum of effort." https://dl.acm.org/doi/pdf/10.1145/240964.240969
 
+It is recommended to use assertions where applicable, and to enable them with
+'--enable-assertions=yes' during the testing and debugging workflow.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ CFLAGS to disable the compilation optimization parameters:
 ```shell
 $ export CFLAGS="-g -O0"
 $ ./build.sh
-$ ./configure
+$ ./configure --enable-assertions=yes
 $ make
 $ sudo make install
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ AC_ARG_ENABLE(assertions,
     [case "${enableval}" in
         yes) assertions=true ;;
         no)  assertions=false ;;
-        *) AC_MSG_ERROR(bad value ${enableval} for --enable-asserions) ;;
+        *) AC_MSG_ERROR(bad value ${enableval} for --enable-assertions) ;;
     esac],
 
     [assertions=false]
@@ -369,10 +369,12 @@ if test "$aflFuzzer" == "true"; then
     $buildExamples = false
 fi
 
-if test "$assertions" == "false"; then
-    ASSERTIONS_CPPCFLAGS="-DNDEBUG"
-    GLOBAL_CPPFLAGS="$GLOBAL_CPPFLAGS $ASSERTIONS_CPPCFLAGS"
-fi
+case $assertions in
+    false) ASSERTIONS_CPPCFLAGS="-DNDEBUG" ;;
+    true) ASSERTIONS_CPPCFLAGS="-UNDEBUG" ;;
+    *) AC_MSG_ERROR(bad value ${assertions} for assertions) ;;
+esac
+GLOBAL_CPPFLAGS="$GLOBAL_CPPFLAGS $ASSERTIONS_CPPCFLAGS"
 
 AC_SUBST(GLOBAL_LDADD)
 AC_SUBST(GLOBAL_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -227,6 +227,19 @@ MSC_GIT_VERSION=msc_version_git
 AC_SUBST([MSC_GIT_VERSION])
 
 
+
+AC_ARG_ENABLE(assertions,
+    [AS_HELP_STRING([--enable-assertions],[Turn on assertions feature: undefine NDEBUG])],
+
+    [case "${enableval}" in
+        yes) assertions=true ;;
+        no)  assertions=false ;;
+        *) AC_MSG_ERROR(bad value ${enableval} for --enable-asserions) ;;
+    esac],
+
+    [assertions=false]
+    )
+
 AC_ARG_ENABLE(debug-logs,
     [AS_HELP_STRING([--disable-debug-logs],[Turn off the SecDebugLog feature])],
 
@@ -355,6 +368,12 @@ if test "$aflFuzzer" == "true"; then
     GLOBAL_CPPFLAGS="$GLOBAL_CPPFLAGS $FUZZ_CPPCFLAGS"
     $buildExamples = false
 fi
+
+if test "$assertions" == "false"; then
+    ASSERTIONS_CPPCFLAGS="-DNDEBUG"
+    GLOBAL_CPPFLAGS="$GLOBAL_CPPFLAGS $ASSERTIONS_CPPCFLAGS"
+fi
+
 AC_SUBST(GLOBAL_LDADD)
 AC_SUBST(GLOBAL_CPPFLAGS)
 
@@ -589,6 +608,14 @@ if test $buildTestUtilities = true; then
 else
     echo "   + Test Utilities                                ....disabled"
 fi
+
+
+if test $assertions = true; then
+    echo "   + Assertions                                    ....enabled"
+else
+    echo "   + Assertions                                    ....disabled"
+fi
+
 if test $debugLogs = true; then
     echo "   + SecDebugLog                                   ....enabled"
 else

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -321,7 +321,7 @@ class TransactionSecMarkerManagement {
     }
 
  private:
-    std::shared_ptr<std::string> m_marker = nullptr;
+    std::shared_ptr<std::string> m_marker;
 };
 
 /** @ingroup ModSecurity_CPP_API */

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -308,7 +308,7 @@ class TransactionSecMarkerManagement {
     }
 
     std::shared_ptr<std::string> getCurrentMarker() const {
-        assert(m_marker != nullptr);
+      assert((m_marker != nullptr) && "You might have forgotten to call and evaluate isInsideAMarker() before calling getCurrentMarker().");
         return m_marker;
     }
 

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -14,6 +14,7 @@
  */
 
 #ifdef __cplusplus
+#include <cassert>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
@@ -307,11 +308,8 @@ class TransactionSecMarkerManagement {
     }
 
     std::shared_ptr<std::string> getCurrentMarker() const {
-        if (m_marker) {
-            return m_marker;
-        } else {
-            throw;
-        }
+        assert(m_marker != nullptr);
+        return m_marker;
     }
 
     void removeMarker() {
@@ -323,7 +321,7 @@ class TransactionSecMarkerManagement {
     }
 
  private:
-    std::shared_ptr<std::string> m_marker;
+    std::shared_ptr<std::string> m_marker = nullptr;
 };
 
 /** @ingroup ModSecurity_CPP_API */

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -122,7 +122,7 @@ RuleWithActions::RuleWithActions(
                     m_actionsRuntimePos.push_back(a);
                 }
             } else {
-                assert(false); // Not implemented
+                assert(false && "The handling of RunTimeBeforeMatchAttemptKind has not been implemented yet.");
                 delete a;
             }
         }

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -127,9 +127,6 @@ RuleWithActions::RuleWithActions(
                     std::cout << "General failure, action: " << a->m_name;
                     std::cout << " has an unknown type." << std::endl;
                     delete a;
-                    #ifdef NDEBUG
-                    break;
-                    #endif
                     assert(false);
             }
         }

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -127,7 +127,11 @@ RuleWithActions::RuleWithActions(
                     std::cout << "General failure, action: " << a->m_name;
                     std::cout << " has an unknown type." << std::endl;
                     delete a;
+                    #ifdef NDEBUG
+                    break;
+                    #else
                     assert(false);
+                    #endif
             }
         }
         delete actions;

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -248,7 +248,7 @@ void RuleWithActions::executeActionsAfterFullMatch(Transaction *trans,
     bool containsBlock, std::shared_ptr<RuleMessage> ruleMessage) {
     bool disruptiveAlreadyExecuted = false;
 
-    for (auto &a : trans->m_rules->m_defaultActions[getPhase()]) { // cppcheck_suppressions.txt:55
+    for (const auto &a : trans->m_rules->m_defaultActions[getPhase()]) { // cppcheck_suppressions.txt:55
         if (a.get()->action_kind != actions::Action::RunTimeOnlyIfMatchKind) {
             continue;
         }

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 
+#include <cassert>
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -121,10 +122,8 @@ RuleWithActions::RuleWithActions(
                     m_actionsRuntimePos.push_back(a);
                 }
             } else {
+                assert(false); // Not implemented
                 delete a;
-                std::cout << "General failure, action: " << a->m_name;
-                std::cout << " has an unknown type." << std::endl;
-                throw;
             }
         }
         delete actions;

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -52,7 +52,7 @@ noConstructor:src/variables/variable.h:152
 danglingTempReference:src/modsecurity.cc:206
 knownConditionTrueFalse:src/operators/validate_url_encoding.cc:77
 knownConditionTrueFalse:src/operators/verify_svnr.cc:87
-ctunullpointer:src/rule_with_actions.cc:250
+ctunullpointer:src/rule_with_actions.cc:247
 ctunullpointer:src/rule_with_operator.cc:135
 ctunullpointer:src/rule_with_operator.cc:95
 passedByValue:test/common/modsecurity_test.cc:49

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -52,7 +52,7 @@ noConstructor:src/variables/variable.h:152
 danglingTempReference:src/modsecurity.cc:206
 knownConditionTrueFalse:src/operators/validate_url_encoding.cc:77
 knownConditionTrueFalse:src/operators/verify_svnr.cc:87
-ctunullpointer:src/rule_with_actions.cc:243
+ctunullpointer:src/rule_with_actions.cc:250
 ctunullpointer:src/rule_with_operator.cc:135
 ctunullpointer:src/rule_with_operator.cc:95
 passedByValue:test/common/modsecurity_test.cc:49

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -52,7 +52,7 @@ noConstructor:src/variables/variable.h:152
 danglingTempReference:src/modsecurity.cc:206
 knownConditionTrueFalse:src/operators/validate_url_encoding.cc:77
 knownConditionTrueFalse:src/operators/verify_svnr.cc:87
-ctunullpointer:src/rule_with_actions.cc:247
+ctunullpointer:src/rule_with_actions.cc:251
 ctunullpointer:src/rule_with_operator.cc:135
 ctunullpointer:src/rule_with_operator.cc:95
 passedByValue:test/common/modsecurity_test.cc:49

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -52,9 +52,7 @@ noConstructor:src/variables/variable.h:152
 danglingTempReference:src/modsecurity.cc:206
 knownConditionTrueFalse:src/operators/validate_url_encoding.cc:77
 knownConditionTrueFalse:src/operators/verify_svnr.cc:87
-rethrowNoCurrentException:headers/modsecurity/transaction.h:313
-rethrowNoCurrentException:src/rule_with_actions.cc:127
-ctunullpointer:src/rule_with_actions.cc:244
+ctunullpointer:src/rule_with_actions.cc:243
 ctunullpointer:src/rule_with_operator.cc:135
 ctunullpointer:src/rule_with_operator.cc:95
 passedByValue:test/common/modsecurity_test.cc:49


### PR DESCRIPTION
Introducing the use of assertions to address throw; calls that lack try-catch blocks. Upon examining the caller code that utilized methods containing the questioned throw; calls, it became clear that, in the current state of development, there are no scenarios where execution could reach these throw; calls. However, we cannot guarantee this for future development. For instance, if someone attempts to use getCurrentMarker() without first verifying isInsideAMarker(), ModSecurity would encounter the throw; and terminate. The issue with the other throw; call is similar in that it is, fortunately, unreachable at the moment. However, it differs because this throw; is intended to handle a case that has not yet been developed.

Fortunately, I found an article titled "Effective Use of Assertions in C++" by Mike A. Martin in (ACM SIGPLAN Language Tips, page 3), which offers a neat way to handle such cases, specifically regarding argument validation and unreachable code. [Link to the article](https://dl.acm.org/doi/pdf/10.1145/240964.240969).

Following the guidance from this article, I addressed the issues and also included modifications to enrich assert error messages. Furthermore, I updated configure.ac to maintain the usual build procedure and modified README.md to introduce the new configure flag.