### PR TITLE
Remove unnecessary dynamic casts

### DIFF
--- a/headers/modsecurity/rule_with_operator.h
+++ b/headers/modsecurity/rule_with_operator.h
@@ -50,7 +50,7 @@ class RuleWithOperator : public RuleWithActions {
     bool evaluate(Transaction *transaction,
         std::shared_ptr<RuleMessage> rm) override;
 
-    void getVariablesExceptions(Transaction *t,
+    void getVariablesExceptions(Transaction &t,
         variables::Variables *exclusion, variables::Variables *addition);
     inline void getFinalVars(variables::Variables *vars,
         variables::Variables *eclusion, Transaction *trans);

--- a/src/actions/set_var.cc
+++ b/src/actions/set_var.cc
@@ -51,18 +51,12 @@ bool SetVar::evaluate(RuleWithActions *rule, Transaction *t) {
     std::string m_variableNameExpanded;
 
     auto *v = m_variable.get();
-    variables::Tx_DynamicElement *tx = dynamic_cast<
-        variables::Tx_DynamicElement *> (v);
-    variables::Session_DynamicElement *session = dynamic_cast<
-        variables::Session_DynamicElement *> (v);
-    variables::Ip_DynamicElement *ip = dynamic_cast<
-        variables::Ip_DynamicElement *> (v);
-    variables::Resource_DynamicElement *resource = dynamic_cast<
-        variables::Resource_DynamicElement *> (v);
-    variables::Global_DynamicElement *global = dynamic_cast<
-        variables::Global_DynamicElement *> (v);
-    variables::User_DynamicElement *user = dynamic_cast<
-        variables::User_DynamicElement *> (v);
+    auto tx = dynamic_cast<variables::Tx_DynamicElement *> (v);
+    auto session = dynamic_cast<variables::Session_DynamicElement *> (v);
+    auto ip = dynamic_cast<variables::Ip_DynamicElement *> (v);
+    auto resource = dynamic_cast<variables::Resource_DynamicElement *> (v);
+    auto global = dynamic_cast<variables::Global_DynamicElement *> (v);
+    auto user = dynamic_cast<variables::User_DynamicElement *> (v);
     if (tx) {
         m_variableNameExpanded = tx->m_string->evaluate(t, rule);
     } else if (session) {

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -2295,8 +2295,9 @@ namespace yy {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
         for (auto &i : *yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ().get()) {
-            if (dynamic_cast<actions::transformations::Transformation *>(i.get())) {
-              t->push_back(dynamic_cast<actions::transformations::Transformation *>(i.release()));
+            if (auto pt = dynamic_cast<actions::transformations::Transformation *>(i.get())) {
+              t->push_back(pt);
+              i.release();
             } else {
               a->push_back(i.release());
             }
@@ -2320,11 +2321,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2324 "seclang-parser.cc"
+#line 2325 "seclang-parser.cc"
     break;
 
   case 76: // expression: "DIRECTIVE" variables op
-#line 1115 "seclang-parser.yy"
+#line 1116 "seclang-parser.yy"
       {
         variables::Variables *v = new variables::Variables();
         for (auto &i : *yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ().get()) {
@@ -2343,17 +2344,18 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2347 "seclang-parser.cc"
+#line 2348 "seclang-parser.cc"
     break;
 
   case 77: // expression: "CONFIG_DIR_SEC_ACTION" actions
-#line 1134 "seclang-parser.yy"
+#line 1135 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
         for (auto &i : *yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ().get()) {
-            if (dynamic_cast<actions::transformations::Transformation *>(i.get())) {
-              t->push_back(dynamic_cast<actions::transformations::Transformation *>(i.release()));
+            if (auto pt = dynamic_cast<actions::transformations::Transformation *>(i.get())) {
+              t->push_back(pt);
+              i.release();
             } else {
               a->push_back(i.release());
             }
@@ -2366,18 +2368,19 @@ namespace yy {
             ));
         driver.addSecAction(std::move(rule));
       }
-#line 2370 "seclang-parser.cc"
+#line 2372 "seclang-parser.cc"
     break;
 
   case 78: // expression: "DIRECTIVE_SECRULESCRIPT" actions
-#line 1153 "seclang-parser.yy"
+#line 1155 "seclang-parser.yy"
       {
         std::string err;
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
         for (auto &i : *yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ().get()) {
-            if (dynamic_cast<actions::transformations::Transformation *>(i.get())) {
-              t->push_back(dynamic_cast<actions::transformations::Transformation *>(i.release()));
+            if (auto pt = dynamic_cast<actions::transformations::Transformation *>(i.get())) {
+              t->push_back(pt);
+              i.release();
             } else {
               a->push_back(i.release());
             }
@@ -2398,11 +2401,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2402 "seclang-parser.cc"
+#line 2405 "seclang-parser.cc"
     break;
 
   case 79: // expression: "CONFIG_DIR_SEC_DEFAULT_ACTION" actions
-#line 1181 "seclang-parser.yy"
+#line 1184 "seclang-parser.yy"
       {
         bool hasDisruptive = false;
         std::vector<actions::Action *> *actions = new std::vector<actions::Action *>();
@@ -2459,78 +2462,78 @@ namespace yy {
 
         delete actions;
       }
-#line 2463 "seclang-parser.cc"
+#line 2466 "seclang-parser.cc"
     break;
 
   case 80: // expression: "CONFIG_DIR_SEC_MARKER"
-#line 1238 "seclang-parser.yy"
+#line 1241 "seclang-parser.yy"
       {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as < std::string > ()),
             /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[0].location.end.filename)),
             /* line number */ yystack_[0].location.end.line
         );
       }
-#line 2474 "seclang-parser.cc"
+#line 2477 "seclang-parser.cc"
     break;
 
   case 81: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_OFF"
-#line 1245 "seclang-parser.yy"
+#line 1248 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DisabledRuleEngine;
       }
-#line 2482 "seclang-parser.cc"
+#line 2485 "seclang-parser.cc"
     break;
 
   case 82: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_ON"
-#line 1249 "seclang-parser.yy"
+#line 1252 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::EnabledRuleEngine;
       }
-#line 2490 "seclang-parser.cc"
+#line 2493 "seclang-parser.cc"
     break;
 
   case 83: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_DETC"
-#line 1253 "seclang-parser.yy"
+#line 1256 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DetectionOnlyRuleEngine;
       }
-#line 2498 "seclang-parser.cc"
+#line 2501 "seclang-parser.cc"
     break;
 
   case 84: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_ON"
-#line 1257 "seclang-parser.yy"
+#line 1260 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2506 "seclang-parser.cc"
+#line 2509 "seclang-parser.cc"
     break;
 
   case 85: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_OFF"
-#line 1261 "seclang-parser.yy"
+#line 1264 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2514 "seclang-parser.cc"
+#line 2517 "seclang-parser.cc"
     break;
 
   case 86: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_ON"
-#line 1265 "seclang-parser.yy"
+#line 1268 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2522 "seclang-parser.cc"
+#line 2525 "seclang-parser.cc"
     break;
 
   case 87: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_OFF"
-#line 1269 "seclang-parser.yy"
+#line 1272 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2530 "seclang-parser.cc"
+#line 2533 "seclang-parser.cc"
     break;
 
   case 88: // expression: "CONFIG_SEC_ARGUMENT_SEPARATOR"
-#line 1273 "seclang-parser.yy"
+#line 1276 "seclang-parser.yy"
       {
         if (yystack_[0].value.as < std::string > ().length() != 1) {
           driver.error(yystack_[1].location, "Argument separator should be set to a single character.");
@@ -2539,259 +2542,259 @@ namespace yy {
         driver.m_secArgumentSeparator.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secArgumentSeparator.m_set = true;
       }
-#line 2543 "seclang-parser.cc"
+#line 2546 "seclang-parser.cc"
     break;
 
   case 89: // expression: "CONFIG_COMPONENT_SIG"
-#line 1282 "seclang-parser.yy"
+#line 1285 "seclang-parser.yy"
       {
         driver.m_components.push_back(yystack_[0].value.as < std::string > ());
       }
-#line 2551 "seclang-parser.cc"
+#line 2554 "seclang-parser.cc"
     break;
 
   case 90: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_ON"
-#line 1286 "seclang-parser.yy"
+#line 1289 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecConnEngine is not yet supported.");
         YYERROR;
       }
-#line 2560 "seclang-parser.cc"
+#line 2563 "seclang-parser.cc"
     break;
 
   case 91: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_OFF"
-#line 1291 "seclang-parser.yy"
+#line 1294 "seclang-parser.yy"
       {
       }
-#line 2567 "seclang-parser.cc"
+#line 2570 "seclang-parser.cc"
     break;
 
   case 92: // expression: "CONFIG_SEC_WEB_APP_ID"
-#line 1294 "seclang-parser.yy"
+#line 1297 "seclang-parser.yy"
       {
         driver.m_secWebAppId.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secWebAppId.m_set = true;
       }
-#line 2576 "seclang-parser.cc"
+#line 2579 "seclang-parser.cc"
     break;
 
   case 93: // expression: "CONFIG_SEC_SERVER_SIG"
-#line 1299 "seclang-parser.yy"
+#line 1302 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecServerSignature is not supported.");
         YYERROR;
       }
-#line 2585 "seclang-parser.cc"
+#line 2588 "seclang-parser.cc"
     break;
 
   case 94: // expression: "CONFIG_SEC_CACHE_TRANSFORMATIONS"
-#line 1304 "seclang-parser.yy"
+#line 1307 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCacheTransformations is not supported.");
         YYERROR;
       }
-#line 2594 "seclang-parser.cc"
+#line 2597 "seclang-parser.cc"
     break;
 
   case 95: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_ON"
-#line 1309 "seclang-parser.yy"
+#line 1312 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecDisableBackendCompression is not supported.");
         YYERROR;
       }
-#line 2603 "seclang-parser.cc"
+#line 2606 "seclang-parser.cc"
     break;
 
   case 96: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_OFF"
-#line 1314 "seclang-parser.yy"
+#line 1317 "seclang-parser.yy"
       {
       }
-#line 2610 "seclang-parser.cc"
+#line 2613 "seclang-parser.cc"
     break;
 
   case 97: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_ON"
-#line 1317 "seclang-parser.yy"
+#line 1320 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecContentInjection is not yet supported.");
         YYERROR;
       }
-#line 2619 "seclang-parser.cc"
+#line 2622 "seclang-parser.cc"
     break;
 
   case 98: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_OFF"
-#line 1322 "seclang-parser.yy"
+#line 1325 "seclang-parser.yy"
       {
       }
-#line 2626 "seclang-parser.cc"
+#line 2629 "seclang-parser.cc"
     break;
 
   case 99: // expression: "CONFIG_SEC_CHROOT_DIR"
-#line 1325 "seclang-parser.yy"
+#line 1328 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecChrootDir is not supported.");
         YYERROR;
       }
-#line 2635 "seclang-parser.cc"
+#line 2638 "seclang-parser.cc"
     break;
 
   case 100: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_ON"
-#line 1330 "seclang-parser.yy"
+#line 1333 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecHashEngine is not yet supported.");
         YYERROR;
       }
-#line 2644 "seclang-parser.cc"
+#line 2647 "seclang-parser.cc"
     break;
 
   case 101: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_OFF"
-#line 1335 "seclang-parser.yy"
+#line 1338 "seclang-parser.yy"
       {
       }
-#line 2651 "seclang-parser.cc"
+#line 2654 "seclang-parser.cc"
     break;
 
   case 102: // expression: "CONFIG_SEC_HASH_KEY"
-#line 1338 "seclang-parser.yy"
+#line 1341 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashKey is not yet supported.");
         YYERROR;
       }
-#line 2660 "seclang-parser.cc"
+#line 2663 "seclang-parser.cc"
     break;
 
   case 103: // expression: "CONFIG_SEC_HASH_PARAM"
-#line 1343 "seclang-parser.yy"
+#line 1346 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashParam is not yet supported.");
         YYERROR;
       }
-#line 2669 "seclang-parser.cc"
+#line 2672 "seclang-parser.cc"
     break;
 
   case 104: // expression: "CONFIG_SEC_HASH_METHOD_RX"
-#line 1348 "seclang-parser.yy"
+#line 1351 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodRx is not yet supported.");
         YYERROR;
       }
-#line 2678 "seclang-parser.cc"
+#line 2681 "seclang-parser.cc"
     break;
 
   case 105: // expression: "CONFIG_SEC_HASH_METHOD_PM"
-#line 1353 "seclang-parser.yy"
+#line 1356 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodPm is not yet supported.");
         YYERROR;
       }
-#line 2687 "seclang-parser.cc"
+#line 2690 "seclang-parser.cc"
     break;
 
   case 106: // expression: "CONFIG_DIR_GSB_DB"
-#line 1358 "seclang-parser.yy"
+#line 1361 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGsbLookupDb is not supported.");
         YYERROR;
       }
-#line 2696 "seclang-parser.cc"
+#line 2699 "seclang-parser.cc"
     break;
 
   case 107: // expression: "CONFIG_SEC_GUARDIAN_LOG"
-#line 1363 "seclang-parser.yy"
+#line 1366 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGuardianLog is not supported.");
         YYERROR;
       }
