### PR TITLE
Invalid pointer access in case rule id == NOT_SET_P 

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -35,7 +35,7 @@ const char* id_log(msre_rule* rule) {
     assert(rule != NULL);
     assert(rule->actionset != NULL);
     const char* id = rule->actionset->id;
-    if (!id || !*id || id == NOT_SET_P) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
+    if (!id || id == NOT_SET_P || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
 	return id;
 }
 


### PR DESCRIPTION
Invalid pointer access in case rule id == NOT_SET_P 
