### PR TITLE
Creating a std::string with a null pointer is undefined behaviour

### DIFF
--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -333,9 +333,9 @@ class RulesSetProperties {
         case FalseConfigBoolean:
             return "False";
         case PropertyNotSetConfigBoolean:
+        default:
             return "Not set";
         }
-        return NULL;
     }
 
 

--- a/src/actions/transformations/url_encode.cc
+++ b/src/actions/transformations/url_encode.cc
@@ -48,7 +48,7 @@ std::string UrlEncode::url_enc(const char *input,
     len = input_len * 3 + 1;
     d = rval = reinterpret_cast<char *>(malloc(len));
     if (rval == NULL) {
-        return NULL;
+        return {};
     }
 
     /* ENH Only encode the characters that really need to be encoded. */


### PR DESCRIPTION
## what

Minor changes to avoid initializing a `std::string` with a null pointer.

## why

cppreference mentions this about the constructor that receives a `const char *` (see [here](https://en.cppreference.com/w/cpp/string/basic_string/basic_string)):

```
9) Constructs the string with the contents initialized with a copy of the null-terminated
character string pointed to by s. The length of the string is determined by the first null
character. The behavior is undefined if [s, s + Traits::length(s)) is not a valid range (for
example, if s is a null pointer).
```

## references

C++23 introduces a deleted constructor to prevent this in static scenarios, which is how this issue was detected.
