### PR TITLE
fix: compilation error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: autogen.sh
         run: ./autogen.sh
       - name: configure ${{ matrix.configure.label }}
-        run: ./configure --enable-assertions ${{ matrix.configure.opt }}
+        run: ./configure --enable-assertions ${{ matrix.configure.opt }} 'CFLAGS=-Werror=format-security'
       - uses: ammaraskar/gcc-problem-matcher@master
       - name: make
         run: make -j `nproc`

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -472,8 +472,8 @@ char *update_rule_target_ex(modsec_rec *msr, msre_ruleset *ruleset, msre_rule *r
 
 end:
     if (my_error_msg) {
-        if (msr) msr_log(msr, 9, my_error_msg);
-        else ap_log_error(APLOG_MARK, APLOG_INFO, 0, NULL, my_error_msg);
+        if (msr) msr_log(msr, 9, "%s", my_error_msg);
+        else ap_log_error(APLOG_MARK, APLOG_INFO, 0, NULL, "%s", my_error_msg);
     }
     if (target_list != NULL) free(target_list);
     if (replace != NULL) free(replace);


### PR DESCRIPTION
## what

* fix the compilation problem if `CFLAG -Werror=format-security` is presented.
* add this `CFLAG` to GH workflow

## why

Version 2.9.8 cannot be compiled with that flag.

## references

#3249