### PR TITLE
Removed unnecessary lock to call acmp_process_quick in Pm::evaluate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -316,23 +316,6 @@ AC_ARG_ENABLE(parser-generation,
     [buildParser=false]
     )
 
-# Mutex
-AC_ARG_ENABLE(mutex-on-pm,
-    [AS_HELP_STRING([--enable-mutex-on-pm],[Treats pm operations as a critical section])],
-
-    [case "${enableval}" in
-        yes) mutexPm=true ;;
-        no)  mutexPm=false ;;
-        *) AC_MSG_ERROR(bad value ${enableval} for --enable-mutex-on-pm) ;;
-    esac],
-
-    [mutexPm=false]
-    )
-if test "$mutexPm" == "true"; then
-    MODSEC_MUTEX_ON_PM="-DMUTEX_ON_PM=1"
-    AC_SUBST(MODSEC_MUTEX_ON_PM)
-fi
-
 
 if test $buildParser = true; then
     AC_PROG_YACC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -321,7 +321,6 @@ libmodsecurity_la_CPPFLAGS = \
 	$(GEOIP_CFLAGS) \
 	$(GLOBAL_CPPFLAGS) \
 	$(MODSEC_NO_LOGS) \
-	$(MODSEC_MUTEX_ON_PM) \
 	$(YAJL_CFLAGS) \
 	$(LMDB_CFLAGS) \
 	$(PCRE_CFLAGS) \

--- a/src/operators/pm.cc
+++ b/src/operators/pm.cc
@@ -85,14 +85,7 @@ bool Pm::evaluate(Transaction *transaction, RuleWithActions *rule,
     pt.parser = m_p;
     pt.ptr = NULL;
     const char *match = NULL;
-#ifdef MODSEC_MUTEX_ON_PM
-    {
-    const std::lock_guard lock(m_mutex);
-#endif
     rc = acmp_process_quick(&pt, &match, input.c_str(), input.length());
-#ifdef MODSEC_MUTEX_ON_PM
-    }
-#endif
 
     if (rc >= 0 && transaction) {
         std::string match_(match?match:"");

--- a/src/operators/pm.h
+++ b/src/operators/pm.h
@@ -53,12 +53,6 @@ class Pm : public Operator {
 
  protected:
     ACMP *m_p;
-
-#ifdef MODSEC_MUTEX_ON_PM
-
- private:
-    std::mutex m_mutex;
-#endif
 };
 
 


### PR DESCRIPTION
## what

Remove the lock in the `Pm` operator, which is off by default (it can be enabled with the `--enable-mutex-on-pm` configure flag, which adds the define for `MODSEC_MUTEX_ON_PM`) and is not needed.

## why

This lock was introduced in commit 119a6fc & 7d786b3 at the same time (and probably because of) issue #1573, where a double-free issue running in a multi-threaded context was reported.

Some time later, it's stated that the lock should not be necessary (see [here](https://github.com/owasp-modsecurity/ModSecurity/issues/1954#issuecomment-438725954)), and that it should be safe without the mutex (the issue explicitly asks about whether it's necessary for multithreaded environments).

Reviewing commit 119a6fc, it includes two separate changes:

 * It introduces the lock to prevent executing `acmp_process_quick` in the same instance of the operator at the same time.
 * It moves the call to `acmp_prepare` from `acmp_process_quick` to `Pm::init`.

The second change is significant because it removes (comments out to be precise) the code that could potentially modify the data structure during the execution of `acmp_process_quick`. The updated version of `acmp_process_quick` only *reads* the data structure (which once initialized in `Pm::init` is not modified afterwards), so it can be safely executed concurrently in a multithreaded context.

This is why the lock is not needed and can be removed.