### PR TITLE
Leverage std::make_unique & std::make_shared to create objects in the heap

### DIFF
--- a/headers/modsecurity/actions/action.h
+++ b/headers/modsecurity/actions/action.h
@@ -105,11 +105,11 @@ class Action {
         }
 
         if (pos == std::string::npos) {
-            m_name = std::shared_ptr<std::string>(new std::string(data));
+            m_name = std::make_shared<std::string>(data);
             return;
         }
 
-        m_name = std::shared_ptr<std::string>(new std::string(data, 0, pos));
+        m_name = std::make_shared<std::string>(data, 0, pos);
         m_parser_payload = std::string(data, pos + 1, data.length());
 
         if (m_parser_payload.at(0) == '\'' && m_parser_payload.size() > 2) {

--- a/src/actions/expire_var.cc
+++ b/src/actions/expire_var.cc
@@ -65,23 +65,23 @@ bool ExpireVar::evaluate(RuleWithActions *rule, Transaction *t) {
 
     std::string collection = fully_qualified_var.substr(0, posDot);
     std::string variable_name = fully_qualified_var.substr(posDot+1);
-    std::unique_ptr<RunTimeString> runTimeString(new RunTimeString());
+    auto runTimeString = std::make_unique<RunTimeString>();
     runTimeString->appendText(fully_qualified_var);
 
     if (collection == "ip") {
-        std::unique_ptr<modsecurity::variables::Ip_DynamicElement> ip_dynamicElement(new modsecurity::variables::Ip_DynamicElement(std::move(runTimeString)));
+        auto ip_dynamicElement = std::make_unique<modsecurity::variables::Ip_DynamicElement>(std::move(runTimeString));
         ip_dynamicElement->setExpiry(t, variable_name, expirySeconds);
     } else if (collection == "global") {
-        std::unique_ptr<modsecurity::variables::Global_DynamicElement> global_dynamicElement(new modsecurity::variables::Global_DynamicElement(std::move(runTimeString)));
+        auto global_dynamicElement = std::make_unique<modsecurity::variables::Global_DynamicElement>(std::move(runTimeString));
         global_dynamicElement->setExpiry(t, variable_name, expirySeconds);
     } else if (collection == "resource") {
-        std::unique_ptr<modsecurity::variables::Resource_DynamicElement> resource_dynamicElement(new modsecurity::variables::Resource_DynamicElement(std::move(runTimeString)));
+        auto resource_dynamicElement = std::make_unique<modsecurity::variables::Resource_DynamicElement>(std::move(runTimeString));
         resource_dynamicElement->setExpiry(t, variable_name, expirySeconds);
     } else if (collection == "session") {
-        std::unique_ptr<modsecurity::variables::Session_DynamicElement> session_dynamicElement(new modsecurity::variables::Session_DynamicElement(std::move(runTimeString)));
+        auto session_dynamicElement = std::make_unique<modsecurity::variables::Session_DynamicElement>(std::move(runTimeString));
         session_dynamicElement->setExpiry(t, variable_name, expirySeconds);
     } else if (collection == "user") {
-        std::unique_ptr<modsecurity::variables::User_DynamicElement> user_dynamicElement(new modsecurity::variables::User_DynamicElement(std::move(runTimeString)));
+        auto user_dynamicElement = std::make_unique<modsecurity::variables::User_DynamicElement>(std::move(runTimeString));
         user_dynamicElement->setExpiry(t, variable_name, expirySeconds);
     } else {
         ms_dbg_a(t, 5, "Invalid collection found in expirevar expression: collection must be `ip', `global', `resource', `user' or `session'");

--- a/src/collection/backend/lmdb.cc
+++ b/src/collection/backend/lmdb.cc
@@ -178,7 +178,7 @@ std::unique_ptr<std::string> LMDB::resolveFirst(const std::string& var) {
 
     collectionData.setFromSerialized(reinterpret_cast<char *>(mdb_value_ret.mv_data), mdb_value_ret.mv_size);
     if ((!collectionData.isExpired()) && (collectionData.hasValue())) {
-        ret = std::unique_ptr<std::string>(new std::string(collectionData.getValue()));
+        ret = std::make_unique<std::string>(collectionData.getValue());
     }
 
 end_get:

--- a/src/operators/operator.cc
+++ b/src/operators/operator.cc
@@ -140,7 +140,7 @@ bool Operator::evaluate(Transaction *transaction, const std::string& a) {
 
 Operator *Operator::instantiate(const std::string& op, const std::string& param_str) {
     std::string op_ = utils::string::tolower(op);
-    std::unique_ptr<RunTimeString> param(new RunTimeString());
+    auto param = std::make_unique<RunTimeString>();
     param->appendText(param_str);
 
     IF_MATCH(beginswith) { return new BeginsWith(std::move(param)); }

--- a/src/run_time_string.cc
+++ b/src/run_time_string.cc
@@ -31,7 +31,7 @@ namespace modsecurity {
 
 
 void RunTimeString::appendText(const std::string &text) {
-    std::unique_ptr<RunTimeElementHolder> r(new RunTimeElementHolder);
+    auto r = std::make_unique<RunTimeElementHolder>();
     r->m_string = text;
     m_elements.push_back(std::move(r));
 }
@@ -39,7 +39,7 @@ void RunTimeString::appendText(const std::string &text) {
 
 void RunTimeString::appendVar(
     std::unique_ptr<modsecurity::variables::Variable> var) {
-    std::unique_ptr<RunTimeElementHolder> r(new RunTimeElementHolder);
+    auto r = std::make_unique<RunTimeElementHolder>();
     r->m_var = std::move(var);
     m_elements.push_back(std::move(r));
     m_containsMacro = true;


### PR DESCRIPTION
## what

Replace naked `new` calls to create object instances in the heap that are then used to create `std::unique_ptr` & `std::shared_ptr` instances.

## why

Simplifies code and follows C++ Core Guidelines, see [R.22: Use make_shared() to make shared_ptrs](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r22-use-make_shared-to-make-shared_ptrs) & [R.23: Use make_unique() to make unique_ptrs](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r23-use-make_unique-to-make-unique_ptrs)

Additionally, the use of `std::make_shared` allows for an optimization by which the shared pointer's control block and the object can be allocated in the same memory block, which increasees memory locality (and thus performance).