### PR TITLE
fix: Handle "filename*" field in MP header

### DIFF
--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -134,7 +134,7 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
          */
 
         char quote = '\0';
-        if (name == "filename*") {
+        if (strcmp(name, "filename*") == 0) {
             /* filename*=charset'[optional-language]'filename */
             /* Read beyond the charset and the optional language*/
             const char* start_of_charset = p;

--- a/apache2/msc_multipart.c
+++ b/apache2/msc_multipart.c
@@ -149,6 +149,7 @@ static int multipart_parse_content_disposition(modsec_rec *msr, char *c_d_value)
                 p++;
             }
             if (*p != '\'') {
+                msr->mpd->flag_invalid_quoting = 1;
                 return -17; // Single quote for end-of-language not found
             }
             p++;


### PR DESCRIPTION
## what

Add handling of Multipart Header's "filename*" (asterisk at the end!) field.

## why

mod_security2 (v2) does not handle MULTIPART header's "filename*" field, eg:

```
Content-Disposition: form-data; name="file"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf
```
where the filename is UTF8 encoded string with value "résumé.pdf".

## references

[RFC 7578](https://www.rfc-editor.org/rfc/rfc7578.html)

## additional notes

v3 handles as well this header, I almost copied that [part](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/src/request_body_processor/multipart.cc#L342-L375) of [code](https://github.com/owasp-modsecurity/ModSecurity/blob/v3/master/src/request_body_processor/multipart.cc#L463-L469).

Thanks @fzipi for bringing it to our attention.

