### PR TITLE
Lua::run: Move logging of `str` parameter to higher log level.

### DIFF
--- a/src/engine/lua.cc
+++ b/src/engine/lua.cc
@@ -185,7 +185,7 @@ int Lua::run(Transaction *t, const std::string &str) {
 
     lua_getglobal(L, "main");
 
-    ms_dbg_a(t, 1, str);
+    ms_dbg_a(t, 9, str);
 
     /* Put the parameter on the stack. */
     if (!str.empty() ) {


### PR DESCRIPTION
## what

This silences a spammy debug log output.

## why

When running with the debug log enabled, it spams a useless line for every request, when using a Lua script. It can't be disabled / filtered, because it's logged with the lowest level.



```
[172433088121.621649] [/something/] [1]
[17243308919.222807] [/] [1]
[17243308919.222807] [/] [1]
[172433090139.589739] [/] [1]
```

I don't know if 9 is the appropriate level. Alternatively this line could be removed altogether.

## references

The line in question was [introduced](https://github.com/owasp-modsecurity/ModSecurity/commit/6624a18a4e7fd9881a7a9b435db3e481e8e986a5#r145821987) in Nov 2019.