### PR TITLE
msr_global_mutex_lock: handle errors from apr_global_mutex_lock

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+(to be released) - 2.9.x 
+------------------------
+
+ * handle errors from apr_global_mutex_lock
+   [PR #3257 - @marcstern]
+
 03 Sep 2024 - 2.9.8
 -------------------
 

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -126,7 +126,7 @@ int acquire_global_lock(apr_global_mutex_t **lock, apr_pool_t *mp) {
     apr_status_t rc;
     apr_file_t *lock_name;
     const char *temp_dir;
-    const char *filename;
+    const char *filename = NULL;
 
     // get platform temp dir
     rc = apr_temp_dir_get(&temp_dir, mp);

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -166,6 +166,24 @@ int acquire_global_lock(apr_global_mutex_t **lock, apr_pool_t *mp) {
 #endif /* MSC_TEST */
     return APR_SUCCESS;
 }
+
+/**
+ * handle errors from apr_global_mutex_lock
+ */
+int msr_global_mutex_lock(modsec_rec* msr, apr_global_mutex_t* lock, const char* fct) {
+    assert(msr);
+    assert(msr->modsecurity); // lock is msr->modsecurity->..._lock
+    assert(msr->mp);
+    if (!lock) {
+        msr_log(msr, 1, "%s: Global mutex was not created", fct);
+        return -1;
+    }
+
+    int rc = apr_global_mutex_lock(msr->modsecurity->auditlog_lock);
+    if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s", get_apr_error(msr->mp, rc));
+    return rc;
+}
+
 /**
  * Initialise the modsecurity engine. This function must be invoked
  * after configuration processing is complete as Apache needs to know the

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -183,6 +183,22 @@ int msr_global_mutex_lock(modsec_rec* msr, apr_global_mutex_t* lock, const char*
     if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s", get_apr_error(msr->mp, rc));
     return rc;
 }
+/**
+ * handle errors from apr_global_mutex_unlock
+ */
+int msr_global_mutex_unlock(modsec_rec* msr, apr_global_mutex_t* lock, const char* fct) {
+    assert(msr);
+    assert(msr->modsecurity); // lock is msr->modsecurity->..._lock
+    assert(msr->mp);
+    if (!lock) {
+        msr_log(msr, 1, "%s: Global mutex was not created", fct);
+        return -1;
+    }
+
+    int rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
+    if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s", get_apr_error(msr->mp, rc));
+    return rc;
+}
 
 /**
  * Initialise the modsecurity engine. This function must be invoked

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -196,7 +196,7 @@ int msr_global_mutex_unlock(modsec_rec* msr, apr_global_mutex_t* lock, const cha
     }
 
     int rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
-    // We should have get the warning at lock time, so ignore it here
+    // We should have been warnend during lock acquisition already, so don't log the same warning here
     // if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s", get_apr_error(msr->mp, rc));
     return rc;
 }

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -179,7 +179,7 @@ int msr_global_mutex_lock(modsec_rec* msr, apr_global_mutex_t* lock, const char*
         return -1;
     }
 
-    int rc = apr_global_mutex_lock(msr->modsecurity->auditlog_lock);
+    int rc = apr_global_mutex_lock(lock);
     if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s", get_apr_error(msr->mp, rc));
     return rc;
 }
@@ -195,7 +195,7 @@ int msr_global_mutex_unlock(modsec_rec* msr, apr_global_mutex_t* lock, const cha
         return -1;
     }
 
-    int rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
+    int rc = apr_global_mutex_unlock(lock);
     // We should have get the warning at lock time, so ignore it here
     // if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s", get_apr_error(msr->mp, rc));
     return rc;

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -175,7 +175,7 @@ int msr_global_mutex_lock(modsec_rec* msr, apr_global_mutex_t* lock, const char*
     assert(msr->modsecurity); // lock is msr->modsecurity->..._lock
     assert(msr->mp);
     if (!lock) {
-        msr_log(msr, 1, "%s: Global mutex was not created", fct);
+        msr_log(msr, 1, "%s: Global mutex not initialised", fct);
         return -1;
     }
 

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -196,7 +196,8 @@ int msr_global_mutex_unlock(modsec_rec* msr, apr_global_mutex_t* lock, const cha
     }
 
     int rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
-    if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s", get_apr_error(msr->mp, rc));
+    // We should have get the warning at lock time, so ignore it here
+    // if (rc != APR_SUCCESS) msr_log(msr, 1, "Audit log: Failed to unlock global mutex: %s", get_apr_error(msr->mp, rc));
     return rc;
 }
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -708,6 +708,7 @@ struct msc_parm {
 /* Reusable functions */
 int acquire_global_lock(apr_global_mutex_t **lock, apr_pool_t *mp);
 int msr_global_mutex_lock(modsec_rec* msr, apr_global_mutex_t* lock, const char* fct);
+int msr_global_mutex_unlock(modsec_rec* msr, apr_global_mutex_t* lock, const char* fct);
 
 /* Engine functions */
 

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -707,6 +707,7 @@ struct msc_parm {
 
 /* Reusable functions */
 int acquire_global_lock(apr_global_mutex_t **lock, apr_pool_t *mp);
+int msr_global_mutex_lock(modsec_rec* msr, apr_global_mutex_t* lock, const char* fct);
 
 /* Engine functions */
 

--- a/apache2/msc_geo.c
+++ b/apache2/msc_geo.c
@@ -357,13 +357,7 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
     if (rec_val == geo->ctry_offset) {
         *error_msg = apr_psprintf(msr->mp, "No geo data for \"%s\").", log_escape(msr->mp, target));
         msr_log(msr, 4, "%s", *error_msg);
-
-        ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-        if (ret != APR_SUCCESS) {
-            msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
-                    get_apr_error(msr->mp, ret));
-        }
-
+        msr_global_mutex_unlock(msr, msr->modsecurity->geo_lock, "Geo Lookup");
         return 0;
     }
 
@@ -373,13 +367,7 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
         if ((country <= 0) || (country > GEO_COUNTRY_LAST)) {
             *error_msg = apr_psprintf(msr->mp, "No geo data for \"%s\" (country %d).", log_escape(msr->mp, target), country);
             msr_log(msr, 4, "%s", *error_msg);
-
-            ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-            if (ret != APR_SUCCESS) {
-                msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
-                        get_apr_error(msr->mp, ret));
-            }
-
+            msr_global_mutex_unlock(msr, msr->modsecurity->geo_lock, "Geo Lookup");
             return 0;
         }
 
@@ -404,13 +392,7 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
         if ((country <= 0) || (country > GEO_COUNTRY_LAST)) {
             *error_msg = apr_psprintf(msr->mp, "No geo data for \"%s\" (country %d).", log_escape(msr->mp, target), country);
             msr_log(msr, 4, "%s", *error_msg);
-
-            ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-            if (ret != APR_SUCCESS) {
-                msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
-                        get_apr_error(msr->mp, ret));
-            }
-
+            msr_global_mutex_unlock(msr, msr->modsecurity->geo_lock, "Geo Lookup");
             return 0;
         }
         if (msr->txcfg->debuglog_level >= 9) {
@@ -499,13 +481,7 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
     }
 
     *error_msg = apr_psprintf(msr->mp, "Geo lookup for \"%s\" succeeded.", log_escape(msr->mp, target));
