### PR TITLE
Build on macOS with Apple silicon (arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-14]
         configure:
           - {label: "with parser generation", opt: "--enable-parser-generation" }
           - {label: "wo curl",    opt: "--without-curl" }
@@ -91,10 +91,12 @@ jobs:
           - {label: "with pcre2", opt: "--with-pcre2" }
     steps:
       - name: Setup Dependencies
-        # autoconf, curl, pcre2 not installed because they're already
+        # curl, pcre2 not installed because they're already
         # included in the image
         run: |
-          brew install automake \
+          brew install autoconf \
+                       automake \
+                       libtool \
                        yajl \
                        lmdb \
                        lua \

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -27,30 +27,41 @@ else
 
     AC_MSG_CHECKING([for libpcre config script])
 
-    for x in ${test_paths}; do
-        dnl # Determine if the script was specified and use it directly
-        if test ! -d "$x" -a -e "$x"; then
-            PCRE_CONFIG=$x
-            pcre_path="no"
-            break
-        fi
+    AC_CHECK_PROG([PCRE_CONFIG_IN_ENV], [pcre-config], [yes], [no])
 
-        dnl # Try known config script names/locations
-        for PCRE_CONFIG in pcre-config; do
-            if test -e "${x}/bin/${PCRE_CONFIG}"; then
-                pcre_path="${x}/bin"
+    if test "$PCRE_CONFIG_IN_ENV" = "yes"; then
+        AC_MSG_NOTICE([pcre-config found in envinronment])
+
+        PCRE_CONFIG=pcre-config
+        pcre_path="no"
+    else
+        AC_MSG_NOTICE([pcre-config not found in environment. checking known paths])
+
+        for x in ${test_paths}; do
+            dnl # Determine if the script was specified and use it directly
+            if test ! -d "$x" -a -e "$x"; then
+                PCRE_CONFIG=$x
+                pcre_path="no"
                 break
-            elif test -e "${x}/${PCRE_CONFIG}"; then
-                pcre_path="${x}"
+            fi
+
+            dnl # Try known config script names/locations
+            for PCRE_CONFIG in pcre-config; do
+                if test -e "${x}/bin/${PCRE_CONFIG}"; then
+                    pcre_path="${x}/bin"
+                    break
+                elif test -e "${x}/${PCRE_CONFIG}"; then
+                    pcre_path="${x}"
+                    break
+                else
+                    pcre_path=""
+                fi
+            done
+            if test -n "$pcre_path"; then
                 break
-            else
-                pcre_path=""
             fi
         done
-        if test -n "$pcre_path"; then
-            break
-        fi
-    done
+    fi
 
     if test -n "${pcre_path}"; then
         if test "${pcre_path}" != "no"; then

--- a/build/yajl.m4
+++ b/build/yajl.m4
@@ -78,6 +78,29 @@ else
 #    fi
 fi
 
+# FIX: if the include directory in CFLAGS ends with "include/yajl",
+# remove the suffix "/yajl". the library header files are included
+# using the prefix (for example, #include <yajl/yajl_tree.h>), and
+# this is even the case for the library itself (for example,
+# yajl_tree.h includes yajl/yajl_common.h).
+
+new_cflags=""
+
+for flag in $YAJL_CFLAGS; do
+    case "$flag" in
+        -I*/include/yajl)
+            new_flag="${flag%/yajl}"
+            new_cflags="$new_cflags $new_flag"
+            ;;
+        *)
+            new_cflags="$new_cflags $flag"
+            ;;
+    esac
+done
+
+YAJL_CFLAGS="$new_cflags"
+
+
 if test -z "${YAJL_LDADD}"; then
     if test -z "${YAJL_MANDATORY}"; then
         if test -z "${YAJL_DISABLED}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -164,8 +164,8 @@ AC_CHECK_HEADERS([iostream])
 AC_CHECK_HEADERS([sys/utsname.h])
 
 
-# ??
-LT_INIT([dlopen])
+# Initialize libtool
+LT_INIT
 
 # Identify platform
 AC_CANONICAL_HOST


### PR DESCRIPTION
## what

Support building libModSecurity on macOS with Apple silicon (arm64)

## why

Apple has been moving the macOS platform to Apple silicon (arm64) over the last few years (as of June 2023, the entire Mac lineup uses Apple silicon chips).

This PR fixes build configuration issues in pcre & yajl that prevented the library from compiling on newer versions of macOS (which probably apply to the x86_64 version of the OS too).

Additionally, it updates the GitHub quality assurance workflow to run now on macOS 14, which is an Apple silicon (arm64) runner image (see [here](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)).