-#line 2705 "seclang-parser.cc"
+#line 2708 "seclang-parser.cc"
     break;
 
   case 108: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_ON"
-#line 1368 "seclang-parser.yy"
+#line 1371 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecInterceptOnError is not yet supported.");
         YYERROR;
       }
-#line 2714 "seclang-parser.cc"
+#line 2717 "seclang-parser.cc"
     break;
 
   case 109: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_OFF"
-#line 1373 "seclang-parser.yy"
+#line 1376 "seclang-parser.yy"
       {
       }
-#line 2721 "seclang-parser.cc"
+#line 2724 "seclang-parser.cc"
     break;
 
   case 110: // expression: "CONFIG_SEC_CONN_R_STATE_LIMIT"
-#line 1376 "seclang-parser.yy"
+#line 1379 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnReadStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2730 "seclang-parser.cc"
+#line 2733 "seclang-parser.cc"
     break;
 
   case 111: // expression: "CONFIG_SEC_CONN_W_STATE_LIMIT"
-#line 1381 "seclang-parser.yy"
+#line 1384 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnWriteStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2739 "seclang-parser.cc"
+#line 2742 "seclang-parser.cc"
     break;
 
   case 112: // expression: "CONFIG_SEC_SENSOR_ID"
-#line 1386 "seclang-parser.yy"
+#line 1389 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecSensorId is not yet supported.");
         YYERROR;
       }
-#line 2748 "seclang-parser.cc"
+#line 2751 "seclang-parser.cc"
     break;
 
   case 113: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_ON"
-#line 1391 "seclang-parser.yy"
+#line 1394 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecRuleInheritance is not yet supported.");
         YYERROR;
       }
-#line 2757 "seclang-parser.cc"
+#line 2760 "seclang-parser.cc"
     break;
 
   case 114: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_OFF"
-#line 1396 "seclang-parser.yy"
+#line 1399 "seclang-parser.yy"
       {
       }
-#line 2764 "seclang-parser.cc"
+#line 2767 "seclang-parser.cc"
     break;
 
   case 115: // expression: "CONFIG_SEC_RULE_PERF_TIME"
-#line 1399 "seclang-parser.yy"
+#line 1402 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecRulePerfTime is not yet supported.");
         YYERROR;
       }
-#line 2773 "seclang-parser.cc"
+#line 2776 "seclang-parser.cc"
     break;
 
   case 116: // expression: "CONFIG_SEC_STREAM_IN_BODY_INSPECTION"
-#line 1404 "seclang-parser.yy"
+#line 1407 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamInBodyInspection is not supported.");
         YYERROR;
       }
-#line 2782 "seclang-parser.cc"
+#line 2785 "seclang-parser.cc"
     break;
 
   case 117: // expression: "CONFIG_SEC_STREAM_OUT_BODY_INSPECTION"
-#line 1409 "seclang-parser.yy"
+#line 1412 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamOutBodyInspection is not supported.");
         YYERROR;
       }
-#line 2791 "seclang-parser.cc"
+#line 2794 "seclang-parser.cc"
     break;
 
   case 118: // expression: "CONFIG_SEC_RULE_REMOVE_BY_ID"
-#line 1414 "seclang-parser.yy"
+#line 1417 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.load(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2804,11 +2807,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2808 "seclang-parser.cc"
+#line 2811 "seclang-parser.cc"
     break;
 
   case 119: // expression: "CONFIG_SEC_RULE_REMOVE_BY_TAG"
-#line 1427 "seclang-parser.yy"
+#line 1430 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByTag(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2821,11 +2824,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2825 "seclang-parser.cc"
+#line 2828 "seclang-parser.cc"
     break;
 
   case 120: // expression: "CONFIG_SEC_RULE_REMOVE_BY_MSG"
-#line 1440 "seclang-parser.yy"
+#line 1443 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByMsg(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2838,11 +2841,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2842 "seclang-parser.cc"
+#line 2845 "seclang-parser.cc"
     break;
 
   case 121: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_TAG" variables_pre_process
-#line 1453 "seclang-parser.yy"
+#line 1456 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByTag(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2855,11 +2858,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2859 "seclang-parser.cc"
+#line 2862 "seclang-parser.cc"
     break;
 
   case 122: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_MSG" variables_pre_process
-#line 1466 "seclang-parser.yy"
+#line 1469 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByMsg(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2872,11 +2875,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2876 "seclang-parser.cc"
+#line 2879 "seclang-parser.cc"
     break;
 
   case 123: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID" variables_pre_process
-#line 1479 "seclang-parser.yy"
+#line 1482 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2902,11 +2905,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2906 "seclang-parser.cc"
+#line 2909 "seclang-parser.cc"
     break;
 
   case 124: // expression: "CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID" actions
-#line 1505 "seclang-parser.yy"
+#line 1508 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2933,11 +2936,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2937 "seclang-parser.cc"
+#line 2940 "seclang-parser.cc"
     break;
 
   case 125: // expression: "CONFIG_DIR_DEBUG_LVL"
-#line 1533 "seclang-parser.yy"
+#line 1536 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as < std::string > ().c_str()));
@@ -2949,11 +2952,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2953 "seclang-parser.cc"
+#line 2956 "seclang-parser.cc"
     break;
 
   case 126: // expression: "CONFIG_DIR_DEBUG_LOG"
-#line 1545 "seclang-parser.yy"
+#line 1548 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -2972,11 +2975,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2976 "seclang-parser.cc"
+#line 2979 "seclang-parser.cc"
     break;
 
   case 127: // expression: "CONFIG_DIR_GEO_DB"
-#line 1565 "seclang-parser.yy"
+#line 1568 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
@@ -3003,47 +3006,47 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 3007 "seclang-parser.cc"
+#line 3010 "seclang-parser.cc"
     break;
 
   case 128: // expression: "CONFIG_DIR_ARGS_LIMIT"
-#line 1592 "seclang-parser.yy"
+#line 1595 "seclang-parser.yy"
       {
         driver.m_argumentsLimit.m_set = true;
         driver.m_argumentsLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3016 "seclang-parser.cc"
+#line 3019 "seclang-parser.cc"
     break;
 
   case 129: // expression: "CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT"
-#line 1597 "seclang-parser.yy"
+#line 1600 "seclang-parser.yy"
       {
         driver.m_requestBodyJsonDepthLimit.m_set = true;
         driver.m_requestBodyJsonDepthLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3025 "seclang-parser.cc"
+#line 3028 "seclang-parser.cc"
     break;
 
   case 130: // expression: "CONFIG_DIR_REQ_BODY_LIMIT"
-#line 1603 "seclang-parser.yy"
+#line 1606 "seclang-parser.yy"
       {
         driver.m_requestBodyLimit.m_set = true;
         driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3034 "seclang-parser.cc"
+#line 3037 "seclang-parser.cc"
     break;
 
   case 131: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
-#line 1608 "seclang-parser.yy"
+#line 1611 "seclang-parser.yy"
       {
         driver.m_requestBodyNoFilesLimit.m_set = true;
         driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3043 "seclang-parser.cc"
+#line 3046 "seclang-parser.cc"
     break;
 
   case 132: // expression: "CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT"
-#line 1613 "seclang-parser.yy"
+#line 1616 "seclang-parser.yy"
       {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -3052,77 +3055,77 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 3056 "seclang-parser.cc"
+#line 3059 "seclang-parser.cc"
     break;
 
   case 133: // expression: "CONFIG_DIR_RES_BODY_LIMIT"
-#line 1622 "seclang-parser.yy"
+#line 1625 "seclang-parser.yy"
       {
         driver.m_responseBodyLimit.m_set = true;
         driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3065 "seclang-parser.cc"
+#line 3068 "seclang-parser.cc"
     break;
 
   case 134: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1627 "seclang-parser.yy"
+#line 1630 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3073 "seclang-parser.cc"
+#line 3076 "seclang-parser.cc"
     break;
 
   case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1631 "seclang-parser.yy"
+#line 1634 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3081 "seclang-parser.cc"
+#line 3084 "seclang-parser.cc"
     break;
 
   case 136: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1635 "seclang-parser.yy"
+#line 1638 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3089 "seclang-parser.cc"
+#line 3092 "seclang-parser.cc"
     break;
 
   case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1639 "seclang-parser.yy"
+#line 1642 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3097 "seclang-parser.cc"
+#line 3100 "seclang-parser.cc"
     break;
 
   case 138: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
-#line 1643 "seclang-parser.yy"
+#line 1646 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 3105 "seclang-parser.cc"
+#line 3108 "seclang-parser.cc"
     break;
 
   case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
-#line 1647 "seclang-parser.yy"
+#line 1650 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 3113 "seclang-parser.cc"
+#line 3116 "seclang-parser.cc"
     break;
 
   case 141: // expression: "CONFIG_DIR_PCRE_MATCH_LIMIT"
-#line 1656 "seclang-parser.yy"
+#line 1659 "seclang-parser.yy"
       {
         driver.m_pcreMatchLimit.m_set = true;
         driver.m_pcreMatchLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3122 "seclang-parser.cc"
+#line 3125 "seclang-parser.cc"
     break;
 
   case 142: // expression: "CONGIG_DIR_RESPONSE_BODY_MP"
-#line 1661 "seclang-parser.yy"
+#line 1664 "seclang-parser.yy"
       {
         std::istringstream buf(yystack_[0].value.as < std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -3134,37 +3137,37 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 3138 "seclang-parser.cc"
+#line 3141 "seclang-parser.cc"
     break;
 
   case 143: // expression: "CONGIG_DIR_RESPONSE_BODY_MP_CLEAR"
-#line 1673 "seclang-parser.yy"
+#line 1676 "seclang-parser.yy"
       {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 3148 "seclang-parser.cc"
+#line 3151 "seclang-parser.cc"
     break;
 
   case 144: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
-#line 1679 "seclang-parser.yy"
+#line 1682 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 3156 "seclang-parser.cc"
+#line 3159 "seclang-parser.cc"
     break;
 
   case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
-#line 1683 "seclang-parser.yy"
+#line 1686 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 3164 "seclang-parser.cc"
+#line 3167 "seclang-parser.cc"
     break;
 
   case 146: // expression: "CONGIG_DIR_SEC_TMP_DIR"
-#line 1687 "seclang-parser.yy"
+#line 1690 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
         std::stringstream ss;
@@ -3175,31 +3178,31 @@ namespace yy {
         YYERROR;
 */
       }
-#line 3179 "seclang-parser.cc"
+#line 3182 "seclang-parser.cc"
     break;
 
   case 149: // expression: "CONGIG_DIR_SEC_COOKIE_FORMAT"
-#line 1708 "seclang-parser.yy"
+#line 1711 "seclang-parser.yy"
       {
         if (atoi(yystack_[0].value.as < std::string > ().c_str()) == 1) {
           driver.error(yystack_[1].location, "SecCookieFormat 1 is not yet supported.");
           YYERROR;
         }
       }
-#line 3190 "seclang-parser.cc"
+#line 3193 "seclang-parser.cc"
     break;
 
   case 150: // expression: "CONFIG_SEC_COOKIEV0_SEPARATOR"
-#line 1715 "seclang-parser.yy"
+#line 1718 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCookieV0Separator is not yet supported.");
         YYERROR;
       }
-#line 3199 "seclang-parser.cc"
+#line 3202 "seclang-parser.cc"
     break;
 
   case 152: // expression: "CONFIG_DIR_UNICODE_MAP_FILE"
-#line 1725 "seclang-parser.yy"
+#line 1728 "seclang-parser.yy"
       {
         std::string error;
         std::vector<std::string> param;
@@ -3253,31 +3256,31 @@ namespace yy {
         }
 
       }
-#line 3257 "seclang-parser.cc"
+#line 3260 "seclang-parser.cc"
     break;
 
   case 153: // expression: "CONFIG_SEC_COLLECTION_TIMEOUT"
-#line 1779 "seclang-parser.yy"
+#line 1782 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default CRS installations with crs-setup.conf-recommended
         driver.error(@0, "SecCollectionTimeout is not yet supported.");
         YYERROR;
 */
       }
-#line 3268 "seclang-parser.cc"
+#line 3271 "seclang-parser.cc"
     break;
 
   case 154: // expression: "CONFIG_SEC_HTTP_BLKEY"
-#line 1786 "seclang-parser.yy"
+#line 1789 "seclang-parser.yy"
       {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 3277 "seclang-parser.cc"
+#line 3280 "seclang-parser.cc"
     break;
 
   case 155: // variables: variables_pre_process
-#line 1794 "seclang-parser.yy"
+#line 1797 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable> > > originalList = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> newList(new std::vector<std::unique_ptr<Variable>>());
@@ -3311,2401 +3314,2401 @@ namespace yy {
         }
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(newNewList);
       }
-#line 3315 "seclang-parser.cc"
+#line 3318 "seclang-parser.cc"
     break;
 
   case 156: // variables_pre_process: variables_may_be_quoted
-#line 1831 "seclang-parser.yy"
+#line 1834 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3323 "seclang-parser.cc"
+#line 3326 "seclang-parser.cc"
     break;
 
   case 157: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
-#line 1835 "seclang-parser.yy"
+#line 1838 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3331 "seclang-parser.cc"
+#line 3334 "seclang-parser.cc"
     break;
 
   case 158: // variables_may_be_quoted: variables_may_be_quoted PIPE var
-#line 1842 "seclang-parser.yy"
+#line 1845 "seclang-parser.yy"
       {
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3340 "seclang-parser.cc"
+#line 3343 "seclang-parser.cc"
     break;
 
   case 159: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_EXCLUSION var
-#line 1847 "seclang-parser.yy"
+#line 1850 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3350 "seclang-parser.cc"
+#line 3353 "seclang-parser.cc"
     break;
 
   case 160: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_COUNT var
-#line 1853 "seclang-parser.yy"
+#line 1856 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3360 "seclang-parser.cc"
+#line 3363 "seclang-parser.cc"
     break;
 
   case 161: // variables_may_be_quoted: var
-#line 1859 "seclang-parser.yy"
+#line 1862 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3370 "seclang-parser.cc"
+#line 3373 "seclang-parser.cc"
     break;
 
   case 162: // variables_may_be_quoted: VAR_EXCLUSION var
-#line 1865 "seclang-parser.yy"
+#line 1868 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3381 "seclang-parser.cc"
+#line 3384 "seclang-parser.cc"
     break;
 
   case 163: // variables_may_be_quoted: VAR_COUNT var
-#line 1872 "seclang-parser.yy"
+#line 1875 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3392 "seclang-parser.cc"
+#line 3395 "seclang-parser.cc"
     break;
 
   case 164: // var: VARIABLE_ARGS "Dictionary element"
-#line 1882 "seclang-parser.yy"
+#line 1885 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3400 "seclang-parser.cc"
+#line 3403 "seclang-parser.cc"
     break;
 
   case 165: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
-#line 1886 "seclang-parser.yy"
+#line 1889 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3408 "seclang-parser.cc"
+#line 3411 "seclang-parser.cc"
     break;
 
   case 166: // var: VARIABLE_ARGS
-#line 1890 "seclang-parser.yy"
+#line 1893 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
       }
-#line 3416 "seclang-parser.cc"
+#line 3419 "seclang-parser.cc"
     break;
 
   case 167: // var: VARIABLE_ARGS_POST "Dictionary element"
-#line 1894 "seclang-parser.yy"
+#line 1897 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3424 "seclang-parser.cc"
+#line 3427 "seclang-parser.cc"
     break;
 
   case 168: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
-#line 1898 "seclang-parser.yy"
+#line 1901 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3432 "seclang-parser.cc"
+#line 3435 "seclang-parser.cc"
     break;
 
   case 169: // var: VARIABLE_ARGS_POST
-#line 1902 "seclang-parser.yy"
+#line 1905 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
       }
-#line 3440 "seclang-parser.cc"
+#line 3443 "seclang-parser.cc"
     break;
 
   case 170: // var: VARIABLE_ARGS_GET "Dictionary element"
-#line 1906 "seclang-parser.yy"
+#line 1909 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3448 "seclang-parser.cc"
+#line 3451 "seclang-parser.cc"
     break;
 
   case 171: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
-#line 1910 "seclang-parser.yy"
+#line 1913 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3456 "seclang-parser.cc"
+#line 3459 "seclang-parser.cc"
     break;
 
   case 172: // var: VARIABLE_ARGS_GET
-#line 1914 "seclang-parser.yy"
+#line 1917 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
       }
-#line 3464 "seclang-parser.cc"
+#line 3467 "seclang-parser.cc"
     break;
 
   case 173: // var: VARIABLE_FILES_SIZES "Dictionary element"
-#line 1918 "seclang-parser.yy"
+#line 1921 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3472 "seclang-parser.cc"
+#line 3475 "seclang-parser.cc"
     break;
 
   case 174: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
-#line 1922 "seclang-parser.yy"
+#line 1925 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3480 "seclang-parser.cc"
+#line 3483 "seclang-parser.cc"
     break;
 
   case 175: // var: VARIABLE_FILES_SIZES
-#line 1926 "seclang-parser.yy"
+#line 1929 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
       }
-#line 3488 "seclang-parser.cc"
+#line 3491 "seclang-parser.cc"
     break;
 
   case 176: // var: VARIABLE_FILES_NAMES "Dictionary element"
-#line 1930 "seclang-parser.yy"
+#line 1933 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3496 "seclang-parser.cc"
+#line 3499 "seclang-parser.cc"
     break;
 
   case 177: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
-#line 1934 "seclang-parser.yy"
+#line 1937 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3504 "seclang-parser.cc"
+#line 3507 "seclang-parser.cc"
     break;
 
   case 178: // var: VARIABLE_FILES_NAMES
-#line 1938 "seclang-parser.yy"
+#line 1941 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
       }
-#line 3512 "seclang-parser.cc"
+#line 3515 "seclang-parser.cc"
     break;
 
   case 179: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
-#line 1942 "seclang-parser.yy"
+#line 1945 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3520 "seclang-parser.cc"
+#line 3523 "seclang-parser.cc"
     break;
 
   case 180: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
-#line 1946 "seclang-parser.yy"
+#line 1949 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3528 "seclang-parser.cc"
+#line 3531 "seclang-parser.cc"
     break;
 
   case 181: // var: VARIABLE_FILES_TMP_CONTENT
-#line 1950 "seclang-parser.yy"
+#line 1953 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
       }
-#line 3536 "seclang-parser.cc"
+#line 3539 "seclang-parser.cc"
     break;
 
   case 182: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
-#line 1954 "seclang-parser.yy"
+#line 1957 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3544 "seclang-parser.cc"
+#line 3547 "seclang-parser.cc"
     break;
 
   case 183: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
-#line 1958 "seclang-parser.yy"
+#line 1961 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3552 "seclang-parser.cc"
+#line 3555 "seclang-parser.cc"
     break;
 
   case 184: // var: VARIABLE_MULTIPART_FILENAME
-#line 1962 "seclang-parser.yy"
+#line 1965 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
       }
-#line 3560 "seclang-parser.cc"
+#line 3563 "seclang-parser.cc"
     break;
 
   case 185: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
-#line 1966 "seclang-parser.yy"
+#line 1969 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3568 "seclang-parser.cc"
+#line 3571 "seclang-parser.cc"
     break;
 
   case 186: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
-#line 1970 "seclang-parser.yy"
+#line 1973 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3576 "seclang-parser.cc"
+#line 3579 "seclang-parser.cc"
     break;
 
   case 187: // var: VARIABLE_MULTIPART_NAME
-#line 1974 "seclang-parser.yy"
+#line 1977 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
       }
-#line 3584 "seclang-parser.cc"
+#line 3587 "seclang-parser.cc"
     break;
 
   case 188: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
-#line 1978 "seclang-parser.yy"
+#line 1981 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3592 "seclang-parser.cc"
+#line 3595 "seclang-parser.cc"
     break;
 
   case 189: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
-#line 1982 "seclang-parser.yy"
+#line 1985 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3600 "seclang-parser.cc"
+#line 3603 "seclang-parser.cc"
     break;
 
   case 190: // var: VARIABLE_MATCHED_VARS_NAMES
-#line 1986 "seclang-parser.yy"
+#line 1989 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
       }
