### PR TITLE
Add cleanup methods to complete C based ABI

### DIFF
--- a/examples/simple_example_using_c/test.c
+++ b/examples/simple_example_using_c/test.c
@@ -68,6 +68,8 @@ int main (int argc, char **argv)
     msc_process_response_body(transaction);
     msc_process_logging(transaction);
 end:
+    if(error != NULL)
+        msc_rules_error_cleanup(error);
     msc_rules_cleanup(rules);
     msc_cleanup(modsec);
 

--- a/headers/modsecurity/rules_set.h
+++ b/headers/modsecurity/rules_set.h
@@ -99,6 +99,7 @@ int msc_rules_add_remote(RulesSet *rules, const char *key, const char *uri,
     const char **error);
 int msc_rules_add_file(RulesSet *rules, const char *file, const char **error);
 int msc_rules_add(RulesSet *rules, const char *plain_rules, const char **error);
+void msc_rules_error_cleanup(const char *error);
 int msc_rules_cleanup(RulesSet *rules);
 
 #ifdef __cplusplus

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -724,6 +724,9 @@ void msc_transaction_cleanup(Transaction *transaction);
 int msc_intervention(Transaction *transaction, ModSecurityIntervention *it);
 
 /** @ingroup ModSecurity_C_API */
+void msc_intervention_cleanup(ModSecurityIntervention *it);
+
+/** @ingroup ModSecurity_C_API */
 int msc_process_logging(Transaction *transaction);
 
 /** @ingroup ModSecurity_C_API */

--- a/src/rules_set.cc
+++ b/src/rules_set.cc
@@ -311,6 +311,21 @@ extern "C" int msc_rules_add(RulesSet *rules, const char *plain_rules,
 }
 
 
+/**
+ * @name    msc_rules_error_cleanup
+ * @brief   Deallocates an error message buffer returned by a msc_rules_xxx function.
+ *
+ * This is a helper function to free the error message buffer allocated
+ * by a msc_rules_xxx function.
+ *
+ * @param error Error message pointer.
+ *
+ */
+extern "C" void msc_rules_error_cleanup(const char *error) {
+    free((void*) error);
+}
+
+
 extern "C" int msc_rules_cleanup(RulesSet *rules) {
     delete rules;
     return true;

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -2274,6 +2274,22 @@ extern "C" int msc_intervention(Transaction *transaction,
 
 
 /**
+ * @name    msc_intervention_cleanup
+ * @brief   Removes all the resources allocated by a given Intervention.
+ *
+ * This is a helper function to free any allocated buffers owned by the
+ * intervention.
+ *
+ * @param it ModSecurity intervention.
+ *
+ */
+extern "C" void msc_intervention_cleanup(ModSecurityIntervention *it) {
+    intervention::free(it);
+    intervention::clean(it);
+}
+
+
+/**
  * @name    msc_get_response_body
  * @brief   Retrieve a buffer with the updated response body.
  *

--- a/test/benchmark/benchmark.cc
+++ b/test/benchmark/benchmark.cc
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
     modsecurity::ModSecurity *modsec;
     modsecurity::RulesSet *rules;
     modsecurity::ModSecurityIntervention it;
-    modsecurity::intervention::reset(&it);
+    modsecurity::intervention::clean(&it);
     modsec = new modsecurity::ModSecurity();
     modsec->setConnectorInformation("ModSecurity-benchmark v0.0.1-alpha" \
             " (ModSecurity benchmark utility)");
@@ -167,6 +167,8 @@ int main(int argc, char *argv[]) {
 next_request:
         modsecTransaction->processLogging();
         delete modsecTransaction;
+        modsecurity::intervention::free(&it);
+        modsecurity::intervention::clean(&it);
     }
 
     delete rules;


### PR DESCRIPTION
## what

Add cleanup methods to C based ABI to allow the library to be used by languages that do not link with the standard C library.

## why

The C/C++ interface of libModSecurity assumes that clients that use the library are also able to link with the standard C library to free any resources allocated by libModSecurity functions and returned to the client (transferring their ownership to them).

If the client wants to build a shared library version of libModSecurity (such as .dll on Windows) and use it through the exported API, it will not be able to deallocate these resources.

This PR adds two cleanup methods to allow clients that depend just on the library's ABI to free those resources.

These methods follow the approach and terminology of existing cleanup methods in the C API (such as `msc_rules_cleanup` & `msc_cleanup`) and aims to provide completeness for the lifecycle management of all objects allocated by the library.

## changes

 * `void msc_rules_error_cleanup(const char *error)`
   * Deallocates an error message returned by the `msc_rules_xxx` methods.
 * `void msc_intervention_cleanup(ModSecurityIntervention *it)`
   * Deallocates the `url` and/or `log` members of the `ModSecurityIntervention` structure that may be allocated in a call to `msc_intervention`.