### PR TITLE
fix: Changed 'equal_range()' + loop by 'find()' in resolveFirst() methods

### DIFF
--- a/src/anchored_set_variable.cc
+++ b/src/anchored_set_variable.cc
@@ -111,9 +111,7 @@ std::unique_ptr<std::string> AnchoredSetVariable::resolveFirst(
     const std::string &key) {
 
     if (auto search = this->find(key); search != this->end()) {
-        auto b = std::make_unique<std::string>();
-        b->assign(search->second->getValue());
-        return b;
+        return std::make_unique<std::string>(search->second->getValue());
     }
 
     return nullptr;

--- a/src/anchored_set_variable.cc
+++ b/src/anchored_set_variable.cc
@@ -109,12 +109,13 @@ void AnchoredSetVariable::resolve(const std::string &key,
 
 std::unique_ptr<std::string> AnchoredSetVariable::resolveFirst(
     const std::string &key) {
-    auto range = equal_range(key);
-    for (auto it = range.first; it != range.second; ++it) {
-        std::unique_ptr<std::string> b(new std::string());
-        b->assign(it->second->getValue());
+
+    if (auto search = this->find(key); search != this->end()) {
+        auto b = std::make_unique<std::string>();
+        b->assign(search->second->getValue());
         return b;
     }
+
     return nullptr;
 }
 

--- a/src/collection/backend/in_memory-per_process.cc
+++ b/src/collection/backend/in_memory-per_process.cc
@@ -67,13 +67,13 @@ bool InMemoryPerProcess::storeOrUpdateFirst(const std::string &key,
 bool InMemoryPerProcess::updateFirst(const std::string &key,
     const std::string &value) {
     pthread_mutex_lock(&m_lock);
-    auto range = this->equal_range(key);
 
-    for (auto it = range.first; it != range.second; ++it) {
-        it->second.setValue(value);
+    if (auto search = this->find(key); search != this->end()) {
+        search->second.setValue(value);
         pthread_mutex_unlock(&m_lock);
         return true;
     }
+
     pthread_mutex_unlock(&m_lock);
     return false;
 }
@@ -97,11 +97,11 @@ void InMemoryPerProcess::delIfExpired(const std::string& key) {
 
 void InMemoryPerProcess::setExpiry(const std::string& key, int32_t expiry_seconds) {
     pthread_mutex_lock(&m_lock);
-    auto range = this->equal_range(key);
-    for (auto it = range.first; it != range.second; ++it) {
-        it->second.setExpiry(expiry_seconds);
+
+    if (auto search = this->find(key); search != this->end()) {
+        search->second.setExpiry(expiry_seconds);
         pthread_mutex_unlock(&m_lock);
-	return;
+        return;
     }
 
     // We allow an expiry value to be set for a key that has not (yet) had a value set.


### PR DESCRIPTION
This PR fixes SonarCloud issues in these files:

* [src/anchored_set_variable.cc](https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=owasp-modsecurity_ModSecurity&open=AY1CfJ_hrsSpWCKX0wV6)
* [src/collection/backend/in_memory-per_process.cc](https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=owasp-modsecurity_ModSecurity&open=AY1CfJ-3rsSpWCKX0wUJ) and one [more](https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=owasp-modsecurity_ModSecurity&open=AY1CfJ-3rsSpWCKX0wUM) place

Summary: [AnchoredSetVariable](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/headers/modsecurity/anchored_set_variable.h#L71) and [InMemoryCollection](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/src/collection/backend/in_memory-per_process.h#L72-L73) types are derived from [std::unordered_multimap](https://en.cppreference.com/w/cpp/container/unordered_multimap).

Both type has a `resolveFirst(key)` method ([AnchoredSetVariable](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/src/anchored_set_variable.cc#L110-L119), [InMemoryCollection](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/src/collection/backend/in_memory-per_process.cc#L226-L240)), which finds the first occurrence of key in the collection.

The current implemented version uses `equal_range()` ([doc](https://en.cppreference.com/w/cpp/container/unordered_multimap/equal_range)) to find the key in a loop, and breaks from that after first match. This C++ collection has another method to find it where we don't need any loop, that's the `find()` ([doc](https://en.cppreference.com/w/cpp/container/unordered_multimap/find)).