-#line 3608 "seclang-parser.cc"
+#line 3611 "seclang-parser.cc"
     break;
 
   case 191: // var: VARIABLE_MATCHED_VARS "Dictionary element"
-#line 1990 "seclang-parser.yy"
+#line 1993 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3616 "seclang-parser.cc"
+#line 3619 "seclang-parser.cc"
     break;
 
   case 192: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
-#line 1994 "seclang-parser.yy"
+#line 1997 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3624 "seclang-parser.cc"
+#line 3627 "seclang-parser.cc"
     break;
 
   case 193: // var: VARIABLE_MATCHED_VARS
-#line 1998 "seclang-parser.yy"
+#line 2001 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
       }
-#line 3632 "seclang-parser.cc"
+#line 3635 "seclang-parser.cc"
     break;
 
   case 194: // var: VARIABLE_FILES "Dictionary element"
-#line 2002 "seclang-parser.yy"
+#line 2005 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3640 "seclang-parser.cc"
+#line 3643 "seclang-parser.cc"
     break;
 
   case 195: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
-#line 2006 "seclang-parser.yy"
+#line 2009 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3648 "seclang-parser.cc"
+#line 3651 "seclang-parser.cc"
     break;
 
   case 196: // var: VARIABLE_FILES
-#line 2010 "seclang-parser.yy"
+#line 2013 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
       }
-#line 3656 "seclang-parser.cc"
+#line 3659 "seclang-parser.cc"
     break;
 
   case 197: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
-#line 2014 "seclang-parser.yy"
+#line 2017 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3664 "seclang-parser.cc"
+#line 3667 "seclang-parser.cc"
     break;
 
   case 198: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
-#line 2018 "seclang-parser.yy"
+#line 2021 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3672 "seclang-parser.cc"
+#line 3675 "seclang-parser.cc"
     break;
 
   case 199: // var: VARIABLE_REQUEST_COOKIES
-#line 2022 "seclang-parser.yy"
+#line 2025 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
       }
-#line 3680 "seclang-parser.cc"
+#line 3683 "seclang-parser.cc"
     break;
 
   case 200: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
-#line 2026 "seclang-parser.yy"
+#line 2029 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3688 "seclang-parser.cc"
+#line 3691 "seclang-parser.cc"
     break;
 
   case 201: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
-#line 2030 "seclang-parser.yy"
+#line 2033 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3696 "seclang-parser.cc"
+#line 3699 "seclang-parser.cc"
     break;
 
   case 202: // var: VARIABLE_REQUEST_HEADERS
-#line 2034 "seclang-parser.yy"
+#line 2037 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
       }
-#line 3704 "seclang-parser.cc"
+#line 3707 "seclang-parser.cc"
     break;
 
   case 203: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
-#line 2038 "seclang-parser.yy"
+#line 2041 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3712 "seclang-parser.cc"
+#line 3715 "seclang-parser.cc"
     break;
 
   case 204: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
-#line 2042 "seclang-parser.yy"
+#line 2045 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3720 "seclang-parser.cc"
+#line 3723 "seclang-parser.cc"
     break;
 
   case 205: // var: VARIABLE_RESPONSE_HEADERS
-#line 2046 "seclang-parser.yy"
+#line 2049 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
       }
-#line 3728 "seclang-parser.cc"
+#line 3731 "seclang-parser.cc"
     break;
 
   case 206: // var: VARIABLE_GEO "Dictionary element"
-#line 2050 "seclang-parser.yy"
+#line 2053 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3736 "seclang-parser.cc"
+#line 3739 "seclang-parser.cc"
     break;
 
   case 207: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
-#line 2054 "seclang-parser.yy"
+#line 2057 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3744 "seclang-parser.cc"
+#line 3747 "seclang-parser.cc"
     break;
 
   case 208: // var: VARIABLE_GEO
-#line 2058 "seclang-parser.yy"
+#line 2061 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
       }
-#line 3752 "seclang-parser.cc"
+#line 3755 "seclang-parser.cc"
     break;
 
   case 209: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
-#line 2062 "seclang-parser.yy"
+#line 2065 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3760 "seclang-parser.cc"
+#line 3763 "seclang-parser.cc"
     break;
 
   case 210: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
-#line 2066 "seclang-parser.yy"
+#line 2069 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3768 "seclang-parser.cc"
+#line 3771 "seclang-parser.cc"
     break;
 
   case 211: // var: VARIABLE_REQUEST_COOKIES_NAMES
-#line 2070 "seclang-parser.yy"
+#line 2073 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
       }
-#line 3776 "seclang-parser.cc"
+#line 3779 "seclang-parser.cc"
     break;
 
   case 212: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element"
-#line 2074 "seclang-parser.yy"
+#line 2077 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3784 "seclang-parser.cc"
+#line 3787 "seclang-parser.cc"
     break;
 
   case 213: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element, selected by regexp"
-#line 2078 "seclang-parser.yy"
+#line 2081 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3792 "seclang-parser.cc"
+#line 3795 "seclang-parser.cc"
     break;
 
   case 214: // var: VARIABLE_MULTIPART_PART_HEADERS
-#line 2082 "seclang-parser.yy"
+#line 2085 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_NoDictElement());
       }
-#line 3800 "seclang-parser.cc"
+#line 3803 "seclang-parser.cc"
     break;
 
   case 215: // var: VARIABLE_RULE "Dictionary element"
-#line 2086 "seclang-parser.yy"
+#line 2089 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3808 "seclang-parser.cc"
+#line 3811 "seclang-parser.cc"
     break;
 
   case 216: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
-#line 2090 "seclang-parser.yy"
+#line 2093 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3816 "seclang-parser.cc"
+#line 3819 "seclang-parser.cc"
     break;
 
   case 217: // var: VARIABLE_RULE
-#line 2094 "seclang-parser.yy"
+#line 2097 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
       }
-#line 3824 "seclang-parser.cc"
+#line 3827 "seclang-parser.cc"
     break;
 
   case 218: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
-#line 2098 "seclang-parser.yy"
+#line 2101 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3832 "seclang-parser.cc"
+#line 3835 "seclang-parser.cc"
     break;
 
   case 219: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
