### PR TITLE
fix: Added missing header to avoid build error with gcc-15

### DIFF
--- a/headers/modsecurity/rules_set.h
+++ b/headers/modsecurity/rules_set.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <cstdint>
 #endif
 
 


### PR DESCRIPTION
## what

Added `cstdint` header to `headers/modsecurity/rules_set.h`

## why

There was (is) an FTBFS error in Debian.

## references

Debian [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1097409) report.
