### PR TITLE
Fixed shared files deadlock in a multi-threaded Windows application

### DIFF
--- a/src/utils/shared_files.h
+++ b/src/utils/shared_files.h
@@ -18,6 +18,9 @@
 
 
 #include <stdio.h>
+#ifdef WIN32
+#include <Windows.h>
+#endif
 
 #include <unordered_map>
 #include <string>
@@ -53,6 +56,9 @@ private:
 
      struct handler_info {
          FILE* fp;
+#ifdef WIN32
+         HANDLE hMutex;
+#endif
          unsigned int cnt;
      };
 


### PR DESCRIPTION
## what

Fix potential deadlock in multi-threaded usage of the library on Windows.

## why

The shared files Windows implementation introduced in PR #3132 works in multi-process single-threaded contexts but it doesn't work correctly in single-process multi-threaded contexts.

## miscellaneous

The issue is that the `LockFileEx` Win32 function works on a per-handle basis. In a multi-process context, each process will have called `SharedFiles::add_new_handler` when initializing the `SharedFile` and obtained a handle, and thus locking will work.

When running ModSecurity in a single process using multiple threads, the initialization of the `SharedFile` will happen once and the handle will be shared by all threads. Then, if two threads try to write to the same shared file concurrently, they may deadlock as one of them will lock the file (by calling `LockFileEx`) and then proceed to write to the file. If before writing to the file and unlocking it, another thread calls `LockFileEx` on the same handle, the attempt to write to the file will lock generating a deadlock.

The new implementation replaces usage of `LockFileEx`/`UnlockFileEx` with a named mutex to lock access to the shared file.

 * A named mutex is used to support multi-process scenarios.
   * The mutex name is generated using the filename to support multiple shared files (such as that for the debug and audit logs).
 * This assumes that both process will initialize the `SharedFile` instance using the same filename (which is expected as they'd be using the same configuration file)