### PR TITLE
feat: Check if the MP header contains invalid character

### DIFF
--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -402,7 +402,7 @@ static int multipart_process_part_header(modsec_rec *msr, char **error_msg) {
             if (msr->mpd->mpp->last_header_line != NULL) {
                 *(char **)apr_array_push(msr->mpd->mpp->header_lines) = msr->mpd->mpp->last_header_line;
                 msr_log(msr, 9, "Multipart: Added part header line \"%s\"", msr->mpd->mpp->last_header_line);
-	    }
+            }
 
             data = msr->mpd->buf;
 
@@ -422,6 +422,16 @@ static int multipart_process_part_header(modsec_rec *msr, char **error_msg) {
                 *error_msg = apr_psprintf(msr->mp, "Multipart: Invalid part header (header name missing).");
 
                  return -1;
+            }
+
+            /* check if multipart header contains any invalid characters */
+            char *ch = header_name;
+            while(*ch != '\0') {
+                if (*ch < 33 || *ch > 126) {
+                    *error_msg = apr_psprintf(msr->mp, "Multipart: Invalid part header (contains invalid character).");
+                    return -1;
+                }
+                ch++;
             }
 
             /* extract the value value */

--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -616,7 +616,6 @@ static int var_reqbody_processor_error_msg_generate(modsec_rec *msr, msre_var *v
 {
     assert(msr != NULL);
     assert(var != NULL);
-    assert(rule != NULL);
     assert(vartab != NULL);
     assert(mptmp != NULL);
     msre_var *rvar = apr_pmemdup(mptmp, var, sizeof(msre_var));


### PR DESCRIPTION
## what

Check MULTIPART HEADER if it contains any illegal characters. If there are any of these characters, variable `REQBODY_ERROR` will set.

## why

MULTIPART HEADERS can't contain any characters outside of interval between 33 and 126, and 58 (`:` - this is the separator).

## references

RFC [2045](https://datatracker.ietf.org/doc/html/rfc2045) refers RFC [822](https://datatracker.ietf.org/doc/html/rfc822#section-3.2) about the header syntax.