### PR TITLE
Simplify checkout of submodules in GitHub workflows (with support for git describe)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,9 @@ jobs:
           sudo apt-get install -y libgeoip-dev:${{ matrix.platform.arch }} \
                                   libfuzzy-dev:${{ matrix.platform.arch }}
       - uses: actions/checkout@v4
-      - name: get submodules
-        # get submodules manually for git describe to work during build
-        run: |
-          git submodule init
-          git submodule update
+        with:
+          submodules: true
+          fetch-depth: 0
       - name: build.sh
         run: ./build.sh
       - name: configure
@@ -108,11 +106,9 @@ jobs:
                        bison \
                        flex
       - uses: actions/checkout@v4
-      - name: get submodules
-        # get submodules manually for git describe to work during build
-        run: |
-          git submodule init
-          git submodule update
+        with:
+          submodules: true
+          fetch-depth: 0
       - name: build.sh
         run: ./build.sh
       - name: configure
@@ -141,11 +137,9 @@ jobs:
           - {label: "wo libxml",  opt: "-WITHOUT_LIBXML2=ON" }
     steps:
       - uses: actions/checkout@v4
-      - name: Get submodules
-        # get submodules manually for git describe to work during build
-        run: |
-          git submodule init
-          git submodule update
+        with:
+          submodules: true
+          fetch-depth: 0
       - name: Install Conan
         run: |
           pip3 install conan --upgrade
@@ -188,10 +182,11 @@ jobs:
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install -y cppcheck
-      - name: Get libModSecurity v3 source
+      - name: Checkout source
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
       - name: Configure libModSecurity
         run: |
           ./build.sh

--- a/build/win32/docker/Dockerfile
+++ b/build/win32/docker/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR C:\
 RUN cmd.exe /C md %SRC_DIR%
 
 # libModSecurity
-WORKDIR ${SCR_DIR}
+WORKDIR ${SRC_DIR}
 
 ARG MOD_SECURITY_TAG=v3/master
 RUN git clone -c advice.detachedHead=false --depth 1 --branch %MOD_SECURITY_TAG% https://github.com/owasp-modsecurity/ModSecurity.git


### PR DESCRIPTION
## what

Checkout submodules in the GitHub QA workflows with the `checkout` action, but using the `fetch-depth: 0` parameter to 'fetch all history for all tags and branches' for the `git describe` command to be able to identify the tag associated with each submodule's commit (if any).

## why

Previously, the GitHub workflows were using the `submodules: true` option, but this would not include tag information about each module so `git describe` would not show tag information in the `configure` step of each build.

As a workaround, in PR #3161 the `submodules` option was replaced with an additional step to explicitly call `git submodules init` & `git submodules update` to address this (see changes to `.github/workflows/ci.yml` in commit 7732b5e).

As suggested by fzipi@ [here](https://github.com/owasp-modsecurity/ModSecurity/pull/3161#issuecomment-2232888046), this could be addressed with the `fetch-depth: 0` option of the `checkout` action (see [here](https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches)), simplifying the workflow again.

## misc

Piggybacked simple typo in `Dockerfile` to build Windows version of the library introduced in commit 9e44964. 🤦