### PR TITLE
V3/sonarcloud replace this declaration by a structured binding declaration

### DIFF
--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -153,7 +153,7 @@ void RuleWithOperator::getVariablesExceptions(Transaction *t,
         }
     }
 
-    for (const auto &[id, v] : t->m_rules->m_exceptions.m_variable_update_target_by_id) {
+    for (const auto &[id, v] : t->m_rules->m_exceptions.m_variable_update_target_by_id) { // cppcheck-suppress unassignedVariable
         if (m_ruleId == id) {
             if (Variable *b{v.get()};dynamic_cast<variables::VariableModificatorExclusion *>(b)) {
                 exclusion->push_back(dynamic_cast<variables::VariableModificatorExclusion *>(b)->m_base.get());

--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -133,45 +133,33 @@ bool RuleWithOperator::executeOperatorAt(Transaction *trans, const std::string &
 
 void RuleWithOperator::getVariablesExceptions(Transaction *t,
     variables::Variables *exclusion, variables::Variables *addition) {
-    for (const auto &a : t->m_rules->m_exceptions.m_variable_update_target_by_tag) { // cppcheck-suppress ctunullpointer
-        if (containsTag(*a.first.get(), t) == false) {
-            continue;
-        }
-        Variable *b = a.second.get();
-        if (dynamic_cast<variables::VariableModificatorExclusion*>(b)) {
-            exclusion->push_back(
-                dynamic_cast<variables::VariableModificatorExclusion*>(
-                    b)->m_base.get());
-        } else {
-            addition->push_back(b);
+    for (const auto &[tag, v] : t->m_rules->m_exceptions.m_variable_update_target_by_tag) { // cppcheck-suppress ctunullpointer
+        if (containsTag(*tag.get(), t)) {
+            if (Variable *b{v.get()};dynamic_cast<variables::VariableModificatorExclusion*>(b)) {
+                exclusion->push_back(dynamic_cast<variables::VariableModificatorExclusion*>(b)->m_base.get());
+            } else {
+                addition->push_back(b);
+            }
         }
     }
 
-    for (const auto &a : t->m_rules->m_exceptions.m_variable_update_target_by_msg) {
-        if (containsMsg(*a.first.get(), t) == false) {
-            continue;
-        }
-        Variable *b = a.second.get();
-        if (dynamic_cast<variables::VariableModificatorExclusion*>(b)) {
-            exclusion->push_back(
-                dynamic_cast<variables::VariableModificatorExclusion*>(
-                    b)->m_base.get());
-        } else {
-            addition->push_back(b);
+    for (const auto &[msg, v] : t->m_rules->m_exceptions.m_variable_update_target_by_msg) {
+        if (containsMsg(*msg.get(), t)) {
+            if (Variable *b{v.get()}; dynamic_cast<variables::VariableModificatorExclusion *>(b)) {
+                exclusion->push_back(dynamic_cast<variables::VariableModificatorExclusion *>(b)->m_base.get());
+            } else {
+                addition->push_back(b);
+            }
         }
     }
 
-    for (const auto &a : t->m_rules->m_exceptions.m_variable_update_target_by_id) {
-        if (m_ruleId != a.first) {
-            continue;
-        }
-        Variable *b = a.second.get();
-        if (dynamic_cast<variables::VariableModificatorExclusion*>(b)) {
-            exclusion->push_back(
-                dynamic_cast<variables::VariableModificatorExclusion*>(
-                    b)->m_base.get());
-        } else {
-            addition->push_back(b);
+    for (const auto &[id, v] : t->m_rules->m_exceptions.m_variable_update_target_by_id) {
+        if (m_ruleId == id) {
+            if (Variable *b{v.get()};dynamic_cast<variables::VariableModificatorExclusion *>(b)) {
+                exclusion->push_back(dynamic_cast<variables::VariableModificatorExclusion *>(b)->m_base.get());
+            } else {
+                addition->push_back(b);
+            }
         }
     }
 }


### PR DESCRIPTION
## what

- Refactor: replaced 3 declarations with 3 structured binding declarations
- Refactor: flipped the conditions in "if (contains[Tag|Msg|Id]( ... " statements
for clearer code.
- Refactor: moved "Variable *b" as an init-statement inside "if()" statements for
stricter scope.
- Suppress cppcheck false positive unassignedVariable warning.

## why

This syntax is far more expressive and easier to understand than the old one.

## references
[Sonarcloud Replace this declaration by a structured binding declaration.](https://sonarcloud.io/project/issues?open=AY8-ff1vm_fzkWiCOtCt&id=owasp-modsecurity_ModSecurity)