### PR TITLE
Missing #include <time.h>

### DIFF
--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -12,6 +12,7 @@
 * directly using the email address security@modsecurity.org.
 */
 
+#include <time.h>
 #include "http_core.h"
 
 #include "modsecurity.h"


### PR DESCRIPTION
"struct tm" defined in time.h is used in re_variables.c.
time.h is not explicitely included, but is included via apr/apr-util.
In latest version of apr/apr-util, the inclusion is no more present, leading to a compilation failure.
This PR just adds the missing include.