### PR TITLE
fix: remove usage of insecure tmpnam

### DIFF
--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -131,6 +131,7 @@ int acquire_global_lock(apr_global_mutex_t *lock, apr_pool_t *mp) {
     // get platform temp dir
     rc = apr_temp_dir_get(&temp_dir, mp);
     if (rc != APR_SUCCESS) {
+        ap_log_perror(APLOG_MARK, APLOG_ERR, 0, NULL, "ModSecurity: Could not get temp dir");
         return -1;
     }
 
@@ -139,6 +140,7 @@ int acquire_global_lock(apr_global_mutex_t *lock, apr_pool_t *mp) {
 
     rc = apr_file_mktemp(&lock_name, path, 0, mp);
     if (rc != APR_SUCCESS) {
+        ap_log_perror(APLOG_MARK, APLOG_ERR, 0, NULL, " ModSecurity: Could not create temporary file for global lock");
         return -1;
     }
     // below func always return APR_SUCCESS
@@ -146,6 +148,7 @@ int acquire_global_lock(apr_global_mutex_t *lock, apr_pool_t *mp) {
 
     rc = apr_global_mutex_create(&lock, filename, APR_LOCK_DEFAULT, mp);
     if (rc != APR_SUCCESS) {
+        ap_log_perror(APLOG_MARK, APLOG_ERR, 0, NULL, " ModSecurity: Could not create global mutex");
         return -1;
     }
     return APR_SUCCESS;

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -122,6 +122,34 @@ msc_engine *modsecurity_create(apr_pool_t *mp, int processing_mode) {
     return msce;
 }
 
+int acquire_global_lock(apr_global_mutex_t *lock, apr_pool_t *mp) {
+    apr_status_t rc;
+    apr_file_t *lock_name;
+    const char *temp_dir;
+    const char *filename;
+
+    // get platform temp dir
+    rc = apr_temp_dir_get(&temp_dir, mp);
+    if (rc != APR_SUCCESS) {
+        return -1;
+    }
+
+    // use temp path template for lock files
+    char *path = apr_pstrcat(mp, temp_dir, GLOBAL_LOCK_TEMPLATE, NULL);
+
+    rc = apr_file_mktemp(&lock_name, path, 0, mp);
+    if (rc != APR_SUCCESS) {
+        return -1;
+    }
+    // below func always return APR_SUCCESS
+    apr_file_name_get(&filename, lock_name);
+
+    rc = apr_global_mutex_create(&lock, filename, APR_LOCK_DEFAULT, mp);
+    if (rc != APR_SUCCESS) {
+        return -1;
+    }
+    return APR_SUCCESS;
+}
 /**
  * Initialise the modsecurity engine. This function must be invoked
  * after configuration processing is complete as Apache needs to know the
@@ -129,12 +157,6 @@ msc_engine *modsecurity_create(apr_pool_t *mp, int processing_mode) {
  */
 int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     apr_status_t rc;
-    apr_file_t *auditlog_lock_name;
-    apr_file_t *geo_lock_name;
-    apr_file_t *dbm_lock_name;
-
-    // use temp path template for lock files
-    char *path = apr_pstrcat(p, temp_dir, "/modsec-lock-tmp.XXXXXX", NULL);
 
     msce->auditlog_lock = msce->geo_lock = NULL;
 #ifdef GLOBAL_COLLECTION_LOCK
@@ -151,12 +173,8 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 #ifdef WITH_CURL
     curl_global_init(CURL_GLOBAL_ALL);
 #endif
-    /* Serial audit log mutext */
-    rc = apr_file_mktemp(&auditlog_lock_name, path, 0, p)
-    if (rc != APR_SUCCESS) {
-        return -1
-    }
-    rc = apr_global_mutex_create(&msce->auditlog_lock, auditlog_lock_name, APR_LOCK_DEFAULT, mp);
+    /* Serial audit log mutex */
+    rc = acquire_global_lock(msce->auditlog_lock, mp);
     if (rc != APR_SUCCESS) {
         return -1;
     }
@@ -175,11 +193,7 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
     }
 #endif /* SET_MUTEX_PERMS */
 
-    rc = apr_file_mktemp(&geo_lock_name, path, 0, p)
-    if (rc != APR_SUCCESS) {
-        return -1
-    }
-    rc = apr_global_mutex_create(&msce->geo_lock, geo_lock_name, APR_LOCK_DEFAULT, mp);
+    rc = acquire_global_lock(msce->geo_lock, mp);
     if (rc != APR_SUCCESS) {
         return -1;
     }
@@ -196,11 +210,7 @@ int modsecurity_init(msc_engine *msce, apr_pool_t *mp) {
 #endif /* SET_MUTEX_PERMS */
 
 #ifdef GLOBAL_COLLECTION_LOCK
-    rc = apr_file_mktemp(&dbm_lock_name, path, 0, p)
-    if (rc != APR_SUCCESS) {
-        return -1
-    }
-    rc = apr_global_mutex_create(&msce->dbm_lock, dbm_lock_name, APR_LOCK_DEFAULT, mp);
+    rc = acquire_global_lock(&msce->dbm_lock, mp);
     if (rc != APR_SUCCESS) {
         return -1;
     }

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -705,6 +705,9 @@ struct msc_parm {
     int                     pad_2;
 };
 
+/* Reusable functions */
+int acquire_global_lock(apr_global_mutex_t *lock, apr_pool_t *mp);
+
 /* Engine functions */
 
 msc_engine DSOLOCAL *modsecurity_create(apr_pool_t *mp, int processing_mode);

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -135,11 +135,7 @@ typedef struct msc_parm msc_parm;
 
 #define FATAL_ERROR "ModSecurity: Fatal error (memory allocation or unexpected internal error)!"
 
-static char auditlog_lock_name[L_tmpnam];
-static char geo_lock_name[L_tmpnam];
-#ifdef GLOBAL_COLLECTION_LOCK
-static char dbm_lock_name[L_tmpnam];
-#endif
+#define GLOBAL_LOCK_TEMPLATE "/modsec-lock-tmp.XXXXXX"
 
 extern DSOLOCAL char *new_server_signature;
 extern DSOLOCAL char *real_server_signature;


### PR DESCRIPTION
## what

- remove usage of tmpnam
- apr has primitives for file handling and unique name creation
- encapsulate mutex creation in one function `acquire_global_lock` so we DRY
- create the temporary file template (`GLOBAL_LOCK_TEMPLATE`) as a definition outside a function
- move preprocessor directives into the new function
- add prototype to modsecurity.h file to enable other functions to create global locks (if needed)

## why

- tmpnam is considered unsafe

## drawbacks

- static memory usage goes up a bit: `L_tmpnam` is 20 bytes, and `APR_MAX_PATH` should be ~ 4096.

## references

- https://sonarcloud.io/project/security_hotspots?id=owasp-modsecurity_ModSecurity&pullRequest=3148&sinceLeakPeriod=true