-#line 2102 "seclang-parser.yy"
+#line 2105 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3840 "seclang-parser.cc"
+#line 3843 "seclang-parser.cc"
     break;
 
   case 220: // var: "RUN_TIME_VAR_ENV"
-#line 2106 "seclang-parser.yy"
+#line 2109 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
       }
-#line 3848 "seclang-parser.cc"
+#line 3851 "seclang-parser.cc"
     break;
 
   case 221: // var: "RUN_TIME_VAR_XML" "Dictionary element"
-#line 2110 "seclang-parser.yy"
+#line 2113 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3856 "seclang-parser.cc"
+#line 3859 "seclang-parser.cc"
     break;
 
   case 222: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
-#line 2114 "seclang-parser.yy"
+#line 2117 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3864 "seclang-parser.cc"
+#line 3867 "seclang-parser.cc"
     break;
 
   case 223: // var: "RUN_TIME_VAR_XML"
-#line 2118 "seclang-parser.yy"
+#line 2121 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
       }
-#line 3872 "seclang-parser.cc"
+#line 3875 "seclang-parser.cc"
     break;
 
   case 224: // var: "FILES_TMPNAMES" "Dictionary element"
-#line 2122 "seclang-parser.yy"
+#line 2125 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3880 "seclang-parser.cc"
+#line 3883 "seclang-parser.cc"
     break;
 
   case 225: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
-#line 2126 "seclang-parser.yy"
+#line 2129 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3888 "seclang-parser.cc"
+#line 3891 "seclang-parser.cc"
     break;
 
   case 226: // var: "FILES_TMPNAMES"
-#line 2130 "seclang-parser.yy"
+#line 2133 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
       }
-#line 3896 "seclang-parser.cc"
+#line 3899 "seclang-parser.cc"
     break;
 
   case 227: // var: "RESOURCE" run_time_string
-#line 2134 "seclang-parser.yy"
+#line 2137 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3904 "seclang-parser.cc"
+#line 3907 "seclang-parser.cc"
     break;
 
   case 228: // var: "RESOURCE" "Dictionary element"
-#line 2138 "seclang-parser.yy"
+#line 2141 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3912 "seclang-parser.cc"
+#line 3915 "seclang-parser.cc"
     break;
 
   case 229: // var: "RESOURCE" "Dictionary element, selected by regexp"
-#line 2142 "seclang-parser.yy"
+#line 2145 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3920 "seclang-parser.cc"
+#line 3923 "seclang-parser.cc"
     break;
 
   case 230: // var: "RESOURCE"
-#line 2146 "seclang-parser.yy"
+#line 2149 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
       }
-#line 3928 "seclang-parser.cc"
+#line 3931 "seclang-parser.cc"
     break;
 
   case 231: // var: "VARIABLE_IP" run_time_string
-#line 2150 "seclang-parser.yy"
+#line 2153 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3936 "seclang-parser.cc"
+#line 3939 "seclang-parser.cc"
     break;
 
   case 232: // var: "VARIABLE_IP" "Dictionary element"
-#line 2154 "seclang-parser.yy"
+#line 2157 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3944 "seclang-parser.cc"
+#line 3947 "seclang-parser.cc"
     break;
 
   case 233: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
-#line 2158 "seclang-parser.yy"
+#line 2161 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3952 "seclang-parser.cc"
+#line 3955 "seclang-parser.cc"
     break;
 
   case 234: // var: "VARIABLE_IP"
-#line 2162 "seclang-parser.yy"
+#line 2165 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
       }
-#line 3960 "seclang-parser.cc"
+#line 3963 "seclang-parser.cc"
     break;
 
   case 235: // var: "VARIABLE_GLOBAL" run_time_string
-#line 2166 "seclang-parser.yy"
+#line 2169 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3968 "seclang-parser.cc"
+#line 3971 "seclang-parser.cc"
     break;
 
   case 236: // var: "VARIABLE_GLOBAL" "Dictionary element"
-#line 2170 "seclang-parser.yy"
+#line 2173 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3976 "seclang-parser.cc"
+#line 3979 "seclang-parser.cc"
     break;
 
   case 237: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
-#line 2174 "seclang-parser.yy"
+#line 2177 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3984 "seclang-parser.cc"
+#line 3987 "seclang-parser.cc"
     break;
 
   case 238: // var: "VARIABLE_GLOBAL"
-#line 2178 "seclang-parser.yy"
+#line 2181 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
       }
-#line 3992 "seclang-parser.cc"
+#line 3995 "seclang-parser.cc"
     break;
 
   case 239: // var: "VARIABLE_USER" run_time_string
-#line 2182 "seclang-parser.yy"
+#line 2185 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4000 "seclang-parser.cc"
+#line 4003 "seclang-parser.cc"
     break;
 
   case 240: // var: "VARIABLE_USER" "Dictionary element"
-#line 2186 "seclang-parser.yy"
+#line 2189 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4008 "seclang-parser.cc"
+#line 4011 "seclang-parser.cc"
     break;
 
   case 241: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
-#line 2190 "seclang-parser.yy"
+#line 2193 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4016 "seclang-parser.cc"
+#line 4019 "seclang-parser.cc"
     break;
 
   case 242: // var: "VARIABLE_USER"
-#line 2194 "seclang-parser.yy"
+#line 2197 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
       }
-#line 4024 "seclang-parser.cc"
+#line 4027 "seclang-parser.cc"
     break;
 
   case 243: // var: "VARIABLE_TX" run_time_string
-#line 2198 "seclang-parser.yy"
+#line 2201 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4032 "seclang-parser.cc"
+#line 4035 "seclang-parser.cc"
     break;
 
   case 244: // var: "VARIABLE_TX" "Dictionary element"
-#line 2202 "seclang-parser.yy"
+#line 2205 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4040 "seclang-parser.cc"
+#line 4043 "seclang-parser.cc"
     break;
 
   case 245: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
-#line 2206 "seclang-parser.yy"
+#line 2209 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4048 "seclang-parser.cc"
+#line 4051 "seclang-parser.cc"
     break;
 
   case 246: // var: "VARIABLE_TX"
-#line 2210 "seclang-parser.yy"
+#line 2213 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
       }
-#line 4056 "seclang-parser.cc"
+#line 4059 "seclang-parser.cc"
     break;
 
   case 247: // var: "VARIABLE_SESSION" run_time_string
-#line 2214 "seclang-parser.yy"
+#line 2217 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4064 "seclang-parser.cc"
+#line 4067 "seclang-parser.cc"
     break;
 
   case 248: // var: "VARIABLE_SESSION" "Dictionary element"
-#line 2218 "seclang-parser.yy"
+#line 2221 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4072 "seclang-parser.cc"
+#line 4075 "seclang-parser.cc"
     break;
 
   case 249: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
-#line 2222 "seclang-parser.yy"
+#line 2225 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4080 "seclang-parser.cc"
+#line 4083 "seclang-parser.cc"
     break;
 
   case 250: // var: "VARIABLE_SESSION"
-#line 2226 "seclang-parser.yy"
+#line 2229 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
       }
-#line 4088 "seclang-parser.cc"
+#line 4091 "seclang-parser.cc"
     break;
 
   case 251: // var: "Variable ARGS_NAMES" "Dictionary element"
-#line 2230 "seclang-parser.yy"
+#line 2233 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4096 "seclang-parser.cc"
+#line 4099 "seclang-parser.cc"
     break;
 
   case 252: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
-#line 2234 "seclang-parser.yy"
+#line 2237 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4104 "seclang-parser.cc"
+#line 4107 "seclang-parser.cc"
     break;
 
   case 253: // var: "Variable ARGS_NAMES"
-#line 2238 "seclang-parser.yy"
+#line 2241 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
       }
-#line 4112 "seclang-parser.cc"
+#line 4115 "seclang-parser.cc"
     break;
 
   case 254: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
-#line 2242 "seclang-parser.yy"
+#line 2245 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4120 "seclang-parser.cc"
+#line 4123 "seclang-parser.cc"
     break;
 
   case 255: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
-#line 2246 "seclang-parser.yy"
+#line 2249 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4128 "seclang-parser.cc"
+#line 4131 "seclang-parser.cc"
     break;
 
   case 256: // var: VARIABLE_ARGS_GET_NAMES
-#line 2250 "seclang-parser.yy"
+#line 2253 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
       }
-#line 4136 "seclang-parser.cc"
+#line 4139 "seclang-parser.cc"
     break;
 
   case 257: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
-#line 2255 "seclang-parser.yy"
+#line 2258 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4144 "seclang-parser.cc"
+#line 4147 "seclang-parser.cc"
     break;
 
   case 258: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
-#line 2259 "seclang-parser.yy"
+#line 2262 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4152 "seclang-parser.cc"
+#line 4155 "seclang-parser.cc"
     break;
 
   case 259: // var: VARIABLE_ARGS_POST_NAMES
-#line 2263 "seclang-parser.yy"
+#line 2266 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
       }
-#line 4160 "seclang-parser.cc"
+#line 4163 "seclang-parser.cc"
     break;
 
   case 260: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
-#line 2268 "seclang-parser.yy"
+#line 2271 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4168 "seclang-parser.cc"
+#line 4171 "seclang-parser.cc"
     break;
 
   case 261: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2272 "seclang-parser.yy"
+#line 2275 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4176 "seclang-parser.cc"
+#line 4179 "seclang-parser.cc"
     break;
 
   case 262: // var: VARIABLE_REQUEST_HEADERS_NAMES
-#line 2276 "seclang-parser.yy"
+#line 2279 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
       }
-#line 4184 "seclang-parser.cc"
+#line 4187 "seclang-parser.cc"
     break;
 
   case 263: // var: VARIABLE_RESPONSE_CONTENT_TYPE
-#line 2281 "seclang-parser.yy"
+#line 2284 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
       }
-#line 4192 "seclang-parser.cc"
+#line 4195 "seclang-parser.cc"
     break;
 
   case 264: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
-#line 2286 "seclang-parser.yy"
+#line 2289 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4200 "seclang-parser.cc"
+#line 4203 "seclang-parser.cc"
     break;
 
   case 265: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2290 "seclang-parser.yy"
+#line 2293 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4208 "seclang-parser.cc"
+#line 4211 "seclang-parser.cc"
     break;
 
   case 266: // var: VARIABLE_RESPONSE_HEADERS_NAMES
-#line 2294 "seclang-parser.yy"
+#line 2297 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
       }
-#line 4216 "seclang-parser.cc"
+#line 4219 "seclang-parser.cc"
     break;
 
   case 267: // var: VARIABLE_ARGS_COMBINED_SIZE
-#line 2298 "seclang-parser.yy"
+#line 2301 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
       }
-#line 4224 "seclang-parser.cc"
+#line 4227 "seclang-parser.cc"
     break;
 
   case 268: // var: "AUTH_TYPE"
-#line 2302 "seclang-parser.yy"
+#line 2305 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
       }
-#line 4232 "seclang-parser.cc"
+#line 4235 "seclang-parser.cc"
     break;
 
   case 269: // var: "FILES_COMBINED_SIZE"
-#line 2306 "seclang-parser.yy"
+#line 2309 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
       }
-#line 4240 "seclang-parser.cc"
+#line 4243 "seclang-parser.cc"
     break;
 
   case 270: // var: "FULL_REQUEST"
-#line 2310 "seclang-parser.yy"
+#line 2313 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
       }
-#line 4248 "seclang-parser.cc"
+#line 4251 "seclang-parser.cc"
     break;
 
   case 271: // var: "FULL_REQUEST_LENGTH"
-#line 2314 "seclang-parser.yy"
+#line 2317 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
       }
-#line 4256 "seclang-parser.cc"
+#line 4259 "seclang-parser.cc"
     break;
 
   case 272: // var: "INBOUND_DATA_ERROR"
-#line 2318 "seclang-parser.yy"
+#line 2321 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
       }
-#line 4264 "seclang-parser.cc"
+#line 4267 "seclang-parser.cc"
     break;
 
   case 273: // var: "MATCHED_VAR"
-#line 2322 "seclang-parser.yy"
+#line 2325 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
       }
-#line 4272 "seclang-parser.cc"
+#line 4275 "seclang-parser.cc"
     break;
 
   case 274: // var: "MATCHED_VAR_NAME"
-#line 2326 "seclang-parser.yy"
+#line 2329 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
       }
-#line 4280 "seclang-parser.cc"
+#line 4283 "seclang-parser.cc"
     break;
 
   case 275: // var: "MSC_PCRE_ERROR"
-#line 2330 "seclang-parser.yy"
+#line 2333 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreError());
       }
-#line 4288 "seclang-parser.cc"
+#line 4291 "seclang-parser.cc"
     break;
 
   case 276: // var: "MSC_PCRE_LIMITS_EXCEEDED"
-#line 2334 "seclang-parser.yy"
+#line 2337 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreLimitsExceeded());
       }
-#line 4296 "seclang-parser.cc"
+#line 4299 "seclang-parser.cc"
     break;
 
   case 277: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
-#line 2338 "seclang-parser.yy"
+#line 2341 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
       }
-#line 4304 "seclang-parser.cc"
+#line 4307 "seclang-parser.cc"
     break;
 
   case 278: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
-#line 2342 "seclang-parser.yy"
+#line 2345 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
       }
