### PR TITLE
Replace usage of std::ctime, which is not safe in multithread contexts

### DIFF
--- a/src/audit_log/writer/parallel.cc
+++ b/src/audit_log/writer/parallel.cc
@@ -51,28 +51,27 @@ Parallel::~Parallel() {
 
 inline std::string Parallel::logFilePath(time_t *t,
     int part) {
-    struct tm timeinfo;
-    char tstr[300];
-    std::string name("");
+    std::string name;
 
+    struct tm timeinfo;
     localtime_r(t, &timeinfo);
 
     if (part & YearMonthDayDirectory) {
-        memset(tstr, '\0', 300);
-        strftime(tstr, 299, "/%Y%m%d", &timeinfo);
-        name = tstr;
+        char tstr[std::size("/yyyymmdd")];
+        strftime(tstr, std::size(tstr), "/%Y%m%d", &timeinfo);
+        name.append(tstr);
     }
 
     if (part & YearMonthDayAndTimeDirectory) {
-        memset(tstr, '\0', 300);
-        strftime(tstr, 299, "/%Y%m%d-%H%M", &timeinfo);
-        name = name + tstr;
+        char tstr[std::size("/yyyymmdd-hhmm")];
+        strftime(tstr, std::size(tstr), "/%Y%m%d-%H%M", &timeinfo);
+        name.append(tstr);
     }
 
     if (part & YearMonthDayAndTimeFileName) {
-        memset(tstr, '\0', 300);
-        strftime(tstr, 299, "/%Y%m%d-%H%M%S", &timeinfo);
-        name = name + tstr;
+        char tstr[std::size("/yyyymmdd-hhmmss")];
+        strftime(tstr, std::size(tstr), "/%Y%m%d-%H%M%S", &timeinfo);
+        name.append(tstr);
     }
 
     return name;

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -65,12 +65,12 @@ MultipartPartTmpFile::~MultipartPartTmpFile() {
 }
 
 void MultipartPartTmpFile::Open() {
-    struct tm timeinfo;
-    time_t tt = time(NULL);
+    time_t tt = time(nullptr);
 
+    struct tm timeinfo;
     localtime_r(&tt, &timeinfo);
 
-    char tstr[17];
+    char tstr[std::size("/yyyymmdd-hhmmss")];
     strftime(tstr, std::size(tstr), "/%Y%m%d-%H%M%S", &timeinfo);
 
     std::string path = m_transaction->m_rules->m_uploadDirectory.m_value;

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1509,13 +1509,12 @@ bool Transaction::intervention(ModSecurityIntervention *it) {
 std::string Transaction::toOldAuditLogFormatIndex(const std::string &filename,
     double size, const std::string &md5) {
     std::stringstream ss;
-    struct tm timeinfo;
-    char tstr[300];
 
-    memset(tstr, '\0', 300);
+    struct tm timeinfo;
     localtime_r(&this->m_timeStamp, &timeinfo);
 
-    strftime(tstr, 299, "[%d/%b/%Y:%H:%M:%S %z]", &timeinfo);
+    char tstr[std::size("[dd/Mmm/yyyy:hh:mm:ss shhmm]")];
+    strftime(tstr, std::size(tstr), "[%d/%b/%Y:%H:%M:%S %z]", &timeinfo);
 
     ss << utils::string::dash_if_empty(
        m_variableRequestHeaders.resolveFirst("Host").get())
@@ -1572,14 +1571,14 @@ std::string Transaction::toOldAuditLogFormatIndex(const std::string &filename,
 std::string Transaction::toOldAuditLogFormat(int parts,
     const std::string &trailer) {
     std::stringstream audit_log;
-    struct tm timeinfo;
-    char tstr[300];
 
-    memset(tstr, '\0', 300);
+    struct tm timeinfo;
     localtime_r(&this->m_timeStamp, &timeinfo);
 
+    char tstr[std::size("[dd/Mmm/yyyy:hh:mm:ss shhmm]")];
+    strftime(tstr, std::size(tstr), "[%d/%b/%Y:%H:%M:%S %z]", &timeinfo);
+
     audit_log << "--" << trailer << "-" << "A--" << std::endl;
-    strftime(tstr, 299, "[%d/%b/%Y:%H:%M:%S %z]", &timeinfo);
     audit_log << tstr;
     audit_log << " " << m_id->c_str();
     audit_log << " " << this->m_clientIpAddress->c_str();

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -21,6 +21,11 @@
 #include <utility>
 #include <sstream>
 #include <iomanip>
+#include <time.h>
+
+#ifdef WIN32
+#include "src/compat/msvc.h"
+#endif
 
 #ifndef SRC_UTILS_STRING_H_
 #define SRC_UTILS_STRING_H_
@@ -60,9 +65,11 @@ const char HEX2DEC[256] = {
 
 
 inline std::string ascTime(const time_t *t) {
-    std::string ts = std::ctime(t);
-    ts.pop_back();
-    return ts;
+    struct tm timeinfo;
+    localtime_r(t, &timeinfo);
+    char tstr[std::size("Www Mmm dd hh:mm:ss yyyy")];
+    strftime(tstr, std::size(tstr), "%c", &timeinfo);
+    return tstr;
 }
 
 

--- a/src/variables/time.cc
+++ b/src/variables/time.cc
@@ -40,15 +40,13 @@ namespace variables {
 void Time::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
+
+    char tstr[std::size("hh:mm:ss")];
     strftime(tstr, 200, "%H:%M:%S", &timeinfo);
 
     transaction->m_variableTime.assign(tstr);

--- a/src/variables/time_day.cc
+++ b/src/variables/time_day.cc
@@ -40,15 +40,14 @@ namespace variables {
 void TimeDay::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%d", &timeinfo);
+
+    char tstr[std::size("dd")];
+    strftime(tstr, std::size(tstr), "%d", &timeinfo);
 
     transaction->m_variableTimeDay.assign(tstr);
 

--- a/src/variables/time_hour.cc
+++ b/src/variables/time_hour.cc
@@ -40,15 +40,14 @@ namespace variables {
 void TimeHour::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%H", &timeinfo);
+
+    char tstr[std::size("hh")];
+    strftime(tstr, std::size(tstr), "%H", &timeinfo);
 
     transaction->m_variableTimeHour.assign(tstr);
 

--- a/src/variables/time_min.cc
+++ b/src/variables/time_min.cc
@@ -40,15 +40,14 @@ namespace variables {
 void TimeMin::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%M", &timeinfo);
+
+    char tstr[std::size("mm")];
+    strftime(tstr, std::size(tstr), "%M", &timeinfo);
 
     transaction->m_variableTimeMin.assign(tstr);
 

--- a/src/variables/time_mon.cc
+++ b/src/variables/time_mon.cc
@@ -40,19 +40,13 @@ namespace variables {
 void TimeMon::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%m", &timeinfo);
-    int a = atoi(tstr);
-    a--;
 
-    transaction->m_variableTimeMin.assign(std::to_string(a));
+    transaction->m_variableTimeMin.assign(std::to_string(timeinfo.tm_mon));
 
     l->push_back(new VariableValue(&m_retName,
         &transaction->m_variableTimeMin));

--- a/src/variables/time_sec.cc
+++ b/src/variables/time_sec.cc
@@ -40,15 +40,14 @@ namespace variables {
 void TimeSec::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%S", &timeinfo);
+
+    char tstr[std::size("ss")];
+    strftime(tstr, std::size(tstr), "%S", &timeinfo);
 
     transaction->m_variableTimeSec.assign(tstr);
 

--- a/src/variables/time_wday.cc
+++ b/src/variables/time_wday.cc
@@ -40,15 +40,14 @@ namespace variables {
 void TimeWDay::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%u", &timeinfo);
+
+    char tstr[std::size("d")];
+    strftime(tstr, std::size(tstr), "%u", &timeinfo);
 
     transaction->m_variableTimeWDay.assign(tstr);
 

--- a/src/variables/time_year.cc
+++ b/src/variables/time_year.cc
@@ -40,15 +40,14 @@ namespace variables {
 void TimeYear::evaluate(Transaction *transaction,
     RuleWithActions *rule,
     std::vector<const VariableValue *> *l) {
-    char tstr[200];
-    struct tm timeinfo;
     time_t timer;
-
     time(&timer);
-    memset(tstr, '\0', 200);
 
+    struct tm timeinfo;
     localtime_r(&timer, &timeinfo);
-    strftime(tstr, 200, "%Y", &timeinfo);
+
+    char tstr[std::size("yyyy")];
+    strftime(tstr, std::size(tstr), "%Y", &timeinfo);
 
     transaction->m_variableTimeYear.assign(tstr);
 


### PR DESCRIPTION
## what

Replace usage of `std::ctime` in the string util [ascTime](https://github.com/owasp-modsecurity/ModSecurity/blob/718d121ee3c4384f01276f36a46bdbbae916c2b0/src/utils/string.h#L62), which is not safe in multithreaded contexts. `ascTime` is used by `Transaction::toJSON`, which is used to log transactions.

## why

From IBM's [ctime](https://www.ibm.com/docs/en/i/7.5?topic=functions-ctime-convert-time-character-string) documentation:

> The asctime() and ctime() functions, and other time functions can use a common, statically allocated buffer to hold the return string. Each call to one of these functions might destroy the result of the previous call. The asctime_r(), ctime_r(), gmtime_r(), and localtime_r() functions do not use a common, statically allocated buffer to hold the return string. These functions can be used in place of asctime(), ctime(), gmtime(), and localtime() if reentrancy is desired.

This was reported by `sonarcloud` while working on PR #3222:

> Remove use of this obsolete "ctime" function. Replace it by a call to "strftime".
> Obsolete POSIX functions should not be used cpp:S1911

## changes

- Replace usage of `std::ctime` with a call to `strftime`, where the output buffer is provided as an argument and is thread-safe.
- Reviewed and adjusted buffer size for others uses of `strftime` to leverage `std::size` to reserve the space needed by the format string.
- Simplified implementation of `TimeMon::evaluate` which was unnecessarily generating a string representation of the month to then parse it as an integer value, when the value is already available in the `struct tm timeinfo` with the call to `localtime_r`.

## notes

Checked that the library doesn't currently include any call to `localtime` (which is not thread-safe either) and uses `localtime_r` instead.