### PR TITLE
feat: Allow regular expressions in ctl:ruleRemoveTargetByX variable names II.

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -66,6 +66,7 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
     char *errptr;
     int erroffset;
     int match = 0;
+    size_t value_len;
 
     if(msr == NULL)
         return 0;
@@ -114,12 +115,17 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
                     value = NULL;
                 }
 
+                value_len = 0;
+                if (value != NULL) {
+                    value_len = strlen(value);
+                }
+
                 if((strlen(myname) == strlen(name)) &&
-                        (strncasecmp(myname, name,strlen(myname)) == 0))   {
+                        (strncasecmp(myname, name, strlen(myname)) == 0))   {
 
                     if(value != NULL && myvalue != NULL)  {
-                        if(strlen(value) > 2 && value[0] == '/' && value[strlen(value) - 1] == '/') {
-                            value[strlen(value) - 1] = '\0';
+                        if(value_len > 2 && value[0] == '/' && value[value_len - 1] == '/') {
+                            value[value_len - 1] = '\0';
 #ifdef WITH_PCRE2
                             regex = msc_pregcomp(msr->mp, value + 1,
                                         PCRE2_DOTALL | PCRE2_CASELESS | PCRE2_DOLLAR_ENDONLY, (const char **)&errptr, &erroffset);
@@ -154,7 +160,7 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
                                     match = 1;
                                 }
                             }
-                        } else if((strlen(myvalue) == strlen(value)) &&
+                        } else if((strlen(myvalue) == value_len) &&
                                 strncasecmp(myvalue,value,strlen(myvalue)) == 0) {
                             if (msr->txcfg->debuglog_level >= 9) {
                                 msr_log(msr, 9, "fetch_target_exception: Target %s will not be processed.", target);

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -167,12 +167,7 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
                             }
                             match = 1;
                         }
-                    } else if (value == NULL && myvalue == NULL)    {
-                        if (msr->txcfg->debuglog_level >= 9) {
-                            msr_log(msr, 9, "fetch_target_exception: Target %s will not be processed.", target);
-                        }
-                        match = 1;
-                    } else if (value == NULL && myvalue != NULL)   {
+                    } else {
                         if (msr->txcfg->debuglog_level >= 9) {
                             msr_log(msr, 9, "fetch_target_exception: Target %s will not be processed.", target);
                         }

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -129,8 +129,18 @@ static int fetch_target_exception(msre_rule *rule, modsec_rec *msr, msre_var *va
 #endif
                             if (regex == NULL) {
                                 if (msr->txcfg->debuglog_level >= 9) {
+#ifdef WITH_PCRE2
+                                    // in case of PCRE2 the errptr won't fill
+                                    msr_log(msr, 9, "fetch_target_exception: Regexp /%s/ failed to compile at pos %d.",
+                                            value + 1, erroffset);
+                                    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, " ModSecurity: exclusion regexp /%s/ failed to compile at pos %d.",
+                                            value + 1, erroffset);
+#else
                                     msr_log(msr, 9, "fetch_target_exception: Regexp /%s/ failed to compile at pos %d: %s.",
                                             value + 1, erroffset, errptr);
+                                    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, " ModSecurity: exclusion regexp /%s/ failed to compile at pos %d: %s.",
+                                            value + 1, erroffset, errptr);
+#endif
                                 }
                             } else {
 #ifdef WITH_PCRE2


### PR DESCRIPTION
This PR is the renewal and addition of the PR #1683, and solves #911.

Example:
```
SecRule REQUEST_URI "@beginswith /index.php"
    "id:1001,phase:1,pass,nolog,
    ctl:ruleRemoveTargetById=942100;ARGS:/^password[\d+]$/"
```

The new patch works with PCRE2 too.

Actually it is only for v2, so until there is no patch for v3 I don't want to merge it (hope I can do that soon).

Many thanks for your work, @vvidic, the credit is yours.