### PR TITLE
Fix modsecurity-regression-test-secremoterules.txt URL in example

### DIFF
--- a/examples/simple_example_using_c/test.c
+++ b/examples/simple_example_using_c/test.c
@@ -47,7 +47,7 @@ int main (int argc, char **argv)
     msc_rules_dump(rules);
 
     ret = msc_rules_add_remote(rules, "test",
-        "https://www.modsecurity.org/modsecurity-regression-test-secremoterules.txt",
+        "https://raw.githubusercontent.com/owasp-modsecurity/ModSecurity/refs/heads/v3/master/test/modsecurity-regression-rules.txt",
         &error);
     if (ret < 0) {
         fprintf(stderr, "Problems loading the rules --\n");

--- a/test/test-cases/regression/config-secremoterules.json
+++ b/test/test-cases/regression/config-secremoterules.json
@@ -36,7 +36,7 @@
     },
     "rules":[
       "SecRuleEngine On",
-      "SecRemoteRules key https://gist.githubusercontent.com/martinhsv/20705a36b7cfa8ff6d0dee0d4efce7e7/raw/faa96c7838b1fe972c1f0881efacbb440f9a4a5e/modsecurity-regression-rules.txt",
+      "SecRemoteRules key https://raw.githubusercontent.com/owasp-modsecurity/ModSecurity/refs/heads/v3/master/test/modsecurity-regression-rules.txt",
       "SecRule ARGS \"@contains somethingelse\" \"id:9,pass,t:trim\""
     ]
   },

--- a/test/test-cases/regression/operator-ipMatchFromFile.json
+++ b/test/test-cases/regression/operator-ipMatchFromFile.json
@@ -129,7 +129,7 @@
     },
     "rules":[
       "SecRuleEngine On",
-      "SecRule REMOTE_ADDR \"@ipMatchFromFile https://gist.githubusercontent.com/martinhsv/20705a36b7cfa8ff6d0dee0d4efce7e7/raw/b9321f190eb0e81b98cb65a56db3d7e0a4f59314/modsecurity-regression-ip-list.txt\" \"id:1,phase:3,pass,t:trim\""
+      "SecRule REMOTE_ADDR \"@ipMatchFromFile https://raw.githubusercontent.com/owasp-modsecurity/ModSecurity/refs/heads/v3/master/test/modsecurity-regression-ip-list.txt\" \"id:1,phase:3,pass,t:trim\""
     ]
   }
 ]


### PR DESCRIPTION
## what

- Fix modsecurity-regression-test-secremoterules.txt URL in example

## why

- The old link https://www.modsecurity.org/modsecurity-regression-test-secremoterules.txt returns 404 Not Found error.

## references

- The URL is changed to the same one in https://github.com/owasp-modsecurity/ModSecurity/commit/62ec4edc4258971deec677b4f5e6bda188d27f26
