### PR TITLE
feat: Check if the MP header contains invalid character

### DIFF
--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -918,6 +918,18 @@ int Multipart::process_part_header(std::string *error, int offset) {
                  return false;
             }
 
+            /* check if multipart header contains any invalid characters */
+            for (const auto& ch : header_name) {
+                if (ch < 33 || ch > 126) {
+                    ms_dbg_a(m_transaction, 1,
+                        "Multipart: Invalid part header " \
+                        "(contains invalid character).");
+                    error->assign("Multipart: Invalid part header "\
+                        "(contains invalid character).");
+                    return false;
+                }
+            }
+
             /* extract the value value */
             data++;
             i++;

--- a/test/test-cases/regression/request-body-parser-multipart.json
+++ b/test/test-cases/regression/request-body-parser-multipart.json
@@ -3294,5 +3294,56 @@
         "SecRequestBodyAccess On",
         "SecRule ARGS:namea \"@streq 111\" \"phase:2,deny,id:500096\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"multipart parser (invalid part header - contains invalid character)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Content-Length":"330",
+        "Content-Type":"multipart/form-data; boundary=a",
+        "Expect":"100-continue"
+      },
+      "uri":"/",
+      "method":"POST",
+      "body":[
+        "--a\r",
+        "\u000eContent-Disposition\u000e: form-data; name=\"file\"; filename=\"1.jsp\"\r",
+        "Content-Disposition: form-data; name=\"post\";\r",
+        "\r",
+        "<%out.print(123)%>\r",
+        "--a--\r"
+      ]
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code":403,
+      "debug_log":"Multipart: Invalid part header \\(contains invalid character\\)"
+    },
+    "rules":[
+        "SecruleEngine On",
+        "SecRule REQBODY_PROCESSOR_ERROR \"@eq 1\" \"phase:2,deny,status:403,id:500077\""
+    ]
   }
 ]


### PR DESCRIPTION
## what

Check MULTIPART HEADER if it contains any illegal characters. If there are any of these characters, variable `REQBODY_ERROR` will set.

## why

MULTIPART HEADERS can't contain any characters outside of interval between 33 and 126, and 58 (`:` - this is the separator).

## references

RFC [2045](https://datatracker.ietf.org/doc/html/rfc2045) refers RFC [822](https://datatracker.ietf.org/doc/html/rfc822#section-3.2) about the header syntax.