### PR TITLE
Fix: Add false positive cppcheck-suppress for compatibility with upda…

### DIFF
--- a/src/utils/system.cc
+++ b/src/utils/system.cc
@@ -210,7 +210,7 @@ bool isFile(const std::string& f) {
         return false;
     }
     fstat(fileno(fp), &fileInfo);
-    if (!S_ISREG(fileInfo.st_mode)) {
+    if (!S_ISREG(fileInfo.st_mode)) { // cppcheck-suppress syntaxError ; false positive
         fclose(fp);
         return false;
     }


### PR DESCRIPTION
…ted cppcheck version

## what

- Added a cppcheck-suppress directive to handle a false positive detected by cppcheck 2.16.

## why

- This change addresses an issue caused by the recent Homebrew update on macOS CI runner, which upgraded cppcheck from version 2.15 to 2.16.

## references

        172/201 files checked 86% done
        Checking src/utils/system.cc ...
        Defines:MS_CPPCHECK_DISABLED_FOR_PARSER=1
        Undefines: MBEDTLS_MD5_ALT; MBEDTLS_SHA1_ALT; YYSTYPE; YY_USER_INIT
        Includes: -Iheaders/ -I./ -Iothers/ -Isrc/ -Iothers/mbedtls/include/
        Platform:native
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1...
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1;NO_LOGS...
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1;S_IFMT;S_IFREG;S_ISREG...        
        warning: src/utils/system.cc,213,error,syntaxError,syntax error                              <<<
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1;WIN32...
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1;_MSC_VER...
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1;__GNUC__...
        Checking src/utils/system.cc: MS_CPPCHECK_DISABLED_FOR_PARSER=1;__OpenBSD__...
        173/201 files checked 87% done

[warning: src/utils/system.cc,213,error,syntaxError,syntax error](https://github.com/gberkes/ModSecurity/actions/runs/11979912803/job/33403077795#step:5:4039)