-#line 4312 "seclang-parser.cc"
+#line 4315 "seclang-parser.cc"
     break;
 
   case 279: // var: "MULTIPART_CRLF_LF_LINES"
-#line 2346 "seclang-parser.yy"
+#line 2349 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
       }
-#line 4320 "seclang-parser.cc"
+#line 4323 "seclang-parser.cc"
     break;
 
   case 280: // var: "MULTIPART_DATA_AFTER"
-#line 2350 "seclang-parser.yy"
+#line 2353 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
       }
-#line 4328 "seclang-parser.cc"
+#line 4331 "seclang-parser.cc"
     break;
 
   case 281: // var: VARIABLE_MULTIPART_DATA_BEFORE
-#line 2354 "seclang-parser.yy"
+#line 2357 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
       }
-#line 4336 "seclang-parser.cc"
+#line 4339 "seclang-parser.cc"
     break;
 
   case 282: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
-#line 2358 "seclang-parser.yy"
+#line 2361 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
       }
-#line 4344 "seclang-parser.cc"
+#line 4347 "seclang-parser.cc"
     break;
 
   case 283: // var: "MULTIPART_HEADER_FOLDING"
-#line 2362 "seclang-parser.yy"
+#line 2365 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
       }
-#line 4352 "seclang-parser.cc"
+#line 4355 "seclang-parser.cc"
     break;
 
   case 284: // var: "MULTIPART_INVALID_HEADER_FOLDING"
-#line 2366 "seclang-parser.yy"
+#line 2369 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
       }
-#line 4360 "seclang-parser.cc"
+#line 4363 "seclang-parser.cc"
     break;
 
   case 285: // var: VARIABLE_MULTIPART_INVALID_PART
-#line 2370 "seclang-parser.yy"
+#line 2373 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
       }
-#line 4368 "seclang-parser.cc"
+#line 4371 "seclang-parser.cc"
     break;
 
   case 286: // var: "MULTIPART_INVALID_QUOTING"
-#line 2374 "seclang-parser.yy"
+#line 2377 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
       }
-#line 4376 "seclang-parser.cc"
+#line 4379 "seclang-parser.cc"
     break;
 
   case 287: // var: VARIABLE_MULTIPART_LF_LINE
-#line 2378 "seclang-parser.yy"
+#line 2381 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
       }
-#line 4384 "seclang-parser.cc"
+#line 4387 "seclang-parser.cc"
     break;
 
   case 288: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
-#line 2382 "seclang-parser.yy"
+#line 2385 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4392 "seclang-parser.cc"
+#line 4395 "seclang-parser.cc"
     break;
 
   case 289: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
-#line 2386 "seclang-parser.yy"
+#line 2389 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4400 "seclang-parser.cc"
+#line 4403 "seclang-parser.cc"
     break;
 
   case 290: // var: "MULTIPART_STRICT_ERROR"
-#line 2390 "seclang-parser.yy"
+#line 2393 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
       }
-#line 4408 "seclang-parser.cc"
+#line 4411 "seclang-parser.cc"
     break;
 
   case 291: // var: "MULTIPART_UNMATCHED_BOUNDARY"
-#line 2394 "seclang-parser.yy"
+#line 2397 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
       }
-#line 4416 "seclang-parser.cc"
+#line 4419 "seclang-parser.cc"
     break;
 
   case 292: // var: "OUTBOUND_DATA_ERROR"
-#line 2398 "seclang-parser.yy"
+#line 2401 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
       }
-#line 4424 "seclang-parser.cc"
+#line 4427 "seclang-parser.cc"
     break;
 
   case 293: // var: "PATH_INFO"
-#line 2402 "seclang-parser.yy"
+#line 2405 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
       }
-#line 4432 "seclang-parser.cc"
+#line 4435 "seclang-parser.cc"
     break;
 
   case 294: // var: "QUERY_STRING"
-#line 2406 "seclang-parser.yy"
+#line 2409 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
       }
-#line 4440 "seclang-parser.cc"
+#line 4443 "seclang-parser.cc"
     break;
 
   case 295: // var: "REMOTE_ADDR"
-#line 2410 "seclang-parser.yy"
+#line 2413 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
       }
-#line 4448 "seclang-parser.cc"
+#line 4451 "seclang-parser.cc"
     break;
 
   case 296: // var: "REMOTE_HOST"
-#line 2414 "seclang-parser.yy"
+#line 2417 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
       }
-#line 4456 "seclang-parser.cc"
+#line 4459 "seclang-parser.cc"
     break;
 
   case 297: // var: "REMOTE_PORT"
-#line 2418 "seclang-parser.yy"
+#line 2421 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
       }
-#line 4464 "seclang-parser.cc"
+#line 4467 "seclang-parser.cc"
     break;
 
   case 298: // var: "REQBODY_ERROR"
-#line 2422 "seclang-parser.yy"
+#line 2425 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
       }
-#line 4472 "seclang-parser.cc"
+#line 4475 "seclang-parser.cc"
     break;
 
   case 299: // var: "REQBODY_ERROR_MSG"
-#line 2426 "seclang-parser.yy"
+#line 2429 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
       }
-#line 4480 "seclang-parser.cc"
+#line 4483 "seclang-parser.cc"
     break;
 
   case 300: // var: "REQBODY_PROCESSOR"
-#line 2430 "seclang-parser.yy"
+#line 2433 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
       }
-#line 4488 "seclang-parser.cc"
+#line 4491 "seclang-parser.cc"
     break;
 
   case 301: // var: "REQBODY_PROCESSOR_ERROR"
-#line 2434 "seclang-parser.yy"
+#line 2437 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
       }
-#line 4496 "seclang-parser.cc"
+#line 4499 "seclang-parser.cc"
     break;
 
   case 302: // var: "REQBODY_PROCESSOR_ERROR_MSG"
-#line 2438 "seclang-parser.yy"
+#line 2441 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
       }
-#line 4504 "seclang-parser.cc"
+#line 4507 "seclang-parser.cc"
     break;
 
   case 303: // var: "REQUEST_BASENAME"
-#line 2442 "seclang-parser.yy"
+#line 2445 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
       }
-#line 4512 "seclang-parser.cc"
+#line 4515 "seclang-parser.cc"
     break;
 
   case 304: // var: "REQUEST_BODY"
-#line 2446 "seclang-parser.yy"
+#line 2449 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
       }
-#line 4520 "seclang-parser.cc"
+#line 4523 "seclang-parser.cc"
     break;
 
   case 305: // var: "REQUEST_BODY_LENGTH"
-#line 2450 "seclang-parser.yy"
+#line 2453 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
       }
-#line 4528 "seclang-parser.cc"
+#line 4531 "seclang-parser.cc"
     break;
 
   case 306: // var: "REQUEST_FILENAME"
-#line 2454 "seclang-parser.yy"
+#line 2457 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
       }
-#line 4536 "seclang-parser.cc"
+#line 4539 "seclang-parser.cc"
     break;
 
   case 307: // var: "REQUEST_LINE"
-#line 2458 "seclang-parser.yy"
+#line 2461 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
       }
-#line 4544 "seclang-parser.cc"
+#line 4547 "seclang-parser.cc"
     break;
 
   case 308: // var: "REQUEST_METHOD"
-#line 2462 "seclang-parser.yy"
+#line 2465 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
       }
-#line 4552 "seclang-parser.cc"
+#line 4555 "seclang-parser.cc"
     break;
 
   case 309: // var: "REQUEST_PROTOCOL"
-#line 2466 "seclang-parser.yy"
+#line 2469 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
       }
-#line 4560 "seclang-parser.cc"
+#line 4563 "seclang-parser.cc"
     break;
 
   case 310: // var: "REQUEST_URI"
-#line 2470 "seclang-parser.yy"
+#line 2473 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
       }
-#line 4568 "seclang-parser.cc"
+#line 4571 "seclang-parser.cc"
     break;
 
   case 311: // var: "REQUEST_URI_RAW"
-#line 2474 "seclang-parser.yy"
+#line 2477 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
       }
-#line 4576 "seclang-parser.cc"
+#line 4579 "seclang-parser.cc"
     break;
 
   case 312: // var: "RESPONSE_BODY"
-#line 2478 "seclang-parser.yy"
+#line 2481 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
       }
-#line 4584 "seclang-parser.cc"
+#line 4587 "seclang-parser.cc"
     break;
 
   case 313: // var: "RESPONSE_CONTENT_LENGTH"
-#line 2482 "seclang-parser.yy"
+#line 2485 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
       }
-#line 4592 "seclang-parser.cc"
+#line 4595 "seclang-parser.cc"
     break;
 
   case 314: // var: "RESPONSE_PROTOCOL"
-#line 2486 "seclang-parser.yy"
+#line 2489 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
       }
-#line 4600 "seclang-parser.cc"
+#line 4603 "seclang-parser.cc"
     break;
 
   case 315: // var: "RESPONSE_STATUS"
-#line 2490 "seclang-parser.yy"
+#line 2493 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
       }
-#line 4608 "seclang-parser.cc"
+#line 4611 "seclang-parser.cc"
     break;
 
   case 316: // var: "SERVER_ADDR"
-#line 2494 "seclang-parser.yy"
+#line 2497 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
       }
-#line 4616 "seclang-parser.cc"
+#line 4619 "seclang-parser.cc"
     break;
 
   case 317: // var: "SERVER_NAME"
-#line 2498 "seclang-parser.yy"
+#line 2501 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
       }
-#line 4624 "seclang-parser.cc"
+#line 4627 "seclang-parser.cc"
     break;
 
   case 318: // var: "SERVER_PORT"
-#line 2502 "seclang-parser.yy"
+#line 2505 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
       }
-#line 4632 "seclang-parser.cc"
+#line 4635 "seclang-parser.cc"
     break;
 
   case 319: // var: "SESSIONID"
-#line 2506 "seclang-parser.yy"
+#line 2509 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
       }
-#line 4640 "seclang-parser.cc"
+#line 4643 "seclang-parser.cc"
     break;
 
   case 320: // var: "UNIQUE_ID"
-#line 2510 "seclang-parser.yy"
+#line 2513 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
       }
-#line 4648 "seclang-parser.cc"
+#line 4651 "seclang-parser.cc"
     break;
 
   case 321: // var: "URLENCODED_ERROR"
-#line 2514 "seclang-parser.yy"
+#line 2517 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
       }
-#line 4656 "seclang-parser.cc"
+#line 4659 "seclang-parser.cc"
     break;
 
   case 322: // var: "USERID"
-#line 2518 "seclang-parser.yy"
+#line 2521 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
       }
-#line 4664 "seclang-parser.cc"
+#line 4667 "seclang-parser.cc"
     break;
 
   case 323: // var: "VARIABLE_STATUS"
-#line 2522 "seclang-parser.yy"
+#line 2525 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4672 "seclang-parser.cc"
+#line 4675 "seclang-parser.cc"
     break;
 
   case 324: // var: "VARIABLE_STATUS_LINE"
-#line 2526 "seclang-parser.yy"
+#line 2529 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4680 "seclang-parser.cc"
+#line 4683 "seclang-parser.cc"
     break;
 
   case 325: // var: "WEBAPPID"
-#line 2530 "seclang-parser.yy"
+#line 2533 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
       }
-#line 4688 "seclang-parser.cc"
+#line 4691 "seclang-parser.cc"
     break;
 
   case 326: // var: "RUN_TIME_VAR_DUR"
-#line 2534 "seclang-parser.yy"
+#line 2537 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4699 "seclang-parser.cc"
+#line 4702 "seclang-parser.cc"
     break;
 
   case 327: // var: "RUN_TIME_VAR_BLD"
-#line 2542 "seclang-parser.yy"
+#line 2545 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4710 "seclang-parser.cc"
+#line 4713 "seclang-parser.cc"
     break;
 
   case 328: // var: "RUN_TIME_VAR_HSV"
-#line 2549 "seclang-parser.yy"
+#line 2552 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4721 "seclang-parser.cc"
+#line 4724 "seclang-parser.cc"
     break;
 
   case 329: // var: "RUN_TIME_VAR_REMOTE_USER"
-#line 2556 "seclang-parser.yy"
+#line 2559 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4732 "seclang-parser.cc"
+#line 4735 "seclang-parser.cc"
     break;
 
   case 330: // var: "RUN_TIME_VAR_TIME"
-#line 2563 "seclang-parser.yy"
+#line 2566 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4743 "seclang-parser.cc"
+#line 4746 "seclang-parser.cc"
     break;
 
   case 331: // var: "RUN_TIME_VAR_TIME_DAY"
-#line 2570 "seclang-parser.yy"
+#line 2573 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4754 "seclang-parser.cc"
+#line 4757 "seclang-parser.cc"
     break;
 
   case 332: // var: "RUN_TIME_VAR_TIME_EPOCH"
-#line 2577 "seclang-parser.yy"
+#line 2580 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4765 "seclang-parser.cc"
+#line 4768 "seclang-parser.cc"
     break;
 
   case 333: // var: "RUN_TIME_VAR_TIME_HOUR"
-#line 2584 "seclang-parser.yy"
+#line 2587 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4776 "seclang-parser.cc"
+#line 4779 "seclang-parser.cc"
     break;
 
   case 334: // var: "RUN_TIME_VAR_TIME_MIN"