-
-    ret = apr_global_mutex_unlock(msr->modsecurity->geo_lock);
-    if (ret != APR_SUCCESS) {
-        msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
-                get_apr_error(msr->mp, ret));
-    }
-
+    msr_global_mutex_unlock(msr, msr->modsecurity->geo_lock, "Geo Lookup");
     return 1;
 }
 

--- a/apache2/msc_geo.c
+++ b/apache2/msc_geo.c
@@ -325,11 +325,7 @@ int geo_lookup(modsec_rec *msr, geo_rec *georec, const char *target, char **erro
         msr_log(msr, 9, "GEO: Using address \"%s\" (0x%08lx). %lu", targetip, ipnum, ipnum);
     }
 
-    ret = apr_global_mutex_lock(msr->modsecurity->geo_lock);
-    if (ret != APR_SUCCESS) {
-        msr_log(msr, 1, "Geo Lookup: Failed to lock proc mutex: %s",
-                get_apr_error(msr->mp, ret));
-    }
+    msr_global_mutex_lock(msr, msr->modsecurity->geo_lock, "Geo lookup");
 
     for (level = 31; level >= 0; level--) {
         /* Read the record */

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -1465,7 +1465,7 @@ void sec_audit_logger_json(modsec_rec *msr) {
      */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
         /* Unlock the mutex we used to serialise access to the audit log file. */
-        msr_global_mutex_lock(msr, msr->modsecurity->auditlog_lock, "Audit log");
+        msr_global_mutex_unlock(msr, msr->modsecurity->auditlog_lock, "Audit log");
         return;
     }
 
@@ -2236,7 +2236,7 @@ void sec_audit_logger_native(modsec_rec *msr) {
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
         sec_auditlog_write(msr, "\n", 1);
         /* Unlock the mutex we used to serialise access to the audit log file. */
-        msr_global_mutex_lock(msr, msr->modsecurity->auditlog_lock, "Audit log");
+        msr_global_mutex_unlock(msr, msr->modsecurity->auditlog_lock, "Audit log");
         return;
     }
 

--- a/apache2/msc_logging.c
+++ b/apache2/msc_logging.c
@@ -757,14 +757,7 @@ void sec_audit_logger_json(modsec_rec *msr) {
 
     /* Lock the mutex, but only if we are using serial format. */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-        if (!msr->modsecurity->auditlog_lock) msr_log(msr, 1, "Audit log: Global mutex was not created");
-        else {
-            rc = apr_global_mutex_lock(msr->modsecurity->auditlog_lock);
-            if (rc != APR_SUCCESS) {
-                msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s",
-                    get_apr_error(msr->mp, rc));
-            }
-        }
+        msr_global_mutex_lock(msr, msr->modsecurity->auditlog_lock, "Audit log");
     }
 
     /**
@@ -1471,15 +1464,8 @@ void sec_audit_logger_json(modsec_rec *msr) {
      * as it does not need an index file.
      */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-
         /* Unlock the mutex we used to serialise access to the audit log file. */
