### PR TITLE
fix: Fix regression test result; Add test to main test-suite list

### DIFF
--- a/test/test-cases/regression/fn-setHostname.json
+++ b/test/test-cases/regression/fn-setHostname.json
@@ -29,7 +29,7 @@
       ]
     },
     "expected":{
-      "http_code": 200,
+      "http_code": 403,
       "debug_log": "[hostname: \"modsecurity.org\"]"
     },
     "rules":[

--- a/test/test-suite.in
+++ b/test/test-suite.in
@@ -49,6 +49,7 @@ TESTS+=test/test-cases/regression/config-update-target-by-tag.json
 TESTS+=test/test-cases/regression/config-xml_external_entity.json
 TESTS+=test/test-cases/regression/debug_log.json
 TESTS+=test/test-cases/regression/directive-sec_rule_script.json
+TESTS+=test/test-cases/regression/fn-setHostname.json
 TESTS+=test/test-cases/regression/issue-1152.json
 TESTS+=test/test-cases/regression/issue-1528.json
 TESTS+=test/test-cases/regression/issue-1565.json


### PR DESCRIPTION
## what

Fix test result in regression test case `fn-setHostname.json`, and add it to test-suite list.

## why

There was a typo in the test file, and I forget to add it to the list.

## references

#3203 