-#line 2591 "seclang-parser.yy"
+#line 2594 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4787 "seclang-parser.cc"
+#line 4790 "seclang-parser.cc"
     break;
 
   case 335: // var: "RUN_TIME_VAR_TIME_MON"
-#line 2598 "seclang-parser.yy"
+#line 2601 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4798 "seclang-parser.cc"
+#line 4801 "seclang-parser.cc"
     break;
 
   case 336: // var: "RUN_TIME_VAR_TIME_SEC"
-#line 2605 "seclang-parser.yy"
+#line 2608 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4809 "seclang-parser.cc"
+#line 4812 "seclang-parser.cc"
     break;
 
   case 337: // var: "RUN_TIME_VAR_TIME_WDAY"
-#line 2612 "seclang-parser.yy"
+#line 2615 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4820 "seclang-parser.cc"
+#line 4823 "seclang-parser.cc"
     break;
 
   case 338: // var: "RUN_TIME_VAR_TIME_YEAR"
-#line 2619 "seclang-parser.yy"
+#line 2622 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4831 "seclang-parser.cc"
+#line 4834 "seclang-parser.cc"
     break;
 
   case 339: // act: "Accuracy"
-#line 2629 "seclang-parser.yy"
+#line 2632 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
       }
-#line 4839 "seclang-parser.cc"
+#line 4842 "seclang-parser.cc"
     break;
 
   case 340: // act: "Allow"
-#line 2633 "seclang-parser.yy"
+#line 2636 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
       }
-#line 4847 "seclang-parser.cc"
+#line 4850 "seclang-parser.cc"
     break;
 
   case 341: // act: "Append"
-#line 2637 "seclang-parser.yy"
+#line 2640 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 4855 "seclang-parser.cc"
+#line 4858 "seclang-parser.cc"
     break;
 
   case 342: // act: "AuditLog"
-#line 2641 "seclang-parser.yy"
+#line 2644 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 4863 "seclang-parser.cc"
+#line 4866 "seclang-parser.cc"
     break;
 
   case 343: // act: "Block"
-#line 2645 "seclang-parser.yy"
+#line 2648 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
       }
-#line 4871 "seclang-parser.cc"
+#line 4874 "seclang-parser.cc"
     break;
 
   case 344: // act: "Capture"
-#line 2649 "seclang-parser.yy"
+#line 2652 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
       }
-#line 4879 "seclang-parser.cc"
+#line 4882 "seclang-parser.cc"
     break;
 
   case 345: // act: "Chain"
-#line 2653 "seclang-parser.yy"
+#line 2656 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
       }
-#line 4887 "seclang-parser.cc"
+#line 4890 "seclang-parser.cc"
     break;
 
   case 346: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_ON"
-#line 2657 "seclang-parser.yy"
+#line 2660 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=on"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4896 "seclang-parser.cc"
+#line 4899 "seclang-parser.cc"
     break;
 
   case 347: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
-#line 2662 "seclang-parser.yy"
+#line 2665 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
       }
-#line 4904 "seclang-parser.cc"
+#line 4907 "seclang-parser.cc"
     break;
 
   case 348: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 2666 "seclang-parser.yy"
+#line 2669 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=relevantonly"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4913 "seclang-parser.cc"
+#line 4916 "seclang-parser.cc"
     break;
 
   case 349: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
-#line 2671 "seclang-parser.yy"
+#line 2674 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
       }
-#line 4921 "seclang-parser.cc"
+#line 4924 "seclang-parser.cc"
     break;
 
   case 350: // act: "ACTION_CTL_BDY_JSON"
-#line 2675 "seclang-parser.yy"
+#line 2678 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
       }
-#line 4929 "seclang-parser.cc"
+#line 4932 "seclang-parser.cc"
     break;
 
   case 351: // act: "ACTION_CTL_BDY_XML"
-#line 2679 "seclang-parser.yy"
+#line 2682 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
       }
-#line 4937 "seclang-parser.cc"
+#line 4940 "seclang-parser.cc"
     break;
 
   case 352: // act: "ACTION_CTL_BDY_URLENCODED"
-#line 2683 "seclang-parser.yy"
+#line 2686 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
       }
-#line 4945 "seclang-parser.cc"
+#line 4948 "seclang-parser.cc"
     break;
 
   case 353: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
-#line 2687 "seclang-parser.yy"
+#line 2690 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4954 "seclang-parser.cc"
+#line 4957 "seclang-parser.cc"
     break;
 
   case 354: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
-#line 2692 "seclang-parser.yy"
+#line 2695 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4963 "seclang-parser.cc"
+#line 4966 "seclang-parser.cc"
     break;
 
   case 355: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
-#line 2697 "seclang-parser.yy"
+#line 2700 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
       }
-#line 4971 "seclang-parser.cc"
+#line 4974 "seclang-parser.cc"
     break;
 
   case 356: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
-#line 2701 "seclang-parser.yy"
+#line 2704 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
       }
-#line 4979 "seclang-parser.cc"
+#line 4982 "seclang-parser.cc"
     break;
 
   case 357: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
-#line 2705 "seclang-parser.yy"
+#line 2708 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 4987 "seclang-parser.cc"
+#line 4990 "seclang-parser.cc"
     break;
 
   case 358: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
-#line 2709 "seclang-parser.yy"
+#line 2712 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 4995 "seclang-parser.cc"
+#line 4998 "seclang-parser.cc"
     break;
 
   case 359: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
-#line 2713 "seclang-parser.yy"
+#line 2716 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 5003 "seclang-parser.cc"
+#line 5006 "seclang-parser.cc"
     break;
 
   case 360: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
-#line 2717 "seclang-parser.yy"
+#line 2720 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
       }
-#line 5011 "seclang-parser.cc"
+#line 5014 "seclang-parser.cc"
     break;
 
   case 361: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
-#line 2721 "seclang-parser.yy"
+#line 2724 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5019 "seclang-parser.cc"
+#line 5022 "seclang-parser.cc"
     break;
 
   case 362: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
-#line 2725 "seclang-parser.yy"
+#line 2728 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
       }
-#line 5027 "seclang-parser.cc"
+#line 5030 "seclang-parser.cc"
     break;
 
   case 363: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
-#line 2729 "seclang-parser.yy"
+#line 2732 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5035 "seclang-parser.cc"
+#line 5038 "seclang-parser.cc"
     break;
 
   case 364: // act: "Deny"
-#line 2733 "seclang-parser.yy"
+#line 2736 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
       }
-#line 5043 "seclang-parser.cc"
+#line 5046 "seclang-parser.cc"
     break;
 
   case 365: // act: "DeprecateVar"
-#line 2737 "seclang-parser.yy"
+#line 2740 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 5051 "seclang-parser.cc"
+#line 5054 "seclang-parser.cc"
     break;
 
   case 366: // act: "Drop"
-#line 2741 "seclang-parser.yy"
+#line 2744 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
       }
-#line 5059 "seclang-parser.cc"
+#line 5062 "seclang-parser.cc"
     break;
 
   case 367: // act: "Exec"
-#line 2745 "seclang-parser.yy"
+#line 2748 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
       }
-#line 5067 "seclang-parser.cc"
+#line 5070 "seclang-parser.cc"
     break;
 
   case 368: // act: "ExpireVar" run_time_string
-#line 2749 "seclang-parser.yy"
+#line 2752 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ExpireVar(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5075 "seclang-parser.cc"
+#line 5078 "seclang-parser.cc"
     break;
 
   case 369: // act: "Id"
-#line 2753 "seclang-parser.yy"
+#line 2756 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
       }
-#line 5083 "seclang-parser.cc"
+#line 5086 "seclang-parser.cc"
     break;
 
   case 370: // act: "InitCol" run_time_string
-#line 2757 "seclang-parser.yy"
+#line 2760 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5091 "seclang-parser.cc"
+#line 5094 "seclang-parser.cc"
     break;
 
   case 371: // act: "LogData" run_time_string
-#line 2761 "seclang-parser.yy"
+#line 2764 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5099 "seclang-parser.cc"
+#line 5102 "seclang-parser.cc"
     break;
 
   case 372: // act: "Log"
-#line 2765 "seclang-parser.yy"
+#line 2768 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
       }
-#line 5107 "seclang-parser.cc"
+#line 5110 "seclang-parser.cc"
     break;
 
   case 373: // act: "Maturity"
-#line 2769 "seclang-parser.yy"
+#line 2772 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
       }
-#line 5115 "seclang-parser.cc"
+#line 5118 "seclang-parser.cc"
     break;
 
   case 374: // act: "Msg" run_time_string
-#line 2773 "seclang-parser.yy"
+#line 2776 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5123 "seclang-parser.cc"
+#line 5126 "seclang-parser.cc"
     break;
 
   case 375: // act: "MultiMatch"
-#line 2777 "seclang-parser.yy"
+#line 2780 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
       }
-#line 5131 "seclang-parser.cc"
+#line 5134 "seclang-parser.cc"
     break;
 
   case 376: // act: "NoAuditLog"
-#line 2781 "seclang-parser.yy"
+#line 2784 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5139 "seclang-parser.cc"
+#line 5142 "seclang-parser.cc"
     break;
 
   case 377: // act: "NoLog"
-#line 2785 "seclang-parser.yy"
+#line 2788 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5147 "seclang-parser.cc"
+#line 5150 "seclang-parser.cc"
     break;
 
   case 378: // act: "Pass"
-#line 2789 "seclang-parser.yy"
+#line 2792 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
       }
-#line 5155 "seclang-parser.cc"
+#line 5158 "seclang-parser.cc"
     break;
 
   case 379: // act: "Pause"
-#line 2793 "seclang-parser.yy"
+#line 2796 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 5163 "seclang-parser.cc"
+#line 5166 "seclang-parser.cc"
     break;
 
   case 380: // act: "Phase"
-#line 2797 "seclang-parser.yy"
+#line 2800 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
       }
-#line 5171 "seclang-parser.cc"
+#line 5174 "seclang-parser.cc"
     break;
 
   case 381: // act: "Prepend"
-#line 2801 "seclang-parser.yy"
+#line 2804 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 5179 "seclang-parser.cc"
+#line 5182 "seclang-parser.cc"
     break;
 
   case 382: // act: "Proxy"
-#line 2805 "seclang-parser.yy"
+#line 2808 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 5187 "seclang-parser.cc"
+#line 5190 "seclang-parser.cc"
     break;
 
   case 383: // act: "Redirect" run_time_string
-#line 2809 "seclang-parser.yy"
+#line 2812 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5195 "seclang-parser.cc"
+#line 5198 "seclang-parser.cc"
     break;
 
   case 384: // act: "Rev"
-#line 2813 "seclang-parser.yy"
+#line 2816 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
       }
-#line 5203 "seclang-parser.cc"
+#line 5206 "seclang-parser.cc"
     break;
 
   case 385: // act: "SanitiseArg"
-#line 2817 "seclang-parser.yy"
+#line 2820 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
       }
-#line 5211 "seclang-parser.cc"
+#line 5214 "seclang-parser.cc"
     break;
 
   case 386: // act: "SanitiseMatched"
-#line 2821 "seclang-parser.yy"
+#line 2824 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
       }
-#line 5219 "seclang-parser.cc"
+#line 5222 "seclang-parser.cc"
     break;
 
   case 387: // act: "SanitiseMatchedBytes"
-#line 2825 "seclang-parser.yy"
+#line 2828 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
       }
-#line 5227 "seclang-parser.cc"
+#line 5230 "seclang-parser.cc"
     break;
 
   case 388: // act: "SanitiseRequestHeader"
-#line 2829 "seclang-parser.yy"
+#line 2832 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
       }
-#line 5235 "seclang-parser.cc"
+#line 5238 "seclang-parser.cc"
     break;
 
   case 389: // act: "SanitiseResponseHeader"
-#line 2833 "seclang-parser.yy"
+#line 2836 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
       }
-#line 5243 "seclang-parser.cc"
+#line 5246 "seclang-parser.cc"
     break;
 
   case 390: // act: "SetEnv" run_time_string
-#line 2837 "seclang-parser.yy"
+#line 2840 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5251 "seclang-parser.cc"
+#line 5254 "seclang-parser.cc"
     break;
 
   case 391: // act: "SetRsc" run_time_string
-#line 2841 "seclang-parser.yy"
+#line 2844 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5259 "seclang-parser.cc"
+#line 5262 "seclang-parser.cc"
     break;
 
   case 392: // act: "SetSid" run_time_string
-#line 2845 "seclang-parser.yy"
+#line 2848 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5267 "seclang-parser.cc"
+#line 5270 "seclang-parser.cc"
     break;
 
   case 393: // act: "SetUID" run_time_string
-#line 2849 "seclang-parser.yy"
+#line 2852 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5275 "seclang-parser.cc"
+#line 5278 "seclang-parser.cc"
     break;
 
   case 394: // act: "SetVar" setvar_action
-#line 2853 "seclang-parser.yy"
+#line 2856 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
       }
-#line 5283 "seclang-parser.cc"
+#line 5286 "seclang-parser.cc"
     break;
 
   case 395: // act: "Severity"
-#line 2857 "seclang-parser.yy"
+#line 2860 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
       }
-#line 5291 "seclang-parser.cc"
+#line 5294 "seclang-parser.cc"
     break;
 
   case 396: // act: "Skip"
