### PR TITLE
Restore pthread LDFLAG in examples

### DIFF
--- a/examples/multithread/Makefile.am
+++ b/examples/multithread/Makefile.am
@@ -21,6 +21,7 @@ multithread_LDFLAGS = \
 	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
 	-lmodsecurity \
+	-lpthread \
 	-lm \
 	-lstdc++ \
 	$(LMDB_LDFLAGS) \

--- a/examples/reading_logs_with_offset/Makefile.am
+++ b/examples/reading_logs_with_offset/Makefile.am
@@ -21,6 +21,7 @@ read_LDFLAGS = \
 	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
 	-lmodsecurity \
+	-lpthread \
 	-lm \
 	-lstdc++ \
 	$(LMDB_LDFLAGS) \


### PR DESCRIPTION
## what

Restore the `pthread` `LDFLAG` to build the following examples: `multithread` & `reading_logs_with_offset`

## why

I removed this flag from the `reading_logs_with_offset` in commit 293cd21 after replacing usage of `pthreads` with C++'s `std::thread`. Additionally, I didn't add that flag either to the `multithread` example added in commit 4bf9616 for the same reason.

However, I'm getting the following error when building both of these projects in a Debian container:

```
/usr/bin/ld: multithread-multithread.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
```

NOTE: It's curious that this doesn't happen when building the projects in all the non-Windows environments of the `Quality Assurance` workflow (which uses the same configuration) and thus wasn't detected before integrating PR #3216. 🤷‍♂️