### PR TITLE
Fixed PCRE2 error message

### DIFF
--- a/apache2/msc_pcre.c
+++ b/apache2/msc_pcre.c
@@ -77,6 +77,10 @@ void *msc_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
         if (_erroffset != NULL) {
             *_erroffset = (int)error_offset;
         }
+        PCRE2_UCHAR buffer[256];
+        // Get the error message from the error code
+        pcre2_get_error_message(error_number, buffer, sizeof(buffer));
+        *_errptr = apr_pstrdup(pool, buffer);
         return NULL;
     }
 

--- a/apache2/msc_pcre.c
+++ b/apache2/msc_pcre.c
@@ -80,7 +80,11 @@ void *msc_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
         PCRE2_UCHAR buffer[256];
         // Get the error message from the error code
         pcre2_get_error_message(error_number, buffer, sizeof(buffer));
-        *_errptr = apr_pstrdup(pool, buffer);
+#ifdef DEBUG_CONF
+        * _errptr = apr_psprintf(pool, "%s - pattern = %s", buffer, pattern);
+#else
+        * _errptr = apr_pstrdup(pool, buffer);
+#endif
         return NULL;
     }
 


### PR DESCRIPTION
In case an error occurs in PCRE2 compilation, the error message is not displayed.
Example: "Error creating rule: Error compiling pattern (offset 6): "

With the fix, the PCRE2 error message is retrieved:
Example: "Error creating rule: Error compiling pattern (offset 6): length of lookbehind assertion is not limited"

The code was mimicing PCRE behaviour; PCRE2 error message handling changed.