-        rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to unlock global mutex '%s': %s",
-                    apr_global_mutex_lockfile(msr->modsecurity->auditlog_lock),
-                    get_apr_error(msr->mp, rc));
-        }
-
+        msr_global_mutex_lock(msr, msr->modsecurity->auditlog_lock, "Audit log");
         return;
     }
 
@@ -1650,11 +1636,7 @@ void sec_audit_logger_native(modsec_rec *msr) {
 
     /* Lock the mutex, but only if we are using serial format. */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
-        rc = apr_global_mutex_lock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to lock global mutex: %s",
-                get_apr_error(msr->mp, rc));
-        }
+        msr_global_mutex_lock(msr, msr->modsecurity->auditlog_lock, "Audit log");
     }
 
 
@@ -2253,15 +2235,8 @@ void sec_audit_logger_native(modsec_rec *msr) {
      */
     if (msr->txcfg->auditlog_type != AUDITLOG_CONCURRENT) {
         sec_auditlog_write(msr, "\n", 1);
-
         /* Unlock the mutex we used to serialise access to the audit log file. */
-        rc = apr_global_mutex_unlock(msr->modsecurity->auditlog_lock);
-        if (rc != APR_SUCCESS) {
-            msr_log(msr, 1, "Audit log: Failed to unlock global mutex '%s': %s",
-                    apr_global_mutex_lockfile(msr->modsecurity->auditlog_lock),
-                    get_apr_error(msr->mp, rc));
-        }
-
+        msr_global_mutex_lock(msr, msr->modsecurity->auditlog_lock, "Audit log");
         return;
     }
 

--- a/apache2/persist_dbm.c
+++ b/apache2/persist_dbm.c
@@ -133,7 +133,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
         if (rc != APR_SUCCESS) {
             dbm = NULL;
 #ifdef GLOBAL_COLLECTION_LOCK
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+            msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_retrieve_ex");
 #endif
             goto cleanup;
         }
@@ -169,7 +169,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
     if (existing_dbm == NULL) {
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_retrieve_ex");
 #endif
         dbm = NULL;
     }
@@ -228,7 +228,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
                     log_escape(msr->mp, dbm_filename), get_apr_error(msr->mp, rc));
                 dbm = NULL;
 #ifdef GLOBAL_COLLECTION_LOCK
