### PR TITLE
Fix apr_global_mutex_create() usage

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,9 @@
 (to be released) - 2.9.x 
 ------------------------
 
- * handle errors from apr_global_mutex_lock
+ * Fixed apr_global_mutex_create() usage (no filename)
+   [PR #3269 - @marcstern]
+* handle errors from apr_global_mutex_lock
    [PR #3257 - @marcstern]
 
 03 Sep 2024 - 2.9.8

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -123,30 +123,7 @@ msc_engine *modsecurity_create(apr_pool_t *mp, int processing_mode) {
 }
 
 int acquire_global_lock(apr_global_mutex_t **lock, apr_pool_t *mp) {
-    apr_status_t rc;
-    apr_file_t *lock_name;
-    const char *temp_dir;
-    const char *filename = NULL;
-
-    // get platform temp dir
-    rc = apr_temp_dir_get(&temp_dir, mp);
-    if (rc != APR_SUCCESS) {
-        ap_log_perror(APLOG_MARK, APLOG_ERR, 0, mp, "ModSecurity: Could not get temp dir");
-        return -1;
-    }
-
-    // use temp path template for lock files
-    char *path = apr_pstrcat(mp, temp_dir, GLOBAL_LOCK_TEMPLATE, NULL);
-
-    rc = apr_file_mktemp(&lock_name, path, 0, mp);
-    if (rc != APR_SUCCESS) {
-        ap_log_perror(APLOG_MARK, APLOG_ERR, 0, mp, " ModSecurity: Could not create temporary file for global lock");
-        return -1;
-    }
-    // below func always return APR_SUCCESS
-    apr_file_name_get(&filename, lock_name);
-
-    rc = apr_global_mutex_create(lock, filename, APR_LOCK_DEFAULT, mp);
+    apr_status_t rc = apr_global_mutex_create(lock, NULL, APR_LOCK_DEFAULT, mp);
     if (rc != APR_SUCCESS) {
         ap_log_perror(APLOG_MARK, APLOG_ERR, 0, mp, " ModSecurity: Could not create global mutex");
         return -1;

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -135,8 +135,6 @@ typedef struct msc_parm msc_parm;
 
 #define FATAL_ERROR "ModSecurity: Fatal error (memory allocation or unexpected internal error)!"
 
-#define GLOBAL_LOCK_TEMPLATE "/modsec-lock-tmp.XXXXXX"
-
 extern DSOLOCAL char *new_server_signature;
 extern DSOLOCAL char *real_server_signature;
 extern DSOLOCAL char *chroot_dir;


### PR DESCRIPTION
Fix for #3255
We don't have to generate a temp name ourselves, it'll be done in apr_global_mutex_create(). We don't have to provide a filename, apr_global_mutex_create() generates one automatically. Moreover, under Unix & Windows, the preferred mechanism won't use a file at all. apr_file_mktemp() cannot be used as it creates the file (at least on FreeBSD). Discussion in Apache mailing list: https://lists.apache.org/thread/ykb26kg4lgcqnldvxwd9p6hv16fy4z9l