-#line 2861 "seclang-parser.yy"
+#line 2864 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
       }
-#line 5299 "seclang-parser.cc"
+#line 5302 "seclang-parser.cc"
     break;
 
   case 397: // act: "SkipAfter"
-#line 2865 "seclang-parser.yy"
+#line 2868 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
       }
-#line 5307 "seclang-parser.cc"
+#line 5310 "seclang-parser.cc"
     break;
 
   case 398: // act: "Status"
-#line 2869 "seclang-parser.yy"
+#line 2872 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
       }
-#line 5315 "seclang-parser.cc"
+#line 5318 "seclang-parser.cc"
     break;
 
   case 399: // act: "Tag" run_time_string
-#line 2873 "seclang-parser.yy"
+#line 2876 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5323 "seclang-parser.cc"
+#line 5326 "seclang-parser.cc"
     break;
 
   case 400: // act: "Ver"
-#line 2877 "seclang-parser.yy"
+#line 2880 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
       }
-#line 5331 "seclang-parser.cc"
+#line 5334 "seclang-parser.cc"
     break;
 
   case 401: // act: "xmlns"
-#line 2881 "seclang-parser.yy"
+#line 2884 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
       }
-#line 5339 "seclang-parser.cc"
+#line 5342 "seclang-parser.cc"
     break;
 
   case 402: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
-#line 2885 "seclang-parser.yy"
+#line 2888 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5347 "seclang-parser.cc"
+#line 5350 "seclang-parser.cc"
     break;
 
   case 403: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
-#line 2889 "seclang-parser.yy"
+#line 2892 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5355 "seclang-parser.cc"
+#line 5358 "seclang-parser.cc"
     break;
 
   case 404: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
-#line 2893 "seclang-parser.yy"
+#line 2896 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5363 "seclang-parser.cc"
+#line 5366 "seclang-parser.cc"
     break;
 
   case 405: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
-#line 2897 "seclang-parser.yy"
+#line 2900 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5371 "seclang-parser.cc"
+#line 5374 "seclang-parser.cc"
     break;
 
   case 406: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
-#line 2901 "seclang-parser.yy"
+#line 2904 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
       }
-#line 5379 "seclang-parser.cc"
+#line 5382 "seclang-parser.cc"
     break;
 
   case 407: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
-#line 2905 "seclang-parser.yy"
+#line 2908 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
       }
-#line 5387 "seclang-parser.cc"
+#line 5390 "seclang-parser.cc"
     break;
 
   case 408: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
-#line 2909 "seclang-parser.yy"
+#line 2912 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
       }
-#line 5395 "seclang-parser.cc"
+#line 5398 "seclang-parser.cc"
     break;
 
   case 409: // act: "ACTION_TRANSFORMATION_CMD_LINE"
-#line 2913 "seclang-parser.yy"
+#line 2916 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
       }
-#line 5403 "seclang-parser.cc"
+#line 5406 "seclang-parser.cc"
     break;
 
   case 410: // act: "ACTION_TRANSFORMATION_SHA1"
-#line 2917 "seclang-parser.yy"
+#line 2920 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
       }
-#line 5411 "seclang-parser.cc"
+#line 5414 "seclang-parser.cc"
     break;
 
   case 411: // act: "ACTION_TRANSFORMATION_MD5"
-#line 2921 "seclang-parser.yy"
+#line 2924 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
       }
-#line 5419 "seclang-parser.cc"
+#line 5422 "seclang-parser.cc"
     break;
 
   case 412: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
-#line 2925 "seclang-parser.yy"
+#line 2928 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5427 "seclang-parser.cc"
+#line 5430 "seclang-parser.cc"
     break;
 
   case 413: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
-#line 2929 "seclang-parser.yy"
+#line 2932 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5435 "seclang-parser.cc"
+#line 5438 "seclang-parser.cc"
     break;
 
   case 414: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
-#line 2933 "seclang-parser.yy"
+#line 2936 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5443 "seclang-parser.cc"
+#line 5446 "seclang-parser.cc"
     break;
 
   case 415: // act: "ACTION_TRANSFORMATION_LOWERCASE"
-#line 2937 "seclang-parser.yy"
+#line 2940 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5451 "seclang-parser.cc"
+#line 5454 "seclang-parser.cc"
     break;
 
   case 416: // act: "ACTION_TRANSFORMATION_UPPERCASE"
-#line 2941 "seclang-parser.yy"
+#line 2944 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5459 "seclang-parser.cc"
+#line 5462 "seclang-parser.cc"
     break;
 
   case 417: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
-#line 2945 "seclang-parser.yy"
+#line 2948 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
       }
-#line 5467 "seclang-parser.cc"
+#line 5470 "seclang-parser.cc"
     break;
 
   case 418: // act: "ACTION_TRANSFORMATION_URL_DECODE"
-#line 2949 "seclang-parser.yy"
+#line 2952 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5475 "seclang-parser.cc"
+#line 5478 "seclang-parser.cc"
     break;
 
   case 419: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
-#line 2953 "seclang-parser.yy"
+#line 2956 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5483 "seclang-parser.cc"
+#line 5486 "seclang-parser.cc"
     break;
 
   case 420: // act: "ACTION_TRANSFORMATION_NONE"
-#line 2957 "seclang-parser.yy"
+#line 2960 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
       }
-#line 5491 "seclang-parser.cc"
+#line 5494 "seclang-parser.cc"
     break;
 
   case 421: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
-#line 2961 "seclang-parser.yy"
+#line 2964 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5499 "seclang-parser.cc"
+#line 5502 "seclang-parser.cc"
     break;
 
   case 422: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
-#line 2965 "seclang-parser.yy"
+#line 2968 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5507 "seclang-parser.cc"
+#line 5510 "seclang-parser.cc"
     break;
 
   case 423: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
-#line 2969 "seclang-parser.yy"
+#line 2972 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5515 "seclang-parser.cc"
+#line 5518 "seclang-parser.cc"
     break;
 
   case 424: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
-#line 2973 "seclang-parser.yy"
+#line 2976 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5523 "seclang-parser.cc"
+#line 5526 "seclang-parser.cc"
     break;
 
   case 425: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
-#line 2977 "seclang-parser.yy"
+#line 2980 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5531 "seclang-parser.cc"
+#line 5534 "seclang-parser.cc"
     break;
 
   case 426: // act: "ACTION_TRANSFORMATION_JS_DECODE"
-#line 2981 "seclang-parser.yy"
+#line 2984 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5539 "seclang-parser.cc"
+#line 5542 "seclang-parser.cc"
     break;
 
   case 427: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
-#line 2985 "seclang-parser.yy"
+#line 2988 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5547 "seclang-parser.cc"
+#line 5550 "seclang-parser.cc"
     break;
 
   case 428: // act: "ACTION_TRANSFORMATION_TRIM"
-#line 2989 "seclang-parser.yy"
+#line 2992 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
       }
-#line 5555 "seclang-parser.cc"
+#line 5558 "seclang-parser.cc"
     break;
 
   case 429: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
-#line 2993 "seclang-parser.yy"
+#line 2996 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
       }
-#line 5563 "seclang-parser.cc"
+#line 5566 "seclang-parser.cc"
     break;
 
   case 430: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
-#line 2997 "seclang-parser.yy"
+#line 3000 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
       }
-#line 5571 "seclang-parser.cc"
+#line 5574 "seclang-parser.cc"
     break;
 
   case 431: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
-#line 3001 "seclang-parser.yy"
+#line 3004 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
       }
-#line 5579 "seclang-parser.cc"
+#line 5582 "seclang-parser.cc"
     break;
 
   case 432: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
-#line 3005 "seclang-parser.yy"
+#line 3008 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
       }
-#line 5587 "seclang-parser.cc"
+#line 5590 "seclang-parser.cc"
     break;
 
   case 433: // act: "ACTION_TRANSFORMATION_LENGTH"
-#line 3009 "seclang-parser.yy"
+#line 3012 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
       }
-#line 5595 "seclang-parser.cc"
+#line 5598 "seclang-parser.cc"
     break;
 
   case 434: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
-#line 3013 "seclang-parser.yy"
+#line 3016 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
       }
-#line 5603 "seclang-parser.cc"
+#line 5606 "seclang-parser.cc"
     break;
 
   case 435: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
-#line 3017 "seclang-parser.yy"
+#line 3020 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
       }
-#line 5611 "seclang-parser.cc"
+#line 5614 "seclang-parser.cc"
     break;
 
   case 436: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
-#line 3021 "seclang-parser.yy"
+#line 3024 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5619 "seclang-parser.cc"
+#line 5622 "seclang-parser.cc"
     break;
 
   case 437: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
-#line 3025 "seclang-parser.yy"
+#line 3028 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5627 "seclang-parser.cc"
+#line 5630 "seclang-parser.cc"
     break;
 
   case 438: // setvar_action: "NOT" var
-#line 3032 "seclang-parser.yy"
+#line 3035 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5635 "seclang-parser.cc"
+#line 5638 "seclang-parser.cc"
     break;
 
   case 439: // setvar_action: var
-#line 3036 "seclang-parser.yy"
+#line 3039 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5643 "seclang-parser.cc"
+#line 5646 "seclang-parser.cc"
     break;
 
   case 440: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
-#line 3040 "seclang-parser.yy"
+#line 3043 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5651 "seclang-parser.cc"
+#line 5654 "seclang-parser.cc"
     break;
 
   case 441: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
-#line 3044 "seclang-parser.yy"
+#line 3047 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5659 "seclang-parser.cc"
+#line 5662 "seclang-parser.cc"
     break;
 
   case 442: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
-#line 3048 "seclang-parser.yy"
+#line 3051 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5667 "seclang-parser.cc"
+#line 5670 "seclang-parser.cc"
     break;
 
   case 443: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3055 "seclang-parser.yy"
+#line 3058 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5676 "seclang-parser.cc"
+#line 5679 "seclang-parser.cc"
     break;
 
   case 444: // run_time_string: run_time_string var
-#line 3060 "seclang-parser.yy"
+#line 3063 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5685 "seclang-parser.cc"
+#line 5688 "seclang-parser.cc"
     break;
 
   case 445: // run_time_string: "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3065 "seclang-parser.yy"
+#line 3068 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5695 "seclang-parser.cc"
+#line 5698 "seclang-parser.cc"
     break;
 
   case 446: // run_time_string: var
-#line 3071 "seclang-parser.yy"
+#line 3074 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5705 "seclang-parser.cc"
+#line 5708 "seclang-parser.cc"
     break;
 
 
-#line 5709 "seclang-parser.cc"
+#line 5712 "seclang-parser.cc"
 
             default:
               break;
