### PR TITLE
Fix SecRemoteRules regression test not to depend on a specific error message

### DIFF
--- a/test/test-cases/regression/config-secremoterules.json
+++ b/test/test-cases/regression/config-secremoterules.json
@@ -46,7 +46,7 @@
     "version_min":300000,
     "title":"Include remote rules - failed download (Abort)",
     "expected":{
-      "parser_error": "Failed to download: HTTP response code said error"
+      "parser_error": "Failed to download"
     },
     "rules":[
       "SecRuleEngine On",


### PR DESCRIPTION
## what

Simplify the `Include remote rules - failed download (Abort)` test expected parser error because it's not always the same in different curl/OS versions.

## why

This was detected after an update of the GitHub runner images to macOS 14.6 released [yesterday](https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240805.3):

```
Current runner version: '2.317.0'
Operating System
  macOS
  14.6
  23G80
Runner Image
  Image: macos-14-arm64
  Version: 20240805.3
```

Builds that were assigned a macOS runner image with this version would fail when running the `test/test-cases/regression/config-secremoterules.json` regression tests.

The test configuration depends on a specific error message from curl/OS (HTTP response code said error), which seems to have changed (Failure when receiving data from the peer).

This PR simplifies the test configuration and look just for `Failed to download`, which is the prefix added by the libModSecurity parser when logging the parser error.