### PR TITLE
Unit tests results should not be displayed in 'automake output' mode

### DIFF
--- a/examples/reading_logs_via_rule_message/Makefile.am
+++ b/examples/reading_logs_via_rule_message/Makefile.am
@@ -21,6 +21,7 @@ simple_request_LDFLAGS = \
 	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
 	-lmodsecurity \
+	-lpthread \
 	-lm \
 	-lstdc++ \
 	$(LMDB_LDFLAGS) \

--- a/examples/reading_logs_with_offset/Makefile.am
+++ b/examples/reading_logs_with_offset/Makefile.am
@@ -21,7 +21,6 @@ read_LDFLAGS = \
 	-L$(top_builddir)/src/.libs/ \
 	$(GEOIP_LDFLAGS) \
 	-lmodsecurity \
-	-lpthread \
 	-lm \
 	-lstdc++ \
 	$(LMDB_LDFLAGS) \

--- a/test/unit/unit.cc
+++ b/test/unit/unit.cc
@@ -275,10 +275,10 @@ int main(int argc, char **argv) {
 
     if (!test.m_automake_output) {
         std::cout << "Total >> "  << total << std::endl;
-    }
 
-    for (const auto t : results) {
-        std::cout << t->print() << std::endl;
+        for (const auto t : results) {
+            std::cout << t->print() << std::endl;
+        }
     }
 
     const int skp = std::count_if(results.cbegin(), results.cend(), [](const auto &i)


### PR DESCRIPTION
## what

Updated `unit_tests` program to not show individual unit tests results in *automake output*.

## why

Showing individual results breaks the collection of results when a test fails bypassing its detection, which makes `make check` show incorrect results.

The issue is that the individual test results include escape characters to colorize the output (to show in red that a test failed for example) and this makes the generated `.log` & `.trs` file binary, which breaks `grep` parsing in `test/custom-test-driver` and the collection of test results from `autotest`.

NOTE: The issue is not limited to the escape characters to colorize output as there are tests that include binary data in the input & output of the tests, which when display trigger the same issue.

For example, in the context of #3231, if you introduce a bug in the `ParityOdd7bit` transformation (by switching the `inplace` template parameter from `true` to `false`, which makes it behave like the `ParityEven7bit` in the new shared implementation), three of the tests should fail. However, if you run the tests with `make check`, they complete with zero errors! If you look at the output of the execution, though, you can see that there are grep errors:

```
(...)
(   4/  0/   4): test/test-cases/secrules-language-tests/transformations/parityEven7bit.json
grep: (standard input): binary file matches
grep: (standard input): binary file matches
grep: (standard input): binary file matches
(   0/  0/   0): test/test-cases/secrules-language-tests/transformations/parityOdd7bit.json
(...)
(   7/  0/   7): test/test-cases/secrules-language-tests/transformations/utf8toUnicode.json
grep: test/test-cases/secrules-language-tests/transformations/parityOdd7bit.json.trs: binary file matches
grep: test/test-cases/secrules-language-tests/transformations/parityOdd7bit.json.trs: binary file matches
grep: test/test-cases/secrules-language-tests/transformations/parityOdd7bit.json.trs: binary file matches
============================================================================
Testsuite summary for modsecurity 3.0
============================================================================
# TOTAL: 4956
# PASS:  4918
# SKIP:  38
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

## misc

Piggyback on this PR to complete update from PR #3229. 🙏