### PR TITLE
Fix for issue #3334: build not finding YAJL

### DIFF
--- a/build/yajl.m4
+++ b/build/yajl.m4
@@ -62,7 +62,7 @@ else
                 YAJL_DISPLAY="${YAJL_LDADD}, ${YAJL_CFLAGS}"
             else
                 # If pkg-config did not find anything useful, go over file lookup.
-                for x in ${YAJL_POSSIBLE_LIB_NAMES}; do
+                for x in ${YAJL_POSSIBLE_PATHS}; do
                     CHECK_FOR_YAJL_AT(${x})
                     if test -n "${YAJL_VERSION}"; then
                         break


### PR DESCRIPTION
When searching for YAJL during ./configure, pkg-config is checked first, and then a list of directories is searched if pkg-config bears no fruit. The previous version of yajl.m4 was looping over YAJL_POSSIBLE_LIB_NAMES instead of YAJL_POSSIBLE_PATHS and passing the lib name to the CHECK_FOR_YAJL_AT() function instead of the path. The would lead to YAJL never being found if pkg-config could not find it.

<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

- if pkg-config cannot locate libyajl it will not be located via path search, as the loop is passing lib names as path instead of possible paths.
- change fixes loop definition to loop over paths instead of lib names.

## why

- so that libyajl may still be located if pkg-config fails

## references

https://github.com/owasp-modsecurity/ModSecurity/issues/3334
