### PR TITLE
Fix m_requestHostName variable behavior

### DIFF
--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -227,7 +227,9 @@ int Transaction::processConnection(const char *client, int cPort,
     const char *server, int sPort) {
     m_clientIpAddress = client;
     m_serverIpAddress = server;
-    m_requestHostName = server;
+    if (m_requestHostName.empty() == true) {
+        m_requestHostName = server;
+    }
     this->m_clientPort = cPort;
     this->m_serverPort = sPort;
     ms_dbg(4, "Transaction context created.");

--- a/test/regression/regression.cc
+++ b/test/regression/regression.cc
@@ -268,14 +268,14 @@ void perform_unit_test(ModSecurityTest<RegressionTest> *test,
 
         auto modsec_transaction = context.create_transaction();
 
+        if (t->hostname != "") {
+            modsec_transaction.setRequestHostName(t->hostname);
+        }
+
         clearAuditLog(modsec_transaction.m_rules->m_auditLog->m_path1);
 
         modsec_transaction.processConnection(t->clientIp.c_str(),
             t->clientPort, t->serverIp.c_str(), t->serverPort);
-
-        if (t->hostname != "") {
-            modsec_transaction.setRequestHostName(t->hostname);
-        }
 
         actions(&r, &modsec_transaction, &context.m_server_log);
 


### PR DESCRIPTION
## what

This PR fixes the wrong behavior of `m_requestHostName` transaction variable.

## why

Previously, this variable was set when the `setRequestHostName()` was called, but previously it was initialized in `processConnection()`. So the last function overwritten the variable, and the previously set value disappeared.

If the connector calls if after `processConnection()`, then the `host` field in log entries which generated during `processConnection()` phase does not contain the necessary value.

The solution was to add a condition which sets the `m_requestHostName` only if it's empty. Also the correct call to the function `setRequestHostName()` can be seen in the `regression.cc`.

This modification does not modify the API.