### PR TITLE
Use standard apache logging format in error log

### DIFF
--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -103,17 +103,17 @@ static int server_limit, thread_limit;
 *
 * \param mp Pointer to memory pool
 */
-static void version(apr_pool_t *mp) {
+static void version(apr_pool_t *mp, server_rec* s) {
     char *pcre_vrs = NULL;
     const char *pcre_loaded_vrs = NULL;
     char pcre2_loaded_vrs_buffer[80] ={0};
 
-    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
+    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
             "ModSecurity: APR compiled version=\"%s\"; "
             "loaded version=\"%s\"", APR_VERSION_STRING, apr_version_string());
 
     if (strstr(apr_version_string(), APR_VERSION_STRING) == NULL)    {
-        ap_log_error(APLOG_MARK, APLOG_WARNING, 0, NULL, "ModSecurity: Loaded APR do not match with compiled!");
+        ap_log_error(APLOG_MARK, APLOG_WARNING, 0, s, "ModSecurity: Loaded APR do not match with compiled!");
     }
 
 #ifdef WITH_PCRE2
@@ -125,7 +125,7 @@ static void version(apr_pool_t *mp) {
     pcre_loaded_vrs = pcre_version();
 #endif
 
-    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
+    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
 #ifdef WITH_PCRE2
             "ModSecurity: PCRE2 compiled version=\"%s\"; "
 #else
@@ -134,21 +134,21 @@ static void version(apr_pool_t *mp) {
             "loaded version=\"%s\"", pcre_vrs, pcre_loaded_vrs);
 
     if (strstr(pcre_loaded_vrs,pcre_vrs) == NULL)    {
-        ap_log_error(APLOG_MARK, APLOG_WARNING, 0, NULL, "ModSecurity: Loaded PCRE do not match with compiled!");
+        ap_log_error(APLOG_MARK, APLOG_WARNING, 0, s, "ModSecurity: Loaded PCRE do not match with compiled!");
     }
 
     /* Lua version function was removed in current 5.1. Need to check in future versions if it's back */
 #if defined(WITH_LUA)
-    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
+    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
             "ModSecurity: LUA compiled version=\"%s\"", LUA_VERSION);
 #endif /* WITH_LUA */
 
 #ifdef WITH_YAJL
-    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
+    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
             "ModSecurity: YAJL compiled version=\"%d.%d.%d\"", YAJL_MAJOR, YAJL_MINOR, YAJL_MICRO);
 #endif /* WITH_YAJL */
 
-    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
+    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
             "ModSecurity: LIBXML compiled version=\"%s\"", LIBXML_DOTTED_VERSION);
 }
 
@@ -778,7 +778,7 @@ static int hook_post_config(apr_pool_t *mp, apr_pool_t *mp_log, apr_pool_t *mp_t
         ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, s,
                 "%s configured.", MODSEC_MODULE_NAME_FULL);
 
-        version(mp);
+        version(mp, s);
 
         /* If we've changed the server signature make note of the original. */
         if (new_server_signature != NULL) {


### PR DESCRIPTION
All credits to @arminabf  - see https://github.com/owasp-modsecurity/ModSecurity/pull/1997

Use the server context, like in all other places to use standard httpd format