### PR TITLE
fix: build library on OSX without GeoIP brew package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
       - name: Build GeoIP
         run: |
-          git clone --depth 0 https://github.com/maxmind/geoip-api-c.git
+          git clone --depth 1 https://github.com/maxmind/geoip-api-c.git
           cd geoip-api-c
           autoreconf --install
           ./configure --disable-dependency-tracking --disable-silent-rules --prefix=/opt/homebrew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
       - name: Build GeoIP
         run: |
-          git clone https://github.com/maxmind/geoip-api-c.git
+          git clone --depth 0 https://github.com/maxmind/geoip-api-c.git
           cd geoip-api-c
           autoreconf --install
           ./configure --disable-dependency-tracking --disable-silent-rules --prefix=/opt/homebrew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,10 +113,10 @@ jobs:
       - name: Build GeoIP
         run: |
           git clone --depth 1 --no-checkout https://github.com/maxmind/geoip-api-c.git
+          cd geoip-api-c
           git fetch --tags
           # Check out the last release, v1.6.12
           git checkout 4b526e7331ca1d692b74a0509ddcc725622ed31a
-          cd geoip-api-c
           autoreconf --install
           ./configure --disable-dependency-tracking --disable-silent-rules --prefix=/opt/homebrew
           make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,6 @@ jobs:
                        lua \
                        libmaxminddb \
                        libxml2 \
-                       geoip \
                        ssdeep \
                        pcre \
                        bison \
@@ -111,6 +110,13 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Build GeoIP
+        run: |
+          git clone https://github.com/maxmind/geoip-api-c.git
+          cd geoip-api-c
+          autoreconf --install
+          ./configure --disable-dependency-tracking --disable-silent-rules --prefix=/opt/homebrew
+          make install
       - name: build.sh
         run: ./build.sh
       - name: configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,10 @@ jobs:
           fetch-depth: 0
       - name: Build GeoIP
         run: |
-          git clone --depth 1 https://github.com/maxmind/geoip-api-c.git
+          git clone --depth 1 --no-checkout https://github.com/maxmind/geoip-api-c.git
+          git fetch --tags
+          # Check out the last release, v1.6.12
+          git checkout 4b526e7331ca1d692b74a0509ddcc725622ed31a
           cd geoip-api-c
           autoreconf --install
           ./configure --disable-dependency-tracking --disable-silent-rules --prefix=/opt/homebrew


### PR DESCRIPTION
## what

Build GeoIP library on OSX from source in GH workflow.

## why

On OSX the GeoIP package is obsolete and could fetch through brew, therefore the GH workflow on OSX was unsuccessful, see [this](https://github.com/owasp-modsecurity/ModSecurity/actions/runs/12270940148/job/34610196548?pr=3314#step:2:45).

