### PR TITLE
Simplified constructors, copy constructors & assignment operators

### DIFF
--- a/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
+++ b/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
@@ -155,8 +155,8 @@ class ReadingLogsViaRuleMessage {
         const modsecurity::RuleMessage *ruleMessage = \
             reinterpret_cast<const modsecurity::RuleMessage *>(ruleMessagev);
 
-        std::cout << "Rule Id: " << std::to_string(ruleMessage->m_ruleId);
-        std::cout << " phase: " << std::to_string(ruleMessage->m_phase);
+        std::cout << "Rule Id: " << std::to_string(ruleMessage->m_rule.m_ruleId);
+        std::cout << " phase: " << std::to_string(ruleMessage->getPhase());
         std::cout << std::endl;
         if (ruleMessage->m_isDisruptive) {
             std::cout << " * Disruptive action: ";

--- a/examples/using_bodies_in_chunks/simple_request.cc
+++ b/examples/using_bodies_in_chunks/simple_request.cc
@@ -76,8 +76,8 @@ static void logCb(void *data, const void *ruleMessagev) {
     const modsecurity::RuleMessage *ruleMessage = \
         reinterpret_cast<const modsecurity::RuleMessage *>(ruleMessagev);
 
-    std::cout << "Rule Id: " << std::to_string(ruleMessage->m_ruleId);
-    std::cout << " phase: " << std::to_string(ruleMessage->m_phase);
+    std::cout << "Rule Id: " << std::to_string(ruleMessage->m_rule.m_ruleId);
+    std::cout << " phase: " << std::to_string(ruleMessage->getPhase());
     std::cout << std::endl;
     if (ruleMessage->m_isDisruptive) {
         std::cout << " * Disruptive action: ";

--- a/headers/modsecurity/actions/action.h
+++ b/headers/modsecurity/actions/action.h
@@ -81,21 +81,9 @@ class Action {
             set_name_and_payload(_action);
         }
 
-    Action(const Action &a)
-        : m_isNone(a.m_isNone),
-        temporaryAction(a.temporaryAction),
-        action_kind(a.action_kind),
-        m_name(a.m_name),
-        m_parser_payload(a.m_parser_payload) { }
+    Action(const Action &a) = delete;
 
-    Action &operator=(const Action& a) {
-        m_isNone = a.m_isNone;
-        temporaryAction = a.temporaryAction;
-        action_kind = a.action_kind;
-        m_name = a.m_name;
-        m_parser_payload = a.m_parser_payload;
-        return *this;
-    }
+    Action &operator=(const Action& a) = delete;
 
     virtual ~Action() { }
 

--- a/headers/modsecurity/rule.h
+++ b/headers/modsecurity/rule.h
@@ -64,8 +64,8 @@ using MatchActions = std::vector<actions::Action *>;
 
 class Rule {
  public:
-    Rule(std::unique_ptr<std::string> fileName, int lineNumber)
-        : m_fileName(*fileName),
+    Rule(const std::string &fileName, int lineNumber)
+        : m_fileName(fileName),
         m_lineNumber(lineNumber),
         m_phase(modsecurity::Phases::RequestHeadersPhase) {
         }

--- a/headers/modsecurity/rule.h
+++ b/headers/modsecurity/rule.h
@@ -65,7 +65,7 @@ using MatchActions = std::vector<actions::Action *>;
 class Rule {
  public:
     Rule(std::unique_ptr<std::string> fileName, int lineNumber)
-        : m_fileName(std::make_shared<std::string>(*fileName)),
+        : m_fileName(*fileName),
         m_lineNumber(lineNumber),
         m_phase(modsecurity::Phases::RequestHeadersPhase) {
         }
@@ -81,7 +81,7 @@ class Rule {
     virtual bool evaluate(Transaction *transaction,
         std::shared_ptr<RuleMessage> rm) = 0;
 
-    std::shared_ptr<std::string> getFileName() const {
+    const std::string& getFileName() const {
         return m_fileName;
     }
 
@@ -93,18 +93,15 @@ class Rule {
     void setPhase(int phase) { m_phase = phase; }
 
     virtual std::string getReference() {
-        if (m_fileName) {
-            return *m_fileName + ":" + std::to_string(m_lineNumber);
-        }
-        return "<<no file>>:" + std::to_string(m_lineNumber);
+        return m_fileName + ":" + std::to_string(m_lineNumber);
     }
 
 
     virtual bool isMarker() { return false; }
 
  private:
-    std::shared_ptr<std::string> m_fileName;
-    int m_lineNumber;
+    const std::string m_fileName;
+    const int m_lineNumber;
     // FIXME: phase may not be neede to SecMarker.
     int m_phase;
 };

--- a/headers/modsecurity/rule.h
+++ b/headers/modsecurity/rule.h
@@ -13,15 +13,6 @@
  *
  */
 
-#ifdef __cplusplus
-#include <stack>
-#include <vector>
-#include <string>
-#include <list>
-#include <memory>
-#include <utility>
-#endif
-
 #ifndef HEADERS_MODSECURITY_RULE_H_
 #define HEADERS_MODSECURITY_RULE_H_
 
@@ -30,6 +21,12 @@
 #include "modsecurity/variable_value.h"
 
 #ifdef __cplusplus
+
+#include <vector>
+#include <string>
+#include <list>
+#include <memory>
+#include <utility>
 
 namespace modsecurity {
 namespace variables {
@@ -73,18 +70,9 @@ class Rule {
         m_phase(modsecurity::Phases::RequestHeadersPhase) {
         }
 
-    Rule(const Rule &other) :
-        m_fileName(other.m_fileName),
-        m_lineNumber(other.m_lineNumber),
-        m_phase(other.m_phase)
-    { }
+    Rule(const Rule &other) = delete;
 
-    Rule &operator=(const Rule& other) {
-        m_fileName = other.m_fileName;
-        m_lineNumber = other.m_lineNumber;
-        m_phase = other.m_phase;
-        return *this;
-    }
+    Rule &operator=(const Rule &other) = delete;
 
     virtual ~Rule() {}
 

--- a/headers/modsecurity/rule_marker.h
+++ b/headers/modsecurity/rule_marker.h
@@ -33,9 +33,9 @@ class RuleMarker : public Rule {
  public:
     RuleMarker(
         const std::string &name,
-        std::unique_ptr<std::string> fileName,
+        const std::string &fileName,
         int lineNumber)
-        : Rule(std::move(fileName), lineNumber),
+        : Rule(fileName, lineNumber),
         m_name(name) { }
 
     RuleMarker(const RuleMarker &r) = delete;

--- a/headers/modsecurity/rule_marker.h
+++ b/headers/modsecurity/rule_marker.h
@@ -13,15 +13,6 @@
  *
  */
 
-#ifdef __cplusplus
-#include <stack>
-#include <vector>
-#include <string>
-#include <list>
-#include <memory>
-#include <utility>
-#endif
-
 #ifndef HEADERS_MODSECURITY_RULE_MARKER_H_
 #define HEADERS_MODSECURITY_RULE_MARKER_H_
 
@@ -31,6 +22,9 @@
 #include "modsecurity/rule.h"
 
 #ifdef __cplusplus
+
+#include <string>
+#include <memory>
 
 namespace modsecurity {
 
@@ -42,45 +36,32 @@ class RuleMarker : public Rule {
         std::unique_ptr<std::string> fileName,
         int lineNumber)
         : Rule(std::move(fileName), lineNumber),
-        m_name(std::make_shared<std::string>(name)) { }
+        m_name(name) { }
 
-    RuleMarker(const RuleMarker& r) :
-        Rule(r),
-        m_name(r.m_name)
-    { }
+    RuleMarker(const RuleMarker &r) = delete;
 
-    RuleMarker &operator =(const RuleMarker& r) {
-        Rule::operator = (r);
-        m_name = r.m_name;
-        return *this;
-    }
-
+    RuleMarker &operator=(const RuleMarker &r) = delete;
+   
     virtual bool evaluate(Transaction *transaction,
         std::shared_ptr<RuleMessage> rm) override {
         return evaluate(transaction);
     }
 
     virtual bool evaluate(Transaction *transaction) override {
-        if (transaction->isInsideAMarker()) {
-            if (*transaction->getCurrentMarker() == *m_name) {
+        if (transaction->isInsideAMarker() &&
+            *transaction->getCurrentMarker() == m_name) {
                 transaction->removeMarker();
                 // FIXME: Move this to .cc
                 //        ms_dbg_a(transaction, 4, "Out of a SecMarker " + *m_name);
-            }
         }
 
         return true;
     };
 
-
-    std::shared_ptr<std::string> getName() {
-        return m_name;
-    }
-
     bool isMarker() override { return true; }
 
  private:
-    std::shared_ptr<std::string> m_name;
+    const std::string m_name;
 };
 
 

--- a/headers/modsecurity/rule_message.h
+++ b/headers/modsecurity/rule_message.h
@@ -42,116 +42,13 @@ class RuleMessage {
         ClientLogMessageInfo = 4
     };
 
-    /**
-     *
-     * FIXME: RuleMessage is currently too big, doing a lot of
-     * unnecessary data duplication. Needs to be shrink down.
-     *
-     */
-    RuleMessage(RuleWithActions *rule, Transaction *trans) :
-        m_accuracy(rule->m_accuracy),
-        m_clientIpAddress(trans->m_clientIpAddress),
-        m_data(""),
-        m_id(trans->m_id),
-        m_isDisruptive(false),
-        m_match(""),
-        m_maturity(rule->m_maturity),
-        m_message(""),
-        m_noAuditLog(false),
-        m_phase(rule->getPhase() - 1),
-        m_reference(""),
-        m_rev(rule->m_rev),
+    RuleMessage(const RuleWithActions &rule, const Transaction &trans) :
         m_rule(rule),
-        m_ruleFile(rule->getFileName()),
-        m_ruleId(rule->m_ruleId),
-        m_ruleLine(rule->getLineNumber()),
-        m_saveMessage(true),
-        m_serverIpAddress(trans->m_serverIpAddress),
-        m_requestHostName(trans->m_requestHostName),
-        m_severity(0),
-        m_uriNoQueryStringDecoded(trans->m_uri_no_query_string_decoded),
-        m_ver(rule->m_ver),
-        m_tags()
+        m_transaction(trans)
     { }
 
-    explicit RuleMessage(RuleMessage *rule) :
-        m_accuracy(rule->m_accuracy),
-        m_clientIpAddress(rule->m_clientIpAddress),
-        m_data(rule->m_data),
-        m_id(rule->m_id),
-        m_isDisruptive(rule->m_isDisruptive),
-        m_match(rule->m_match),
-        m_maturity(rule->m_maturity),
-        m_message(rule->m_message),
-        m_noAuditLog(rule->m_noAuditLog),
-        m_phase(rule->m_phase),
-        m_reference(rule->m_reference),
-        m_rev(rule->m_rev),
-        m_rule(rule->m_rule),
-        m_ruleFile(rule->m_ruleFile),
-        m_ruleId(rule->m_ruleId),
-        m_ruleLine(rule->m_ruleLine),
-        m_saveMessage(rule->m_saveMessage),
-        m_serverIpAddress(rule->m_serverIpAddress),
-        m_requestHostName(rule->m_requestHostName),
-        m_severity(rule->m_severity),
-        m_uriNoQueryStringDecoded(rule->m_uriNoQueryStringDecoded),
-        m_ver(rule->m_ver),
-        m_tags(rule->m_tags)
-    { }
-
-    RuleMessage(const RuleMessage& ruleMessage)
-        : m_accuracy(ruleMessage.m_accuracy),
-        m_clientIpAddress(ruleMessage.m_clientIpAddress),
-        m_data(ruleMessage.m_data),
-        m_id(ruleMessage.m_id),
-        m_isDisruptive(ruleMessage.m_isDisruptive),
-        m_match(ruleMessage.m_match),
-        m_maturity(ruleMessage.m_maturity),
-        m_message(ruleMessage.m_message),
-        m_noAuditLog(ruleMessage.m_noAuditLog),
-        m_phase(ruleMessage.m_phase),
-        m_reference(ruleMessage.m_reference),
-        m_rev(ruleMessage.m_rev),
-        m_rule(ruleMessage.m_rule),
-        m_ruleFile(ruleMessage.m_ruleFile),
-        m_ruleId(ruleMessage.m_ruleId),
-        m_ruleLine(ruleMessage.m_ruleLine),
-        m_saveMessage(ruleMessage.m_saveMessage),
-        m_serverIpAddress(ruleMessage.m_serverIpAddress),
-        m_requestHostName(ruleMessage.m_requestHostName),
-        m_severity(ruleMessage.m_severity),
-        m_uriNoQueryStringDecoded(ruleMessage.m_uriNoQueryStringDecoded),
-        m_ver(ruleMessage.m_ver),
-        m_tags(ruleMessage.m_tags)
-    { }
-
-    RuleMessage &operator=(const RuleMessage& ruleMessage) {
-        m_accuracy = ruleMessage.m_accuracy;
-        m_clientIpAddress = ruleMessage.m_clientIpAddress;
-        m_data = ruleMessage.m_data;
-        m_id = ruleMessage.m_id;
-        m_isDisruptive = ruleMessage.m_isDisruptive;
-        m_match = ruleMessage.m_match;
-        m_maturity = ruleMessage.m_maturity;
-        m_message = ruleMessage.m_message;
-        m_noAuditLog = ruleMessage.m_noAuditLog;
-        m_phase = ruleMessage.m_phase;
-        m_reference = ruleMessage.m_reference;
-        m_rev = ruleMessage.m_rev;
-        m_rule = ruleMessage.m_rule;
-        m_ruleFile = ruleMessage.m_ruleFile;
-        m_ruleId = ruleMessage.m_ruleId;
-        m_ruleLine = ruleMessage.m_ruleLine;
-        m_saveMessage = ruleMessage.m_saveMessage;
-        m_serverIpAddress = ruleMessage.m_serverIpAddress;
-        m_requestHostName = ruleMessage.m_requestHostName;
-        m_severity = ruleMessage.m_severity;
-        m_uriNoQueryStringDecoded = ruleMessage.m_uriNoQueryStringDecoded;
-        m_ver = ruleMessage.m_ver;
-        m_tags = ruleMessage.m_tags;
-        return *this;
-    }
+    RuleMessage(const RuleMessage &ruleMessage) = default;
+    RuleMessage &operator=(const RuleMessage &ruleMessage) = delete;
 
     void clean() {
         m_data = "";
@@ -159,7 +56,6 @@ class RuleMessage {
         m_isDisruptive = false;
         m_reference = "";
         m_severity = 0;
-        m_ver = "";
     }
 
     std::string log() {
@@ -187,28 +83,18 @@ class RuleMessage {
     static std::string _details(const RuleMessage *rm);
     static std::string _errorLogTail(const RuleMessage *rm);
 
-    int m_accuracy;
-    std::shared_ptr<std::string> m_clientIpAddress;
+    int getPhase() const { return m_rule.getPhase() - 1; }
+
+    const RuleWithActions &m_rule;
+    const Transaction &m_transaction;
     std::string m_data;
-    std::shared_ptr<std::string> m_id;
-    bool m_isDisruptive;
+    bool m_isDisruptive = false;
     std::string m_match;
-    int m_maturity;
     std::string m_message;
-    bool m_noAuditLog;
-    int m_phase;
+    bool m_noAuditLog = false;
     std::string m_reference;
-    std::string m_rev;
-    RuleWithActions *m_rule;
-    std::shared_ptr<std::string> m_ruleFile;
-    int m_ruleId;
-    int m_ruleLine;
-    bool m_saveMessage;
-    std::shared_ptr<std::string> m_serverIpAddress;
-    std::shared_ptr<std::string> m_requestHostName;
-    int m_severity;
-    std::shared_ptr<std::string> m_uriNoQueryStringDecoded;
-    std::string m_ver;
+    bool m_saveMessage = true;
+    int m_severity = 0;
 
     std::list<std::string> m_tags;
 };

--- a/headers/modsecurity/rule_unconditional.h
+++ b/headers/modsecurity/rule_unconditional.h
@@ -13,15 +13,6 @@
  *
  */
 
-#ifdef __cplusplus
-#include <stack>
-#include <vector>
-#include <string>
-#include <list>
-#include <memory>
-#include <utility>
-#endif
-
 #ifndef HEADERS_MODSECURITY_RULE_UNCONDITIONAL_H_
 #define HEADERS_MODSECURITY_RULE_UNCONDITIONAL_H_
 
@@ -34,30 +25,18 @@
 
 #ifdef __cplusplus
 
+#include <vector>
+#include <string>
+#include <memory>
+
 namespace modsecurity {
 
 
 class RuleUnconditional : public RuleWithActions {
  public:
-    RuleUnconditional(
-        std::vector<actions::Action *> *actions,
-        Transformations *transformations,
-        std::unique_ptr<std::string> fileName,
-        int lineNumber)
-        : RuleWithActions(actions, transformations, std::move(fileName), lineNumber) { }
-
-    RuleUnconditional(const RuleUnconditional& r)
-        : RuleWithActions(r)
-    { }
-
-    RuleUnconditional &operator=(const RuleUnconditional& r) {
-        RuleWithActions::operator = (r);
-        return *this;
-    }
+    using RuleWithActions::RuleWithActions;
 
     virtual bool evaluate(Transaction *transaction, std::shared_ptr<RuleMessage> ruleMessage) override;
-
- private:
 };
 
 

--- a/headers/modsecurity/rule_with_actions.h
+++ b/headers/modsecurity/rule_with_actions.h
@@ -43,63 +43,15 @@ class RuleWithActions : public Rule {
         std::unique_ptr<std::string> fileName,
         int lineNumber);
 
-    ~RuleWithActions();
+    ~RuleWithActions() override;
 
-    RuleWithActions(const RuleWithActions& r)
-        : Rule(r),
-        m_rev(r.m_rev),
-        m_ver(r.m_ver),
-        m_accuracy(r.m_accuracy),
-        m_maturity(r.m_maturity),
-        m_ruleId(r.m_ruleId),
-        m_chainedRuleChild(r.m_chainedRuleChild),
-        m_chainedRuleParent(r.m_chainedRuleParent),
-        m_disruptiveAction(r.m_disruptiveAction),
-        m_logData(r.m_logData),
-        m_msg(r.m_msg),
-        m_severity(r.m_severity),
-        m_actionsRuntimePos(r.m_actionsRuntimePos),
-        m_actionsSetVar(r.m_actionsSetVar),
-        m_actionsTag(r.m_actionsTag),
-        m_transformations(r.m_transformations),
-        m_containsCaptureAction(r.m_containsCaptureAction),
-        m_containsMultiMatchAction(r.m_containsMultiMatchAction),
-        m_containsStaticBlockAction(r.m_containsStaticBlockAction),
-        m_isChained(r.m_isChained)
-    { }
+    RuleWithActions(const RuleWithActions &r) = delete;
 
-    RuleWithActions &operator=(const RuleWithActions& r) {
-        Rule::operator = (r);
-        m_rev = r.m_rev;
-        m_ver = r.m_ver;
-        m_accuracy = r.m_accuracy;
-        m_maturity = r.m_maturity;
-        m_ruleId = r.m_ruleId;
-        m_chainedRuleChild = r.m_chainedRuleChild;
-        m_chainedRuleParent = r.m_chainedRuleParent;
-
-        m_disruptiveAction = r.m_disruptiveAction;
-        m_logData = r.m_logData;
-        m_msg = r.m_msg;
-        m_severity = r.m_severity;
-        m_actionsRuntimePos = r.m_actionsRuntimePos;
-        m_actionsSetVar = r.m_actionsSetVar;
-        m_actionsTag = r.m_actionsTag;
-
-        m_transformations = r.m_transformations;
-
-        m_containsCaptureAction = r.m_containsCaptureAction;
-        m_containsMultiMatchAction = r.m_containsMultiMatchAction;
-        m_containsStaticBlockAction = r.m_containsStaticBlockAction;
-        m_isChained = r.m_isChained;
-
-        return *this;
-    }
-
-    virtual bool evaluate(Transaction *transaction, std::shared_ptr<RuleMessage> ruleMessage) override;
+    RuleWithActions &operator=(const RuleWithActions &r) = delete;
 
     virtual bool evaluate(Transaction *transaction) override;
 
+    virtual bool evaluate(Transaction *transaction, std::shared_ptr<RuleMessage> ruleMessage) override;
 
     void executeActionsIndependentOfChainedRuleResult(
         Transaction *trasn,

--- a/headers/modsecurity/rule_with_actions.h
+++ b/headers/modsecurity/rule_with_actions.h
@@ -40,7 +40,7 @@ class RuleWithActions : public Rule {
     RuleWithActions(
         Actions *a,
         Transformations *t,
-        std::unique_ptr<std::string> fileName,
+        const std::string &fileName,
         int lineNumber);
 
     ~RuleWithActions() override;

--- a/headers/modsecurity/rule_with_actions.h
+++ b/headers/modsecurity/rule_with_actions.h
@@ -76,7 +76,7 @@ class RuleWithActions : public Rule {
     void performLogging(Transaction *trans,
         std::shared_ptr<RuleMessage> ruleMessage,
         bool lastLog = true,
-        bool chainedParentNull = false);
+        bool chainedParentNull = false) const;
 
     std::vector<actions::Action *> getActionsByName(const std::string& name,
         Transaction *t);

--- a/headers/modsecurity/rule_with_operator.h
+++ b/headers/modsecurity/rule_with_operator.h
@@ -45,7 +45,7 @@ class RuleWithOperator : public RuleWithActions {
         std::unique_ptr<std::string> fileName,
         int lineNumber);
 
-    virtual ~RuleWithOperator();
+    ~RuleWithOperator() override;
 
     bool evaluate(Transaction *transaction,
         std::shared_ptr<RuleMessage> rm) override;

--- a/headers/modsecurity/rule_with_operator.h
+++ b/headers/modsecurity/rule_with_operator.h
@@ -42,7 +42,7 @@ class RuleWithOperator : public RuleWithActions {
         variables::Variables *variables,
         std::vector<actions::Action *> *actions,
         Transformations *transformations,
-        std::unique_ptr<std::string> fileName,
+        const std::string &fileName,
         int lineNumber);
 
     ~RuleWithOperator() override;

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -57,7 +57,7 @@ typedef struct Rules_t RulesSet;
 #define ms_dbg(b, c) \
   do { \
       if (m_rules && m_rules->m_debugLog && m_rules->m_debugLog->m_debugLevel >= b) { \
-          m_rules->debug(b, *m_id.get(), m_uri, c); \
+          m_rules->debug(b, m_id, m_uri, c); \
       } \
   } while (0);
 #else
@@ -431,7 +431,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     /**
      * Holds the client IP address.
      */
-    std::shared_ptr<std::string> m_clientIpAddress;
+    std::string m_clientIpAddress;
 
     /**
      * Holds the HTTP version: 1.2, 2.0, 3.0 and so on....
@@ -441,12 +441,12 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     /**
      * Holds the server IP Address
      */
-    std::shared_ptr<std::string> m_serverIpAddress;
+    std::string m_serverIpAddress;
 
     /**
      * Holds the request's hostname
      */
-    std::shared_ptr<std::string> m_requestHostName;
+    std::string m_requestHostName;
 
     /**
      * Holds the raw URI that was requested.
@@ -456,7 +456,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     /**
      * Holds the URI that was requests (without the query string).
      */
-    std::shared_ptr<std::string> m_uri_no_query_string_decoded;
+    std::string m_uri_no_query_string_decoded;
 
     /**
      * Holds the combined size of all arguments, later used to fill the
@@ -568,7 +568,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
      * Contains the unique ID of the transaction. Use by the variable
 	 * `UNIQUE_ID'. This unique id is also saved as part of the AuditLog.
      */
-    std::shared_ptr<std::string> m_id;
+    std::string m_id;
 
     /**
      * Holds the amount of rules that should be skipped. If bigger than 0 the

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -13,6 +13,9 @@
  *
  */
 
+#ifndef HEADERS_MODSECURITY_TRANSACTION_H_
+#define HEADERS_MODSECURITY_TRANSACTION_H_
+
 #ifdef __cplusplus
 #include <cassert>
 #include <ctime>
@@ -32,9 +35,6 @@
 
 #include <stdlib.h>
 #include <stddef.h>
-
-#ifndef HEADERS_MODSECURITY_TRANSACTION_H_
-#define HEADERS_MODSECURITY_TRANSACTION_H_
 
 #ifndef __cplusplus
 typedef struct ModSecurity_t ModSecurity;
@@ -327,8 +327,8 @@ class TransactionSecMarkerManagement {
 /** @ingroup ModSecurity_CPP_API */
 class Transaction : public TransactionAnchoredVariables, public TransactionSecMarkerManagement {
  public:
-    Transaction(ModSecurity *transaction, RulesSet *rules, void *logCbData);
-    Transaction(ModSecurity *transaction, RulesSet *rules, char *id,
+    Transaction(ModSecurity *ms, RulesSet *rules, void *logCbData);
+    Transaction(ModSecurity *ms, RulesSet *rules, const char *id,
         void *logCbData);
     ~Transaction();
 
@@ -426,7 +426,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
 	 *       need to be filled if there is no rule using the variable
 	 *       `duration'.
      */
-    clock_t m_creationTimeStamp;
+    const clock_t m_creationTimeStamp;
 
     /**
      * Holds the client IP address.
@@ -505,7 +505,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     /**
      * Rules object utilized during this specific transaction.
      */
-    RulesSet *m_rules;
+    RulesSet * const m_rules;
 
     /**
      *
@@ -568,7 +568,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
      * Contains the unique ID of the transaction. Use by the variable
 	 * `UNIQUE_ID'. This unique id is also saved as part of the AuditLog.
      */
-    std::string m_id;
+    const std::string m_id;
 
     /**
      * Holds the amount of rules that should be skipped. If bigger than 0 the
@@ -600,7 +600,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
      * TODO: m_timeStamp and m_creationTimeStamp may be merged into a single
      *       variable.
      */
-    time_t m_timeStamp;
+    const time_t m_timeStamp;
 
 
     /**
@@ -636,6 +636,10 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     std::vector<std::shared_ptr<RequestBodyProcessor::MultipartPartTmpFile>> m_multipartPartTmpFiles;
 
  private:
+
+    Transaction(ModSecurity *ms, RulesSet *rules, const char *id,
+        void *logCbData, const time_t timestamp);
+
     /**
      * Pointer to the callback function that will be called to fill
      * the web server (connector) log.
@@ -656,7 +660,7 @@ Transaction *msc_new_transaction(ModSecurity *ms,
 
 /** @ingroup ModSecurity_C_API */
 Transaction *msc_new_transaction_with_id(ModSecurity *ms,
-    RulesSet *rules, char *id, void *logCbData);
+    RulesSet *rules, const char *id, void *logCbData);
 
 /** @ingroup ModSecurity_C_API */
 int msc_process_connection(Transaction *transaction,

--- a/src/audit_log/writer/parallel.cc
+++ b/src/audit_log/writer/parallel.cc
@@ -49,7 +49,7 @@ Parallel::~Parallel() {
 }
 
 
-inline std::string Parallel::logFilePath(time_t *t,
+inline std::string Parallel::logFilePath(const time_t *t,
     int part) {
     std::string name;
 

--- a/src/audit_log/writer/parallel.cc
+++ b/src/audit_log/writer/parallel.cc
@@ -123,7 +123,7 @@ bool Parallel::write(Transaction *transaction, int parts, std::string *error) {
     }
 
     const auto &logPath = m_audit->m_storage_dir;
-    fileName = logPath + fileName + "-" + *transaction->m_id.get();
+    fileName = logPath + fileName + "-" + transaction->m_id;
 
     if (logPath.empty()) {
         error->assign("Log path is not valid.");

--- a/src/audit_log/writer/parallel.h
+++ b/src/audit_log/writer/parallel.h
@@ -65,7 +65,7 @@ class Parallel : public Writer {
      YearMonthDayAndTimeFileName = 8,
     };
 
-    static inline std::string logFilePath(time_t *t, int part);
+    static inline std::string logFilePath(const time_t *t, int part);
 };
 
 }  // namespace writer

--- a/src/parser/driver.cc
+++ b/src/parser/driver.cc
@@ -43,11 +43,10 @@ Driver::~Driver() {
 }
 
 
-int Driver::addSecMarker(const std::string& marker, std::unique_ptr<std::string> fileName, int lineNumber) {
+int Driver::addSecMarker(const std::string& marker, const std::string &fileName, int lineNumber) {
     // FIXME: we might move this to the parser.
     for (int i = 0; i < modsecurity::Phases::NUMBER_OF_PHASES; i++) {
-        RuleMarker *r = new RuleMarker(marker, std::unique_ptr<std::string>(new std::string(*fileName)), lineNumber);
-        std::unique_ptr<RuleMarker> rule(r);
+        auto rule = std::make_unique<RuleMarker>(marker, fileName, lineNumber);
         rule->setPhase(i);
         m_rulesSetPhases.insert(std::move(rule));
     }

--- a/src/parser/driver.h
+++ b/src/parser/driver.h
@@ -60,7 +60,7 @@ class Driver : public RulesSetProperties {
 
     int addSecRule(std::unique_ptr<RuleWithActions> rule);
     int addSecAction(std::unique_ptr<RuleWithActions> rule);
-    int addSecMarker(const std::string& marker, std::unique_ptr<std::string> fileName, int lineNumber);
+    int addSecMarker(const std::string& marker, const std::string &fileName, int lineNumber);
     int addSecRuleScript(std::unique_ptr<RuleScript> rule);
 
     bool scan_begin();

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -2313,7 +2313,7 @@ namespace yy {
             /* variables */ v,
             /* actions */ a,
             /* transformations */ t,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[3].location.end.filename)),
+            /* file name */ std::string(*yystack_[3].location.end.filename),
             /* line number */ yystack_[3].location.end.line
             ));
 
@@ -2337,7 +2337,7 @@ namespace yy {
             /* variables */ v,
             /* actions */ NULL,
             /* transformations */ NULL,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[2].location.end.filename)),
+            /* file name */ std::string(*yystack_[2].location.end.filename),
             /* line number */ yystack_[2].location.end.line
             ));
         if (driver.addSecRule(std::move(rule)) == false) {
@@ -2363,7 +2363,7 @@ namespace yy {
         std::unique_ptr<RuleUnconditional> rule(new RuleUnconditional(
             /* actions */ a,
             /* transformations */ t,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[1].location.end.filename)),
+            /* file name */ std::string(*yystack_[1].location.end.filename),
             /* line number */ yystack_[1].location.end.line
             ));
         driver.addSecAction(std::move(rule));
@@ -2389,7 +2389,7 @@ namespace yy {
             /* path to script */ yystack_[1].value.as < std::string > (),
             /* actions */ a,
             /* transformations */ t,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[1].location.end.filename)),
+            /* file name */ std::string(*yystack_[1].location.end.filename),
             /* line number */ yystack_[1].location.end.line
             ));
 
@@ -2469,7 +2469,7 @@ namespace yy {
 #line 1241 "seclang-parser.yy"
       {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as < std::string > ()),
-            /* file name */ std::unique_ptr<std::string>(new std::string(*yystack_[0].location.end.filename)),
+            /* file name */ std::string(*yystack_[0].location.end.filename),
             /* line number */ yystack_[0].location.end.line
         );
       }

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1104,7 +1104,7 @@ expression:
             /* variables */ v,
             /* actions */ a,
             /* transformations */ t,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*@1.end.filename)),
+            /* file name */ std::string(*@1.end.filename),
             /* line number */ @1.end.line
             ));
 
@@ -1124,7 +1124,7 @@ expression:
             /* variables */ v,
             /* actions */ NULL,
             /* transformations */ NULL,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*@1.end.filename)),
+            /* file name */ std::string(*@1.end.filename),
             /* line number */ @1.end.line
             ));
         if (driver.addSecRule(std::move(rule)) == false) {
@@ -1146,7 +1146,7 @@ expression:
         std::unique_ptr<RuleUnconditional> rule(new RuleUnconditional(
             /* actions */ a,
             /* transformations */ t,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*@1.end.filename)),
+            /* file name */ std::string(*@1.end.filename),
             /* line number */ @1.end.line
             ));
         driver.addSecAction(std::move(rule));
@@ -1168,7 +1168,7 @@ expression:
             /* path to script */ $1,
             /* actions */ a,
             /* transformations */ t,
-            /* file name */ std::unique_ptr<std::string>(new std::string(*@1.end.filename)),
+            /* file name */ std::string(*@1.end.filename),
             /* line number */ @1.end.line
             ));
 
@@ -1240,7 +1240,7 @@ expression:
     | CONFIG_DIR_SEC_MARKER
       {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded($1),
-            /* file name */ std::unique_ptr<std::string>(new std::string(*@1.end.filename)),
+            /* file name */ std::string(*@1.end.filename),
             /* line number */ @1.end.line
         );
       }

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -74,7 +74,7 @@ void MultipartPartTmpFile::Open() {
     strftime(tstr, std::size(tstr), "/%Y%m%d-%H%M%S", &timeinfo);
 
     std::string path = m_transaction->m_rules->m_uploadDirectory.m_value;
-    path = path + tstr + "-" + *m_transaction->m_id.get();
+    path = path + tstr + "-" + m_transaction->m_id;
     path += "-file-XXXXXX";
 
 #ifndef WIN32

--- a/src/rule_message.cc
+++ b/src/rule_message.cc
@@ -26,26 +26,26 @@ namespace modsecurity {
 std::string RuleMessage::_details(const RuleMessage *rm) {
     std::string msg;
 
-    msg.append(" [file \"" + std::string(*rm->m_ruleFile.get()) + "\"]");
-    msg.append(" [line \"" + std::to_string(rm->m_ruleLine) + "\"]");
-    msg.append(" [id \"" + std::to_string(rm->m_ruleId) + "\"]");
-    msg.append(" [rev \"" + utils::string::toHexIfNeeded(rm->m_rev, true) + "\"]");
+    msg.append(" [file \"" + rm->m_rule.getFileName() + "\"]");
+    msg.append(" [line \"" + std::to_string(rm->m_rule.getLineNumber()) + "\"]");
+    msg.append(" [id \"" + std::to_string(rm->m_rule.m_ruleId) + "\"]");
+    msg.append(" [rev \"" + utils::string::toHexIfNeeded(rm->m_rule.m_rev, true) + "\"]");
     msg.append(" [msg \"" + rm->m_message + "\"]");
     msg.append(" [data \"" + utils::string::toHexIfNeeded(utils::string::limitTo(200, rm->m_data), true) + "\"]");
     msg.append(" [severity \"" +
         std::to_string(rm->m_severity) + "\"]");
-    msg.append(" [ver \"" + utils::string::toHexIfNeeded(rm->m_ver, true) + "\"]");
-    msg.append(" [maturity \"" + std::to_string(rm->m_maturity) + "\"]");
-    msg.append(" [accuracy \"" + std::to_string(rm->m_accuracy) + "\"]");
+    msg.append(" [ver \"" + utils::string::toHexIfNeeded(rm->m_rule.m_ver, true) + "\"]");
+    msg.append(" [maturity \"" + std::to_string(rm->m_rule.m_maturity) + "\"]");
+    msg.append(" [accuracy \"" + std::to_string(rm->m_rule.m_accuracy) + "\"]");
 
     for (const auto &a : rm->m_tags) {
         msg.append(" [tag \"" + utils::string::toHexIfNeeded(a, true) + "\"]");
     }
 
-    msg.append(" [hostname \"" + *rm->m_requestHostName.get() + "\"]");
-
-    msg.append(" [uri \"" + utils::string::limitTo(200, *rm->m_uriNoQueryStringDecoded.get()) + "\"]");
-    msg.append(" [unique_id \"" + *rm->m_id + "\"]");
+    msg.append(" [hostname \"" + rm->m_transaction.m_requestHostName \
+        + "\"]");
+    msg.append(" [uri \"" + utils::string::limitTo(200, rm->m_transaction.m_uri_no_query_string_decoded) + "\"]");
+    msg.append(" [unique_id \"" + rm->m_transaction.m_id + "\"]");
     msg.append(" [ref \"" + utils::string::limitTo(200, rm->m_reference) + "\"]");
 
     return msg;
@@ -55,9 +55,9 @@ std::string RuleMessage::_details(const RuleMessage *rm) {
 std::string RuleMessage::_errorLogTail(const RuleMessage *rm) {
     std::string msg;
 
-    msg.append("[hostname \"" + *rm->m_serverIpAddress.get() + "\"]");
-    msg.append(" [uri \"" + utils::string::limitTo(200, *rm->m_uriNoQueryStringDecoded.get()) + "\"]");
-    msg.append(" [unique_id \"" + *rm->m_id + "\"]");
+    msg.append("[hostname \"" + rm->m_transaction.m_serverIpAddress + "\"]");
+    msg.append(" [uri \"" + utils::string::limitTo(200, rm->m_transaction.m_uri_no_query_string_decoded) + "\"]");
+    msg.append(" [unique_id \"" + rm->m_transaction.m_id + "\"]");
 
     return msg;
 }
@@ -68,7 +68,7 @@ std::string RuleMessage::log(const RuleMessage *rm, int props, int code) {
     msg.reserve(2048);
 
     if (props & ClientLogMessageInfo) {
-        msg.append("[client " + std::string(*rm->m_clientIpAddress.get()) + "] ");
+        msg.append("[client " + rm->m_transaction.m_clientIpAddress + "] ");
     }
 
     if (rm->m_isDisruptive) {
@@ -79,7 +79,7 @@ std::string RuleMessage::log(const RuleMessage *rm, int props, int code) {
             msg.append(std::to_string(code));
         }
         msg.append(" (phase ");
-        msg.append(std::to_string(rm->m_rule->getPhase() - 1) + "). ");
+        msg.append(std::to_string(rm->getPhase()) + "). ");
     } else {
         msg.append("ModSecurity: Warning. ");
     }

--- a/src/rule_script.h
+++ b/src/rule_script.h
@@ -47,9 +47,9 @@ class RuleScript : public RuleWithActions {
     RuleScript(const std::string &name,
         std::vector<Action *> *actions,
         Transformations *t,
-        std::unique_ptr<std::string> fileName,
+        const std::string &fileName,
         int lineNumber)
-            : RuleWithActions(actions, t, std::move(fileName), lineNumber),
+            : RuleWithActions(actions, t, fileName, lineNumber),
         m_name(name),
         m_lua() { }
 

--- a/src/rule_script.h
+++ b/src/rule_script.h
@@ -14,6 +14,9 @@
  *
  */
 
+#ifndef SRC_RULE_SCRIPT_H_
+#define SRC_RULE_SCRIPT_H_
+
 #include <string>
 #include <memory>
 #include <vector>
@@ -33,9 +36,6 @@
 #include "src/actions/severity.h"
 #include "src/variables/variable.h"
 
-#ifndef SRC_RULE_SCRIPT_H_
-#define SRC_RULE_SCRIPT_H_
-
 
 namespace modsecurity {
 
@@ -53,12 +53,14 @@ class RuleScript : public RuleWithActions {
         m_name(name),
         m_lua() { }
 
-    RuleScript(const RuleWithActions& r) = delete;
+    RuleScript(const RuleScript& r) = delete;
+
+    RuleScript &operator=(const RuleScript &r) = delete;
 
     bool init(std::string *err);
+
     bool evaluate(Transaction *trans,
         std::shared_ptr<RuleMessage> ruleMessage) override;
-
 
     std::string m_name;
     engine::Lua m_lua;

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -59,9 +59,9 @@ using actions::transformations::Transformation;
 RuleWithActions::RuleWithActions(
     Actions *actions,
     Transformations *transformations,
-    std::unique_ptr<std::string> fileName,
+    const std::string &fileName,
     int lineNumber)
-    : Rule(std::move(fileName), lineNumber),
+    : Rule(fileName, lineNumber),
     m_rev(""),
     m_ver(""),
     m_accuracy(0),

--- a/src/rule_with_actions.cc
+++ b/src/rule_with_actions.cc
@@ -179,7 +179,7 @@ RuleWithActions::~RuleWithActions() {
 
 
 bool RuleWithActions::evaluate(Transaction *transaction) {
-    return evaluate(transaction, std::make_shared<RuleMessage>(this, transaction));
+    return evaluate(transaction, std::make_shared<RuleMessage>(*this, *transaction));
 }
 
 
@@ -494,7 +494,7 @@ std::vector<actions::Action *> RuleWithActions::getActionsByName(const std::stri
 void RuleWithActions::performLogging(Transaction *trans,
     std::shared_ptr<RuleMessage> ruleMessage,
     bool lastLog,
-    bool chainedParentNull) {
+    bool chainedParentNull) const {
 
     /* last rule in the chain. */
     bool isItToBeLogged = ruleMessage->m_saveMessage;
@@ -551,7 +551,7 @@ void RuleWithActions::performLogging(Transaction *trans,
                 trans->serverLog(ruleMessage);
             }
 
-            RuleMessage *rm = new RuleMessage(this, trans);
+            RuleMessage *rm = new RuleMessage(*this, *trans);
             rm->m_saveMessage = ruleMessage->m_saveMessage;
             ruleMessage.reset(rm);
         }

--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -55,9 +55,9 @@ RuleWithOperator::RuleWithOperator(Operator *op,
     variables::Variables *_variables,
     std::vector<Action *> *actions,
     Transformations *transformations,
-    std::unique_ptr<std::string> fileName,
+    const std::string &fileName,
     int lineNumber)
-    : RuleWithActions(actions, transformations, std::move(fileName), lineNumber),
+    : RuleWithActions(actions, transformations, fileName, lineNumber),
     m_variables(_variables),
     m_operator(op) { /* */ }
 

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -104,12 +104,12 @@ namespace modsecurity {
  */
 Transaction::Transaction(ModSecurity *ms, RulesSet *rules, void *logCbData)
     : m_creationTimeStamp(utils::cpu_seconds()),
-     m_clientIpAddress(std::make_shared<std::string>("")),
+    m_clientIpAddress(""),
     m_httpVersion(""),
-    m_serverIpAddress(std::make_shared<std::string>("")),
-    m_requestHostName(std::make_shared<std::string>("")),
+    m_serverIpAddress(""),
+    m_requestHostName(""),
     m_uri(""),
-    m_uri_no_query_string_decoded(std::make_shared<std::string>("")),
+    m_uri_no_query_string_decoded(""),
     m_ARGScombinedSizeDouble(0),
     m_clientPort(0),
     m_highestSeverityAction(255),
@@ -166,9 +166,8 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, void *logCbData)
     m_variableTimeYear(""),
     m_logCbData(logCbData),
     TransactionAnchoredVariables(this) {
-    m_id = std::unique_ptr<std::string>( new std::string(
-        std::to_string(m_timeStamp)
-        + std::to_string(modsecurity::utils::generate_transaction_unique_id())));
+    m_id = std::to_string(m_timeStamp) +
+           std::to_string(modsecurity::utils::generate_transaction_unique_id());
 
     m_variableUrlEncodedError.set("0", 0);
     m_variableMscPcreError.set("0", 0);
@@ -181,12 +180,12 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, void *logCbData)
 
 Transaction::Transaction(ModSecurity *ms, RulesSet *rules, char *id, void *logCbData)
     : m_creationTimeStamp(utils::cpu_seconds()),
-    m_clientIpAddress(std::make_shared<std::string>("")),
+    m_clientIpAddress(""),
     m_httpVersion(""),
-    m_serverIpAddress(std::make_shared<std::string>("")),
-    m_requestHostName(std::make_shared<std::string>("")),
+    m_serverIpAddress(""),
+    m_requestHostName(""),
     m_uri(""),
-    m_uri_no_query_string_decoded(std::make_shared<std::string>("")),
+    m_uri_no_query_string_decoded(""),
     m_ARGScombinedSizeDouble(0),
     m_clientPort(0),
     m_highestSeverityAction(255),
@@ -207,7 +206,7 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, char *id, void *logCb
     m_rulesMessages(),
     m_requestBody(),
     m_responseBody(),
-    m_id(std::unique_ptr<std::string>(new std::string(id))),
+    m_id(id),
     m_skip_next(0),
     m_allowType(modsecurity::actions::disruptive::NoneAllowType),
     m_uri_decoded(""),
@@ -292,7 +291,7 @@ void Transaction::debug(int level, const std::string& message) const {
         return;
     }
 
-    m_rules->debug(level, *m_id.get(), m_uri, message);
+    m_rules->debug(level, m_id, m_uri, message);
 }
 #endif
 
@@ -319,19 +318,19 @@ void Transaction::debug(int level, const std::string& message) const {
  */
 int Transaction::processConnection(const char *client, int cPort,
     const char *server, int sPort) {
-    m_clientIpAddress = std::unique_ptr<std::string>(new std::string(client));
-    m_serverIpAddress = std::unique_ptr<std::string>(new std::string(server));
-    m_requestHostName = std::unique_ptr<std::string>(new std::string(server));
+    m_clientIpAddress = client;
+    m_serverIpAddress = server;
+    m_requestHostName = server;
     this->m_clientPort = cPort;
     this->m_serverPort = sPort;
     ms_dbg(4, "Transaction context created.");
     ms_dbg(4, "Starting phase CONNECTION. (SecRules 0)");
 
 
-    m_variableRemoteHost.set(*m_clientIpAddress.get(), m_variableOffset);
-    m_variableUniqueID.set(*m_id.get(), m_variableOffset);
-    m_variableRemoteAddr.set(*m_clientIpAddress.get(), m_variableOffset);
-    m_variableServerAddr.set(*m_serverIpAddress.get(), m_variableOffset);
+    m_variableRemoteHost.set(m_clientIpAddress, m_variableOffset);
+    m_variableUniqueID.set(m_id, m_variableOffset);
+    m_variableRemoteAddr.set(m_clientIpAddress, m_variableOffset);
+    m_variableServerAddr.set(m_serverIpAddress, m_variableOffset);
     m_variableServerPort.set(std::to_string(this->m_serverPort),
         m_variableOffset);
     m_variableRemotePort.set(std::to_string(this->m_clientPort),
@@ -467,9 +466,7 @@ int Transaction::processURI(const char *uri, const char *method,
     m_variableRequestProtocol.set("HTTP/" + std::string(http_version),
         m_variableOffset + requestLine.size() + 1);
 
-    m_uri_no_query_string_decoded = std::unique_ptr<std::string>(
-        new std::string(path_info));
-
+    m_uri_no_query_string_decoded = path_info;
 
     if (pos_raw_query != std::string::npos) {
         std::string qry = std::string(uri_s, pos_raw_query + 1,
@@ -1495,7 +1492,7 @@ std::string Transaction::toOldAuditLogFormatIndex(const std::string &filename,
     ss << utils::string::dash_if_empty(
        m_variableRequestHeaders.resolveFirst("Host").get())
         << " ";
-    ss << utils::string::dash_if_empty(this->m_clientIpAddress.get()) << " ";
+    ss << utils::string::dash_if_empty(&this->m_clientIpAddress) << " ";
     /** TODO: Check variable */
     variables::RemoteUser *r = new variables::RemoteUser("REMOTE_USER");
     std::vector<const VariableValue *> l;
@@ -1530,7 +1527,7 @@ std::string Transaction::toOldAuditLogFormatIndex(const std::string &filename,
     ss << utils::string::dash_if_empty(
         m_variableRequestHeaders.resolveFirst("User-Agent").get());
     ss << "\" ";
-    ss << *m_id.get() << " ";
+    ss << m_id << " ";
     /** TODO: Check variable */
     ss << utils::string::dash_if_empty(
         m_variableRequestHeaders.resolveFirst("REFERER").get()) << " ";
@@ -1556,10 +1553,10 @@ std::string Transaction::toOldAuditLogFormat(int parts,
 
     audit_log << "--" << trailer << "-" << "A--" << std::endl;
     audit_log << tstr;
-    audit_log << " " << m_id->c_str();
-    audit_log << " " << this->m_clientIpAddress->c_str();
+    audit_log << " " << m_id;
+    audit_log << " " << this->m_clientIpAddress;
     audit_log << " " << this->m_clientPort;
-    audit_log << " " << m_serverIpAddress->c_str();
+    audit_log << " " << m_serverIpAddress;
     audit_log << " " << this->m_serverPort;
     audit_log << std::endl;
 
@@ -1676,13 +1673,13 @@ std::string Transaction::toJSON(int parts) {
 
     yajl_gen_map_open(g);
     /* Part: A (header mandatory) */
-    LOGFY_ADD("client_ip", this->m_clientIpAddress->c_str());
+    LOGFY_ADD("client_ip", m_clientIpAddress.c_str());
     LOGFY_ADD("time_stamp", ts.c_str());
     LOGFY_ADD("server_id", uniqueId.c_str());
     LOGFY_ADD_NUM("client_port", m_clientPort);
-    LOGFY_ADD("host_ip", m_serverIpAddress->c_str());
+    LOGFY_ADD("host_ip", m_serverIpAddress.c_str());
     LOGFY_ADD_NUM("host_port", m_serverPort);
-    LOGFY_ADD("unique_id", m_id->c_str());
+    LOGFY_ADD("unique_id", m_id.c_str());
 
     /* request */
     yajl_gen_string(g, reinterpret_cast<const unsigned char*>("request"),
@@ -1797,13 +1794,13 @@ std::string Transaction::toJSON(int parts) {
             yajl_gen_map_open(g);
             LOGFY_ADD("match", a.m_match.c_str());
             LOGFY_ADD("reference", a.m_reference.c_str());
-            LOGFY_ADD("ruleId", std::to_string(a.m_ruleId).c_str());
-            LOGFY_ADD("file", a.m_ruleFile->c_str());
-            LOGFY_ADD("lineNumber", std::to_string(a.m_ruleLine).c_str());
+            LOGFY_ADD("ruleId", std::to_string(a.m_rule.m_ruleId).c_str());
+            LOGFY_ADD("file", a.m_rule.getFileName().c_str());
+            LOGFY_ADD("lineNumber", std::to_string(a.m_rule.getLineNumber()).c_str());
             LOGFY_ADD("data", a.m_data.c_str());
             LOGFY_ADD("severity", std::to_string(a.m_severity).c_str());
-            LOGFY_ADD("ver", a.m_ver.c_str());
-            LOGFY_ADD("rev", a.m_rev.c_str());
+            LOGFY_ADD("ver", a.m_rule.m_ver.c_str());
+            LOGFY_ADD("rev", a.m_rule.m_rev.c_str());
 
             yajl_gen_string(g,
                 reinterpret_cast<const unsigned char*>("tags"),
@@ -1816,8 +1813,8 @@ std::string Transaction::toJSON(int parts) {
             }
             yajl_gen_array_close(g);
 
-            LOGFY_ADD("maturity", std::to_string(a.m_maturity).c_str());
-            LOGFY_ADD("accuracy", std::to_string(a.m_accuracy).c_str());
+            LOGFY_ADD("maturity", std::to_string(a.m_rule.m_maturity).c_str());
+            LOGFY_ADD("accuracy", std::to_string(a.m_rule.m_accuracy).c_str());
             yajl_gen_map_close(g);
             yajl_gen_map_close(g);
         }
@@ -2384,7 +2381,7 @@ extern "C" int msc_update_status_code(Transaction *transaction, int status) {
 int Transaction::setRequestHostName(const std::string& hostname) {
 
     if (hostname != "") {
-        m_requestHostName = std::unique_ptr<std::string>(new std::string(hostname));
+        m_requestHostName = hostname;
     }
 
     return true;

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -379,7 +379,7 @@ class VariableMonkeyResolution {
 
     static std::string stringMatchResolve(Transaction *t,
         const std::string &variable) {
-        std::unique_ptr<std::string> vv = nullptr;
+        std::unique_ptr<std::string> vv;
         size_t collection = variable.find(".");
         if (collection == std::string::npos) {
             collection = variable.find(":");


### PR DESCRIPTION
## what

Several constructors, copy constructors & assignment operators in the codebase can be simplified or even removed because they're not used.

## why

Simplify the codebase making it easier to maintain.

NOTE: In the case of `RuleMessage`, it addresses one of the `FIXME` in the codebase, see [here](https://github.com/owasp-modsecurity/ModSecurity/blob/1a8c96a1cd5e58e00401ad392ab1344104afd283/headers/modsecurity/rule_message.h#L47)

## misc

This is part of a series of PRs to improve performance of the library (5/n). Previous: #3231