@@ -7236,44 +7239,44 @@ namespace yy {
      934,   938,   942,   946,   950,   954,   958,   963,   967,   971,
      975,   979,   983,   988,   993,   997,  1001,  1005,  1009,  1013,
     1017,  1021,  1025,  1029,  1033,  1037,  1041,  1045,  1049,  1053,
-    1057,  1061,  1065,  1069,  1083,  1084,  1114,  1133,  1152,  1180,
-    1237,  1244,  1248,  1252,  1256,  1260,  1264,  1268,  1272,  1281,
-    1285,  1290,  1293,  1298,  1303,  1308,  1313,  1316,  1321,  1324,
-    1329,  1334,  1337,  1342,  1347,  1352,  1357,  1362,  1367,  1372,
-    1375,  1380,  1385,  1390,  1395,  1398,  1403,  1408,  1413,  1426,
-    1439,  1452,  1465,  1478,  1504,  1532,  1544,  1564,  1591,  1596,
-    1602,  1607,  1612,  1621,  1626,  1630,  1634,  1638,  1642,  1646,
-    1650,  1655,  1660,  1672,  1678,  1682,  1686,  1697,  1706,  1707,
-    1714,  1719,  1724,  1778,  1785,  1793,  1830,  1834,  1841,  1846,
-    1852,  1858,  1864,  1871,  1881,  1885,  1889,  1893,  1897,  1901,
-    1905,  1909,  1913,  1917,  1921,  1925,  1929,  1933,  1937,  1941,
-    1945,  1949,  1953,  1957,  1961,  1965,  1969,  1973,  1977,  1981,
-    1985,  1989,  1993,  1997,  2001,  2005,  2009,  2013,  2017,  2021,
-    2025,  2029,  2033,  2037,  2041,  2045,  2049,  2053,  2057,  2061,
-    2065,  2069,  2073,  2077,  2081,  2085,  2089,  2093,  2097,  2101,
-    2105,  2109,  2113,  2117,  2121,  2125,  2129,  2133,  2137,  2141,
-    2145,  2149,  2153,  2157,  2161,  2165,  2169,  2173,  2177,  2181,
-    2185,  2189,  2193,  2197,  2201,  2205,  2209,  2213,  2217,  2221,
-    2225,  2229,  2233,  2237,  2241,  2245,  2249,  2254,  2258,  2262,
-    2267,  2271,  2275,  2280,  2285,  2289,  2293,  2297,  2301,  2305,
-    2309,  2313,  2317,  2321,  2325,  2329,  2333,  2337,  2341,  2345,
-    2349,  2353,  2357,  2361,  2365,  2369,  2373,  2377,  2381,  2385,
-    2389,  2393,  2397,  2401,  2405,  2409,  2413,  2417,  2421,  2425,
-    2429,  2433,  2437,  2441,  2445,  2449,  2453,  2457,  2461,  2465,
-    2469,  2473,  2477,  2481,  2485,  2489,  2493,  2497,  2501,  2505,
-    2509,  2513,  2517,  2521,  2525,  2529,  2533,  2541,  2548,  2555,
-    2562,  2569,  2576,  2583,  2590,  2597,  2604,  2611,  2618,  2628,
-    2632,  2636,  2640,  2644,  2648,  2652,  2656,  2661,  2665,  2670,
-    2674,  2678,  2682,  2686,  2691,  2696,  2700,  2704,  2708,  2712,
-    2716,  2720,  2724,  2728,  2732,  2736,  2740,  2744,  2748,  2752,
-    2756,  2760,  2764,  2768,  2772,  2776,  2780,  2784,  2788,  2792,
-    2796,  2800,  2804,  2808,  2812,  2816,  2820,  2824,  2828,  2832,
-    2836,  2840,  2844,  2848,  2852,  2856,  2860,  2864,  2868,  2872,
-    2876,  2880,  2884,  2888,  2892,  2896,  2900,  2904,  2908,  2912,
-    2916,  2920,  2924,  2928,  2932,  2936,  2940,  2944,  2948,  2952,
-    2956,  2960,  2964,  2968,  2972,  2976,  2980,  2984,  2988,  2992,
-    2996,  3000,  3004,  3008,  3012,  3016,  3020,  3024,  3031,  3035,
-    3039,  3043,  3047,  3054,  3059,  3064,  3070
+    1057,  1061,  1065,  1069,  1083,  1084,  1115,  1134,  1154,  1183,
+    1240,  1247,  1251,  1255,  1259,  1263,  1267,  1271,  1275,  1284,
+    1288,  1293,  1296,  1301,  1306,  1311,  1316,  1319,  1324,  1327,
+    1332,  1337,  1340,  1345,  1350,  1355,  1360,  1365,  1370,  1375,
+    1378,  1383,  1388,  1393,  1398,  1401,  1406,  1411,  1416,  1429,
+    1442,  1455,  1468,  1481,  1507,  1535,  1547,  1567,  1594,  1599,
+    1605,  1610,  1615,  1624,  1629,  1633,  1637,  1641,  1645,  1649,
+    1653,  1658,  1663,  1675,  1681,  1685,  1689,  1700,  1709,  1710,
+    1717,  1722,  1727,  1781,  1788,  1796,  1833,  1837,  1844,  1849,
+    1855,  1861,  1867,  1874,  1884,  1888,  1892,  1896,  1900,  1904,
+    1908,  1912,  1916,  1920,  1924,  1928,  1932,  1936,  1940,  1944,
+    1948,  1952,  1956,  1960,  1964,  1968,  1972,  1976,  1980,  1984,
+    1988,  1992,  1996,  2000,  2004,  2008,  2012,  2016,  2020,  2024,
+    2028,  2032,  2036,  2040,  2044,  2048,  2052,  2056,  2060,  2064,
+    2068,  2072,  2076,  2080,  2084,  2088,  2092,  2096,  2100,  2104,
+    2108,  2112,  2116,  2120,  2124,  2128,  2132,  2136,  2140,  2144,
+    2148,  2152,  2156,  2160,  2164,  2168,  2172,  2176,  2180,  2184,
+    2188,  2192,  2196,  2200,  2204,  2208,  2212,  2216,  2220,  2224,
+    2228,  2232,  2236,  2240,  2244,  2248,  2252,  2257,  2261,  2265,
+    2270,  2274,  2278,  2283,  2288,  2292,  2296,  2300,  2304,  2308,
+    2312,  2316,  2320,  2324,  2328,  2332,  2336,  2340,  2344,  2348,
+    2352,  2356,  2360,  2364,  2368,  2372,  2376,  2380,  2384,  2388,
+    2392,  2396,  2400,  2404,  2408,  2412,  2416,  2420,  2424,  2428,
+    2432,  2436,  2440,  2444,  2448,  2452,  2456,  2460,  2464,  2468,
+    2472,  2476,  2480,  2484,  2488,  2492,  2496,  2500,  2504,  2508,
+    2512,  2516,  2520,  2524,  2528,  2532,  2536,  2544,  2551,  2558,
+    2565,  2572,  2579,  2586,  2593,  2600,  2607,  2614,  2621,  2631,
+    2635,  2639,  2643,  2647,  2651,  2655,  2659,  2664,  2668,  2673,
+    2677,  2681,  2685,  2689,  2694,  2699,  2703,  2707,  2711,  2715,
+    2719,  2723,  2727,  2731,  2735,  2739,  2743,  2747,  2751,  2755,
+    2759,  2763,  2767,  2771,  2775,  2779,  2783,  2787,  2791,  2795,
+    2799,  2803,  2807,  2811,  2815,  2819,  2823,  2827,  2831,  2835,
+    2839,  2843,  2847,  2851,  2855,  2859,  2863,  2867,  2871,  2875,
+    2879,  2883,  2887,  2891,  2895,  2899,  2903,  2907,  2911,  2915,
+    2919,  2923,  2927,  2931,  2935,  2939,  2943,  2947,  2951,  2955,
+    2959,  2963,  2967,  2971,  2975,  2979,  2983,  2987,  2991,  2995,
+    2999,  3003,  3007,  3011,  3015,  3019,  3023,  3027,  3034,  3038,
+    3042,  3046,  3050,  3057,  3062,  3067,  3073
   };
 
   void
@@ -7305,9 +7308,9 @@ namespace yy {
 
 
 } // yy
-#line 7309 "seclang-parser.cc"
+#line 7312 "seclang-parser.cc"
 
-#line 3077 "seclang-parser.yy"
+#line 3080 "seclang-parser.yy"
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1086,8 +1086,9 @@ expression:
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
         for (auto &i : *$4.get()) {
-            if (dynamic_cast<actions::transformations::Transformation *>(i.get())) {
-              t->push_back(dynamic_cast<actions::transformations::Transformation *>(i.release()));
+            if (auto pt = dynamic_cast<actions::transformations::Transformation *>(i.get())) {
+              t->push_back(pt);
+              i.release();
             } else {
               a->push_back(i.release());
             }
@@ -1135,8 +1136,9 @@ expression:
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
         for (auto &i : *$2.get()) {
-            if (dynamic_cast<actions::transformations::Transformation *>(i.get())) {
-              t->push_back(dynamic_cast<actions::transformations::Transformation *>(i.release()));
+            if (auto pt = dynamic_cast<actions::transformations::Transformation *>(i.get())) {
+              t->push_back(pt);
+              i.release();
             } else {
               a->push_back(i.release());
             }
@@ -1155,8 +1157,9 @@ expression:
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
         for (auto &i : *$2.get()) {
-            if (dynamic_cast<actions::transformations::Transformation *>(i.get())) {
-              t->push_back(dynamic_cast<actions::transformations::Transformation *>(i.release()));
+            if (auto pt = dynamic_cast<actions::transformations::Transformation *>(i.get())) {
+              t->push_back(pt);
+              i.release();
             } else {
               a->push_back(i.release());
             }

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -213,7 +213,7 @@ void RuleWithActions::executeActionsIndependentOfChainedRuleResult(Transaction *
         if (m_ruleId != b.first) {
             continue;
         }
-        actions::Action *a = dynamic_cast<actions::Action*>(b.second.get());
+        actions::Action *a = b.second.get();
         if (a->isDisruptive() == true && *a->m_name.get() == "block") {
             ms_dbg_a(trans, 9, "Rule contains a `block' action");
                 *containsBlock = true;
@@ -266,7 +266,7 @@ void RuleWithActions::executeActionsAfterFullMatch(Transaction *trans,
         if (m_ruleId != b.first) {
             continue;
         }
-        actions::Action *a = dynamic_cast<actions::Action*>(b.second.get());
+        actions::Action *a = b.second.get();
         executeAction(trans, containsBlock, ruleMessage, a, false);
         disruptiveAlreadyExecuted = true;
     }
@@ -394,8 +394,7 @@ void RuleWithActions::executeTransformations(
 
     for (Transformation *a : m_transformations) {
         if (none == 0) {
-            Transformation *t = dynamic_cast<Transformation *>(a);
-            executeTransformation(t, &value, trans, &ret, &path,
+            executeTransformation(a, &value, trans, &ret, &path,
                 &transformations);
         }
         if (a->m_isNone) {
@@ -423,8 +422,7 @@ void RuleWithActions::executeTransformations(
         }
         Transformation *a = dynamic_cast<Transformation*>(b.second.get());
         if (none == 0) {
-            Transformation *t = dynamic_cast<Transformation *>(a);
-            executeTransformation(t, &value, trans, &ret, &path,
+            executeTransformation(a, &value, trans, &ret, &path,
                 &transformations);
         }
         if (a->m_isNone) {
@@ -479,7 +477,7 @@ std::vector<actions::Action *> RuleWithActions::getActionsByName(const std::stri
         if (m_ruleId != b.first) {
             continue;
         }
-        actions::Action *z = dynamic_cast<actions::Action*>(b.second.get());
+        actions::Action *z = b.second.get();
         if (*z->m_name.get() == name) {
             ret.push_back(z);
         }
@@ -489,7 +487,7 @@ std::vector<actions::Action *> RuleWithActions::getActionsByName(const std::stri
         if (m_ruleId != b.first) {
             continue;
         }
-        actions::Action *z = dynamic_cast<actions::Action*>(b.second.get());
+        actions::Action *z = b.second.get();
         if (*z->m_name.get() == name) {
             ret.push_back(z);
         }

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -99,17 +99,16 @@ RuleWithActions::RuleWithActions(
                     } else if (dynamic_cast<actions::MultiMatch *>(a)) {
                         m_containsMultiMatchAction = true;
                         delete a;
-                    } else if (dynamic_cast<actions::Severity *>(a)) {
-                        m_severity = dynamic_cast<actions::Severity *>(a);
-                    } else if (dynamic_cast<actions::LogData *>(a)) {
-                        m_logData = dynamic_cast<actions::LogData*>(a);
-                    } else if (dynamic_cast<actions::Msg *>(a)) {
-                        m_msg = dynamic_cast<actions::Msg*>(a);
-                    } else if (dynamic_cast<actions::SetVar *>(a)) {
-                        m_actionsSetVar.push_back(
-                            dynamic_cast<actions::SetVar *>(a));
-                    } else if (dynamic_cast<actions::Tag *>(a)) {
-                        m_actionsTag.push_back(dynamic_cast<actions::Tag *>(a));
+                    } else if (auto sa = dynamic_cast<actions::Severity *>(a)) {
+                        m_severity = sa;
+                    } else if (auto lda = dynamic_cast<actions::LogData *>(a)) {
+                        m_logData = lda;
+                    } else if (auto ma = dynamic_cast<actions::Msg *>(a)) {
+                        m_msg = ma;
+                    } else if (auto sva = dynamic_cast<actions::SetVar *>(a)) {
+                        m_actionsSetVar.push_back(sva);
+                    } else if (auto ta = dynamic_cast<actions::Tag *>(a)) {
+                        m_actionsTag.push_back(ta);
                     } else if (dynamic_cast<actions::Block *>(a)) {
                         m_actionsRuntimePos.push_back(a);
                         m_containsStaticBlockAction = true;

--- a/test/optimization/optimization.cc
+++ b/test/optimization/optimization.cc
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
                 continue;
             }
 
-            if (dynamic_cast<modsecurity::RuleUnconditional *>(z.get()) != nullptr) {
+            if (dynamic_cast<modsecurity::RuleUnconditional *>(z.get())) {
                 std::string op = "Unconditional";
                 if (operators.count(op) > 0) {
                     operators[op] = 1 + operators[op];
@@ -96,9 +96,7 @@ int main(int argc, char **argv) {
                 }
             }
 
-            if (dynamic_cast<modsecurity::RuleWithOperator *>(z.get()) != nullptr) {
-                auto *rwo = dynamic_cast<modsecurity::RuleWithOperator *>(z.get());
-
+            if (auto rwo = dynamic_cast<modsecurity::RuleWithOperator *>(z.get())) {
                 std::string op = rwo->getOperatorName();
                 if (operators.count(op) > 0) {
                     operators[op] = 1 + operators[op];


### PR DESCRIPTION
## what

This short PR removes a number of `dynamic_cast` casts in the codebase, some of which are performed twice and could be rewritten to perform the *runtime* cast only once.

## why

`dynamic_cast` is performed at runtime and requires inspecting the object's RTTI information to perform the cast. Executing it more than once incurs a bit of a performance cost that could be avoided by rewriting the code snippet. Additionally, the rewritten code is shorter and thus easier to read and maintain.

For example (from `src/rule_with_actions.cc`):

```cpp
                    } else if (dynamic_cast<actions::Severity *>(a)) {
                        m_severity = dynamic_cast<actions::Severity *>(a);
```

can be rewritten as:

```cpp
                    } else if (auto sa = dynamic_cast<actions::Severity *>(a)) {
                        m_severity = sa;
```

## misc

This is part of a series of PRs to improve performance of the library (2/n). Previous: #3164