### PR TITLE
Adjust reference to modsecurity::utils::string::VALID_HEX

### DIFF
--- a/src/operators/pm.cc
+++ b/src/operators/pm.cc
@@ -22,6 +22,7 @@
 #include "src/utils/acmp.h"
 #include "src/utils/string.h"
 
+using namespace modsecurity::utils::string;
 
 static inline std::string parse_pm_content(const std::string &op_parm) {
     auto offset = op_parm.find_first_not_of(" \t");

--- a/test/test-cases/regression/operator-pm.json
+++ b/test/test-cases/regression/operator-pm.json
@@ -3,7 +3,7 @@
     "enabled": 1,
     "version_min": 300000,
     "version_max": 0,
-    "title": "pm operator test 1/4",
+    "title": "pm operator test 1/6",
     "client": {
       "ip": "200.249.12.31",
       "port": 2313
@@ -77,7 +77,7 @@
     "enabled": 1,
     "version_min": 300000,
     "version_max": 0,
-    "title": "pm operater test 3/4",
+    "title": "pm operater test 3/6",
     "client": {
       "ip": "200.249.12.31",
       "port": 2313
@@ -114,7 +114,7 @@
     "enabled": 1,
     "version_min": 300000,
     "version_max": 0,
-    "title": "pm operater test 4/4",
+    "title": "pm operater test 4/6",
     "client": {
       "ip": "200.249.12.31",
       "port": 2313
@@ -145,6 +145,80 @@
     "rules": [
       "SecRuleEngine On",
       "SecRule ARGS \"@pm a ` b\" \"phase:1,id:999,deny,status:500\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "version_max": 0,
+    "title": "pm operater test 5/6",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 2313
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "net.tutsplus.com"
+      },
+      "uri": "\/test.pl?param1=123",
+      "method": "GET",
+      "http_version": 1.1,
+      "body": ""
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "text\/xml; charset=utf-8\n\r",
+        "Content-Length": "length\n\r"
+      }
+    },
+    "expected": {
+      "debug_log": "Rule returned 1",
+      "http_code": 403
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@pm 1 2 3\" \"phase:1,id:999,deny\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "version_max": 0,
+    "title": "pm operater test 6/6",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 2313
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "net.tutsplus.com"
+      },
+      "uri": "\/test.pl?param1=abc",
+      "method": "GET",
+      "http_version": 1.1,
+      "body": ""
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "text\/xml; charset=utf-8\n\r",
+        "Content-Length": "length\n\r"
+      }
+    },
+    "expected": {
+      "debug_log": "Rule returned 0",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@pm 1 2 3\" \"phase:1,id:999,deny\""
     ]
   }
 ]


### PR DESCRIPTION
## what

Fix build after integrating PR #3231 & #3233 because of reference to `modsecurity::utils::string::VALID_HEX` in `pm.cc`'s `parse_pm_content`.

## why

These two PRs were independent of each other, but when we added a reference to `VALID_HEX` to simplify the code, we introduced an incompatibility between both PRs because PR #3231 moved `VALID_HEX` into the namespace `modsecurity::utils::string` (alongside all other helper functions in `src/utils/string.h`) and adjusted all call sites to this function (previously a macro). However, in that branch the call added to `parse_pm_content` that we introduced later in PR #3233 was not present and thus was not adjusted.