### PR TITLE
Refactor: moved 3 #include directives to the top of the file.

### DIFF
--- a/headers/modsecurity/modsecurity.h
+++ b/headers/modsecurity/modsecurity.h
@@ -38,10 +38,10 @@
  *     std::cout << "There is an intervention" << std::endl;
  * }
  *
- * ...      
+ * ...
  *
  * @endcode
- * 
+ *
  */
 
 /**
@@ -79,6 +79,11 @@
 #include <string>
 #include <memory>
 #endif
+
+
+#include "modsecurity/intervention.h"
+#include "modsecurity/transaction.h"
+#include "modsecurity/debug_log.h"
 
 
 #ifndef HEADERS_MODSECURITY_MODSECURITY_H_
@@ -160,7 +165,7 @@ namespace modsecurity {
      LoggingPhase,
     /**
      * Just a marking for the expected number of phases.
-     * 
+     *
      */
      NUMBER_OF_PHASES,
     };
@@ -169,11 +174,6 @@ namespace modsecurity {
 }  // namespace modsecurity
 #endif
 
-
-
-#include "modsecurity/intervention.h"
-#include "modsecurity/transaction.h"
-#include "modsecurity/debug_log.h"
 
 /**
  * TAG_NUM:


### PR DESCRIPTION
## what

- Moved 3 #include directives to the top of the file.
- Deleted some unnecessary trailing spaces as well.

## why

To aid code readability, all #include directives in a code file should be grouped together near the top. The only items that may precede an #include in a file are other preprocessor directives or comments.

## references

[Sonarcloud: Move these 3 #include directives to the top of the file.](https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&id=owasp-modsecurity_ModSecurity&open=AY8-ffgqm_fzkWiCOtCs&tab=code
)
