### PR TITLE
msc_regexec() != PCRE_ERROR_NOMATCH

### DIFF
--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -120,8 +120,7 @@ static int var_args_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
                 /* Run the regex against the argument name. */
-                if (!(msc_regexec((msc_regex_t *)var->param_data, arg->name,
-                    arg->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, arg->name, arg->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(arg->name, var->param) == 0) match = 1;
             }
@@ -198,8 +197,7 @@ static int var_args_names_generate(modsec_rec *msr, msre_var *var, msre_rule *ru
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, arg->name,
-                    arg->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, arg->name, arg->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(arg->name, var->param) == 0) match = 1;
             }
@@ -250,8 +248,7 @@ static int var_args_get_generate(modsec_rec *msr, msre_var *var, msre_rule *rule
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
                 /* Run the regex against the argument name. */
-                if (!(msc_regexec((msc_regex_t *)var->param_data, arg->name,
-                    arg->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, arg->name, arg->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(arg->name, var->param) == 0) match = 1;
             }
@@ -300,8 +297,7 @@ static int var_args_get_names_generate(modsec_rec *msr, msre_var *var, msre_rule
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, arg->name,
-                    arg->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, arg->name, arg->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(arg->name, var->param) == 0) match = 1;
             }
@@ -352,8 +348,7 @@ static int var_args_post_generate(modsec_rec *msr, msre_var *var, msre_rule *rul
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
                 /* Run the regex against the argument name. */
-                if (!(msc_regexec((msc_regex_t *)var->param_data, arg->name,
-                    arg->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, arg->name, arg->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(arg->name, var->param) == 0) match = 1;
             }
@@ -402,8 +397,7 @@ static int var_args_post_names_generate(modsec_rec *msr, msre_var *var, msre_rul
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, arg->name,
-                    arg->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, arg->name, arg->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(arg->name, var->param) == 0) match = 1;
             }
@@ -899,8 +893,7 @@ static int var_tx_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -955,8 +948,7 @@ static int var_geo_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -1016,8 +1008,7 @@ static int var_ip_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -1096,8 +1087,7 @@ static int var_session_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -1152,8 +1142,7 @@ static int var_user_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -1212,8 +1201,7 @@ static int var_global_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -1264,8 +1252,7 @@ static int var_resource_generate(modsec_rec *msr, msre_var *var, msre_rule *rule
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    str->name_len, &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, str->name_len, &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -1306,38 +1293,21 @@ static int var_files_tmp_contents_generate(modsec_rec *msr, msre_var *var,
     if (msr->mpd == NULL) return 0;
 
     parts = (multipart_part **)msr->mpd->parts->elts;
-    for (i = 0; i < msr->mpd->parts->nelts; i++)
-    {
-        if ((parts[i]->type == MULTIPART_FILE) &&
-                (parts[i]->tmp_file_name != NULL))
-        {
+    for (i = 0; i < msr->mpd->parts->nelts; i++) {
+        if ((parts[i]->type == MULTIPART_FILE) && (parts[i]->tmp_file_name != NULL)) {
             int match = 0;
 
             /* Figure out if we want to include this variable. */
-            if (var->param == NULL)
-            {
-                match = 1;
-            }
-            else
-            {
-                if (var->param_data != NULL)
-                {
+            if (var->param == NULL)match = 1;
+            else {
+                if (var->param_data != NULL) {
                     /* Regex. */
                     char *my_error_msg = NULL;
-                    if (!(msc_regexec((msc_regex_t *)var->param_data,
-                        parts[i]->name, strlen(parts[i]->name),
-                        &my_error_msg) == PCRE_ERROR_NOMATCH)) 
-                    {
-                        match = 1;
-                    }
+                    if (msc_regexec((msc_regex_t*)var->param_data, parts[i]->name, strlen(parts[i]->name), &my_error_msg) >= 0) match = 1;
                 }
-                else
-                {
+                else {
                     /* Simple comparison. */
-                    if (strcasecmp(parts[i]->name, var->param) == 0)
-                    {
-                        match = 1;
-                    }
+                    if (strcasecmp(parts[i]->name, var->param) == 0)match = 1;
                 }
             }
             /* If we had a match add this argument to the collection. */
@@ -1351,10 +1321,7 @@ static int var_files_tmp_contents_generate(modsec_rec *msr, msre_var *var,
                 msre_var *rvar = NULL;
 
                 file = fopen(parts[i]->tmp_file_name, "r");
-                if (file == NULL)
-                {
-                    continue;
-                }
+                if (file == NULL) continue;
 
                 full_content = (char *)apr_pcalloc(mptmp, (sizeof(char)*parts[i]->length) + 1);
                 if (full_content == NULL) {
@@ -1416,8 +1383,7 @@ static int var_files_tmpnames_generate(modsec_rec *msr, msre_var *var, msre_rule
             else {
                 if (var->param_data != NULL) { /* Regex. */
                     char *my_error_msg = NULL;
-                    if (!(msc_regexec((msc_regex_t *)var->param_data, parts[i]->name,
-                        strlen(parts[i]->name), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                    if (msc_regexec((msc_regex_t *)var->param_data, parts[i]->name, strlen(parts[i]->name), &my_error_msg) >= 0) match = 1;
                 } else { /* Simple comparison. */
                     if (strcasecmp(parts[i]->name, var->param) == 0) match = 1;
                 }
@@ -1465,8 +1431,7 @@ static int var_files_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
             else {
                 if (var->param_data != NULL) { /* Regex. */
                     char *my_error_msg = NULL;
-                    if (!(msc_regexec((msc_regex_t *)var->param_data, parts[i]->name,
-                        strlen(parts[i]->name), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                    if (msc_regexec((msc_regex_t *)var->param_data, parts[i]->name, strlen(parts[i]->name), &my_error_msg) >= 0) match = 1;
                 } else { /* Simple comparison. */
                     if (strcasecmp(parts[i]->name, var->param) == 0) match = 1;
                 }
@@ -1514,8 +1479,7 @@ static int var_files_sizes_generate(modsec_rec *msr, msre_var *var, msre_rule *r
             else {
                 if (var->param_data != NULL) { /* Regex. */
                     char *my_error_msg = NULL;
-                    if (!(msc_regexec((msc_regex_t *)var->param_data, parts[i]->name,
-                        strlen(parts[i]->name), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                    if (msc_regexec((msc_regex_t *)var->param_data, parts[i]->name, strlen(parts[i]->name), &my_error_msg) >= 0) match = 1;
                 } else { /* Simple comparison. */
                     if (strcasecmp(parts[i]->name, var->param) == 0) match = 1;
                 }
@@ -1632,8 +1596,7 @@ static int var_multipart_part_headers_generate(modsec_rec *msr, msre_var *var, m
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, parts[i]->name,
-                    strlen(parts[i]->name), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, parts[i]->name, strlen(parts[i]->name), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(parts[i]->name, var->param) == 0) match = 1;
             }
@@ -2105,8 +2068,7 @@ static int var_perf_rules_generate(modsec_rec *msr, msre_var *var, msre_rule *ru
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                                strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }
@@ -2591,8 +2553,7 @@ static int var_matched_vars_names_generate(modsec_rec *msr, msre_var *var, msre_
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                    strlen(str->name), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, strlen(str->name), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -2660,8 +2621,7 @@ static int var_matched_vars_generate(modsec_rec *msr, msre_var *var, msre_rule *
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, str->name,
-                                strlen(str->name), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, str->name, strlen(str->name), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(str->name, var->param) == 0) match = 1;
             }
@@ -2728,8 +2688,7 @@ static int var_request_cookies_generate(modsec_rec *msr, msre_var *var, msre_rul
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                                strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }
@@ -2783,8 +2742,7 @@ static int var_request_cookies_names_generate(modsec_rec *msr, msre_var *var, ms
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                    strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }
@@ -2838,8 +2796,7 @@ static int var_request_headers_generate(modsec_rec *msr, msre_var *var, msre_rul
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                    strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }
@@ -2893,8 +2850,7 @@ static int var_request_headers_names_generate(modsec_rec *msr, msre_var *var, ms
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                    strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }
@@ -3171,8 +3127,7 @@ static int var_response_headers_generate(modsec_rec *msr, msre_var *var, msre_ru
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                    strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }
@@ -3226,8 +3181,7 @@ static int var_response_headers_names_generate(modsec_rec *msr, msre_var *var, m
         else {
             if (var->param_data != NULL) { /* Regex. */
                 char *my_error_msg = NULL;
-                if (!(msc_regexec((msc_regex_t *)var->param_data, te[i].key,
-                    strlen(te[i].key), &my_error_msg) == PCRE_ERROR_NOMATCH)) match = 1;
+                if (msc_regexec((msc_regex_t *)var->param_data, te[i].key, strlen(te[i].key), &my_error_msg) >= 0) match = 1;
             } else { /* Simple comparison. */
                 if (strcasecmp(te[i].key, var->param) == 0) match = 1;
             }


### PR DESCRIPTION
Return of msc_regexec() compared with PCRE_ERROR_NOMATCH (!=) to check if match.
Other errors may happen that would return -2, -3, ...
Matching would be incorrectly set in this case.
We must check if >= 0