### PR TITLE
CI improvement: First check syntax & always display error/audit logs

### DIFF
--- a/.github/security2.conf
+++ b/.github/security2.conf
@@ -4,3 +4,5 @@ LoadModule security2_module /usr/lib/apache2/modules/mod_security2.so
     SecDataDir /var/cache/modsecurity
     Include /etc/apache2/modsecurity.conf
 </IfModule>
+
+SecAuditLog /var/log/apache2/modsec_audit.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           # '|| :' handles the case grep doesn't match, otherwise the script exits with 1 (error)
           errors=$(grep -E ':(?error|warn)[]]' /var/log/apache2/error.log) || :
           if [[ -z "${errors}" ]]; then exit 0; fi
-          echo "Found errors/warnings in error.log"
+          echo "::error Found errors/warnings in error.log"
           echo "${errors}"
           exit 1
       - name: Show httpd error log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           # '|| :' handles the case grep doesn't match, otherwise the script exits with 1 (error)
           errors=$(grep -E ':(?error|warn)[]]' /var/log/apache2/error.log) || :
           if [[ -z "${errors}" ]]; then exit 0; fi
-          echo "::error Found errors/warnings in error.log"
+          echo "::error::Found errors/warnings in error.log"
           echo "${errors}"
           exit 1
       - name: Show httpd error log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,12 @@ jobs:
       - name: Search for errors/warnings in error log
         run: |
           errors=$(grep -E ':(?error|warn)[]]' /var/log/apache2/error.log)
-          if [ -n "${errors}" ]; then
+          if [[ -n "${errors}" ]]; then
             echo "Found errors/warnings in error.log"
             echo "${errors}"
             exit 1
           fi
+          exit 0
       - name: Show httpd error log
         if: always()
         run: sudo cat /var/log/apache2/error.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: sudo systemctl restart apache2.service
       - name: Search for errors/warnings in error log
         run: |
-          errors="$(grep -E ":(?error|warn)[]]" /var/log/apache2/error.log)"
+          errors=$(grep -E ':(?error|warn)[]]' /var/log/apache2/error.log)
           if [ -n "${errors}" ]; then
             echo "Found errors/warnings in error.log"
             echo "${errors}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,3 @@ jobs:
       - name: Show mod_security2 audit log
         if: always()
         run: sudo cat /var/log/apache2/modsec_audit.log
-        # For non-regression tests: /home/runner/work/ModSecurity/ModSecurity/tests/regression/server_root/logs/audit/audit.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,14 @@ jobs:
           sudo cp unicode.mapping /etc/apache2/
           sudo mkdir -p /var/cache/modsecurity
           sudo chown -R www-data:www-data /var/cache/modsecurity
+      - name: first check config (to get syntax errors)
+        run: sudo apachectl configtest
       - name: start apache with module
-        run: |
-          sudo systemctl restart apache2.service
-          sudo cat /var/log/apache2/error.log
-
+        run: sudo systemctl restart apache2.service
+      - name: Show httpd error log
+        if: always()
+        run: sudo cat /var/log/apache2/error.log
+      - name: Show mod_security2 audit log
+        if: always()
+        run: sudo cat /var/log/apache2/modsec_audit.log
+        # For non-regression tests: /home/runner/work/ModSecurity/ModSecurity/tests/regression/server_root/logs/audit/audit.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,12 @@ jobs:
         run: sudo systemctl restart apache2.service
       - name: Search for errors/warnings in error log
         run: |
-          errors=$(grep -E ':(?error|warn)[]]' /var/log/apache2/error.log)
-          if [[ -n "${errors}" ]]; then
-            echo "Found errors/warnings in error.log"
-            echo "${errors}"
-            exit 1
-          fi
-          exit 0
+          # '|| :' handles the case grep doesn't match, otherwise the script exits with 1 (error)
+          errors=$(grep -E ':(?error|warn)[]]' /var/log/apache2/error.log) || :
+          if [[ -z "${errors}" ]]; then exit 0; fi
+          echo "Found errors/warnings in error.log"
+          echo "${errors}"
+          exit 1
       - name: Show httpd error log
         if: always()
         run: sudo cat /var/log/apache2/error.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
         run: sudo apachectl configtest
       - name: start apache with module
         run: sudo systemctl restart apache2.service
+      - name: Search for errors/warnings in error log
+        run: |
+          errors="$(grep -E ":(?error|warn)[]]" /var/log/apache2/error.log)"
+          if [ -n "${errors}" ]; then
+            echo "Found errors/warnings in error.log"
+            echo "${errors}"
+            exit 1
+          fi
       - name: Show httpd error log
         if: always()
         run: sudo cat /var/log/apache2/error.log


### PR DESCRIPTION
First check syntax, in case no error.log is generated. this displays error on console.
Always show error.log (in sub-menu) after start. Even if error and CI processing stops. Same for audit log (even if empty for the moment)