### PR TITLE
Deleted redundant code in 'ModSecurity::serverLog(...)'.

### DIFF
--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -210,10 +210,6 @@ void ModSecurity::serverLog(void *data, std::shared_ptr<RuleMessage> rm) {
 
     if (m_logProperties & RuleMessageLogProperty) {
         const void *a = static_cast<const void *>(rm.get());
-        if (m_logProperties & IncludeFullHighlightLogProperty) {
-            m_logCb(data, a);
-            return;
-        }
         m_logCb(data, a);
         return;
     }


### PR DESCRIPTION
The complete 'if (...) {...}' construction can be removed because the same code is executed immediately after the 'if (...) {...}' construction. When the condition evaluates to true, the same data is logged twice.