### PR TITLE
Move id_log() to msc_util to fix unit tests; it is declared on msc_ut…

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -30,16 +30,6 @@
     APLOG_USE_MODULE(security2);
 #endif
 
-// Returns the rule id if existing, otherwise the file name & line number
-const char* id_log(msre_rule* rule) {
-    assert(rule != NULL);
-    assert(rule->actionset != NULL);
-    assert(rule->ruleset != NULL);
-    const char* id = rule->actionset->id;
-    if (!id || id == NOT_SET_P || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
-	return id;
-}
-
 /* -- Directory context creation and initialisation -- */
 
 /**

--- a/apache2/msc_util.c
+++ b/apache2/msc_util.c
@@ -2849,3 +2849,13 @@ char* get_username(apr_pool_t* mp) {
     if (rc != APR_SUCCESS) return "apache";
     return username;
 }
+
+// Returns the rule id if existing, otherwise the file name & line number
+const char* id_log(msre_rule* rule) {
+    assert(rule != NULL);
+    assert(rule->actionset != NULL);
+    assert(rule->ruleset != NULL);
+    const char* id = rule->actionset->id;
+    if (!id || id == NOT_SET_P || !*id) id = apr_psprintf(rule->ruleset->mp, "%s (%d)", rule->filename, rule->line_num);
+        return id;
+}


### PR DESCRIPTION
The previous move of id_log() from re.c to apache2_config.c broke running the unit tests. The binary msc_test does not have apache2_config.c as a dependency in tests/Makefile so when linking you get an undefined symbol. And if you add apache2_config.c to the msc_test dependencies, even more undefined symbols now needed by apache2_config.c show up.

Since id_log() is already declared in msc_util.h, it seems right to move it to msc_util.c. And indeed this fixes the problem.