### PR TITLE
Refactor: used the init-statement to declare "pos" inside the if statement

### DIFF
--- a/src/variables/remote_user.cc
+++ b/src/variables/remote_user.cc
@@ -56,8 +56,7 @@ void RemoteUser::evaluate(Transaction *transaction,
 
         base64 = Utils::Base64::decode(base64);
 
-        const auto pos = base64.find(":");
-        if (pos != std::string::npos) {
+        if (const auto pos{base64.find(":")}; pos != std::string::npos) {
             transaction->m_variableRemoteUser.assign(std::string(base64, 0, pos));
 
             auto var = std::make_unique<VariableValue>(&v->getKeyWithCollection(),


### PR DESCRIPTION
## what

Used the init-statement to declare "pos" inside the if statement.

## why

C++17 introduced a construct to create and initialize a variable within the condition of if and switch statements, and C++20 added this construct to range-based for loops. Using this new feature simplifies common code patterns and helps in giving variables the right scope.

## references

[Sonarcloud: Use the init-statement to declare "pos" inside the if statement.](https://sonarcloud.io/project/issues?open=AZDCieK2zGtqRpL2rnl-&id=owasp-modsecurity_ModSecurity)