-                apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+                msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_retrieve_ex");
 #endif
                 goto cleanup;
             }
@@ -253,7 +253,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
         if (existing_dbm == NULL) {
             apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+            msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_retrieve_ex");
 #endif
             dbm = NULL;
         }
@@ -318,7 +318,7 @@ static apr_table_t *collection_retrieve_ex(apr_sdbm_t *existing_dbm, modsec_rec 
 
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_retrieve_ex");
 #endif
     }
 
@@ -329,7 +329,7 @@ cleanup:
     if ((existing_dbm == NULL) && dbm) {
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_retrieve_ex");
 #endif
     }
 
@@ -461,7 +461,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
         CREATEMODE, msr->mp);
     if (rc != APR_SUCCESS) {
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_store");
 #endif
         msr_log(msr, 1, "collection_store: Failed to access DBM file \"%s\": %s", log_escape(msr->mp, dbm_filename),
             get_apr_error(msr->mp, rc));
@@ -544,7 +544,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
         if (dbm != NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
             apr_sdbm_close(dbm);
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+            msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_store");
 #else
             apr_sdbm_unlock(dbm);
             apr_sdbm_close(dbm);
@@ -607,7 +607,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
         if (dbm != NULL) {
 #ifdef GLOBAL_COLLECTION_LOCK
             apr_sdbm_close(dbm);
-            apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+            msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_store");
 #else
             apr_sdbm_unlock(dbm);
             apr_sdbm_close(dbm);
@@ -619,7 +619,7 @@ int collection_store(modsec_rec *msr, apr_table_t *col) {
 
 #ifdef GLOBAL_COLLECTION_LOCK
     apr_sdbm_close(dbm);
-    apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+    msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collection_store");
 #else
     apr_sdbm_unlock(dbm);
     apr_sdbm_close(dbm);
@@ -680,7 +680,7 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
             CREATEMODE, msr->mp);
     if (rc != APR_SUCCESS) {
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collections_remove_stale");
 #endif
         msr_log(msr, 1, "collections_remove_stale: Failed to access DBM file \"%s\": %s", log_escape(msr->mp, dbm_filename),
                 get_apr_error(msr->mp, rc));
@@ -783,7 +783,7 @@ int collections_remove_stale(modsec_rec *msr, const char *col_name) {
 
     apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-    apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+    msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collections_remove_stale");
 #endif
     return 1;
 
@@ -792,7 +792,7 @@ error:
     if (dbm) {
         apr_sdbm_close(dbm);
 #ifdef GLOBAL_COLLECTION_LOCK
-        apr_global_mutex_unlock(msr->modsecurity->dbm_lock);
+        msr_global_mutex_unlock(msr, msr->modsecurity->dbm_lock, "collections_remove_stale");
 #endif
     }
 


### PR DESCRIPTION
`apr_global_mutex_lock` is sometimes called with a lock that wasn't created (for any reason).
In this case, the pointer is null and `apr_global_mutex_lock` dereferences a null pointer, leading to a crash.
This PR creates a wrapper around `apr_global_mutex_lock` to handle checking that and correct logging.
Same for `msr_global_mutex_unlock`.