### PR TITLE
Build libModSecurity with std C++20

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Windows build information can be found [here](build/win32/README.md).
 
 ## Dependencies
 
-This library is written in C++ using the C++17 standards. It also uses Flex
+This library is written in C++ using the C++20 standards. It also uses Flex
 and Yacc to produce the “Sec Rules Language” parser. Other, mandatory dependencies include YAJL, as ModSecurity uses JSON for producing logs and its testing framework, libpcre (not yet mandatory) for processing regular expressions in SecRules, and libXML2 (not yet mandatory) which is used for parsing XML requests.
 
 All others dependencies are related to operators specified within SecRules or configuration directives and may not be required for compilation. A short list of such dependencies is as follows:

--- a/build/win32/CMakeLists.txt
+++ b/build/win32/CMakeLists.txt
@@ -77,7 +77,7 @@ project(libModSecurity
         CXX
 )
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
 set(CMAKE_CXX_EXTENSIONS Off)
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ PKG_PROG_PKG_CONFIG
 
 
 # Set C++ standard version and check if compiler supports it.
-AX_CXX_COMPILE_STDCXX(17, noext, mandatory)
+AX_CXX_COMPILE_STDCXX(20, noext, mandatory)
 
 # Check for libinjection
 if ! test -f "${srcdir}/others/libinjection/src/libinjection_html5.c"; then

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -20,7 +20,7 @@ if "%3"=="USE_ASAN" (
 )
 
 cd build\win32
-conan install . -s compiler.cppstd=17 %CI_ASAN% --output-folder=build --build=missing --settings=build_type=%build_type% --settings=arch=%arch%
+conan install . -s compiler.cppstd=20 %CI_ASAN% --output-folder=build --build=missing --settings=build_type=%build_type% --settings=arch=%arch%
 cd build
 cmake --fresh .. -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DUSE_ASAN=%ASAN_FLAG% %4 %5 %6 %7 %8 %9
 cmake --build . --config %build_type%


### PR DESCRIPTION
## what

Update build configuration to build the library using std C++20

## why

The goal of this PR is not necessarily to update this configuration at this time, but rather to document that the library builds correctly at this stage using std C++20 on all platforms.

## why not C++23

This PR is limited to C++20 because moving to C++23 is not yet possible on all platforms, as the compilers available in some of the images do not include support for this C++ std. Additionally, the current version of the `ax_cxx_compile_stdcxx` `autoconf` macro doesn't support C++23 yet either.

NOTE: Building the library using std C++23 on Windows found the issue found in PR #3220.

## a note on adoption of C++20 ranges

C++20 introduces the ranges library (see [here](https://en.cppreference.com/w/cpp/ranges)). The library offers a powerful and expressive way to handle data due to its declarative approach and composability.

However, adoption of the library needs to consider potential performance drawbacks when compared to existing approaches (such as STL algorithms), as library implementations may not be as efficient yet.

For the sake of reference, see:

 * [Performance benchmark: Ranges VS STL algorithms VS Smart output iterators](https://www.fluentcpp.com/2019/03/15/performance-benchmark-ranges-vs-stl-algorithms-vs-smart-output-iterators/)
 * [Performance of C++20's ranges](https://www.cppstories.com/2022/ranges-perf/)
 * [C++ ranges are better than iterators?](https://softwarebits.substack.com/p/c-ranges-are-better-than-iterators)

sonarcloud code analysis on PRs usually recommend replacing existing code with C++20 ranges, but that feedback should be taken with a grain of salt (such as considering performance implications of the changes).

NOTE: This is feedback is unrelated to the [Range-based for loop](https://en.cppreference.com/w/cpp/language/range-for) feature introduced in C++11.

## references

The library was updated to build with std C++17 in PR #3079 (and the configuration was simplified in PR #3219 to make it easier to upgrade in the future).