### PR TITLE
Move xmlFree() call to the right place

### DIFF
--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -745,13 +745,12 @@ static int var_xml_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
     }
 
     /* Create one variable for each node in the result. */
+    char* content = NULL;
     for(i = 0; i < nodes->nodeNr; i++) {
         msre_var *rvar = NULL;
-        char *content = NULL;
 
         content = (char *)xmlNodeGetContent(nodes->nodeTab[i]);
         if (content != NULL) {
-            xmlFree(content);
             rvar = apr_pmemdup(mptmp, var, sizeof(msre_var));
             if (!rvar) {
                 msr_log(msr, 1, "XML: Memory allocation error");
@@ -766,12 +765,15 @@ static int var_xml_generate(modsec_rec *msr, msre_var *var, msre_rule *rule,
             }
             rvar->value_len = strlen(rvar->value);
             apr_table_addn(vartab, rvar->name, (void *)rvar);
+            xmlFree(content);
+            content = NULL;
 
             count++;
          }
     }
 
 var_xml_generate_Error:
+    if (content != NULL) xmlFree(content);
     xmlXPathFreeObject(xpathObj);
     xmlXPathFreeContext(xpathCtx);
 


### PR DESCRIPTION
## what

v2/master branch contains a bug after #3120: the `xmlFree()` function call was at a wrong place.

This patch fixes it.

## why

The wrong call produces this behavior:

```
Executing operator "streq" with param "signin" against XML:/myxml/path.
Target value: "P[as0(twq21"
```
so the target was some trash.
