### PR TITLE
fix: align code to fix cppcheck errors

### DIFF
--- a/examples/multiprocess_c/multi.c
+++ b/examples/multiprocess_c/multi.c
@@ -38,7 +38,7 @@ RulesSet *rules = NULL;
 ModSecurity *modsec = NULL;
 
 
-void process_special_request (int j) {
+static void process_special_request (int j) {
     Transaction *transaction;
     transaction = msc_new_transaction(modsec, rules, NULL);
 
@@ -60,7 +60,7 @@ void process_special_request (int j) {
     msc_transaction_cleanup(transaction);
 }
 
-void process_request (int j) {
+static void process_request (int j) {
     int i;
     
     for (i = 0; i < REQUESTS_PER_PROCESS; i++) {

--- a/headers/modsecurity/rules_exceptions.h
+++ b/headers/modsecurity/rules_exceptions.h
@@ -53,8 +53,8 @@ class RulesExceptions {
     bool contains(int a);
     bool merge(RulesExceptions *from);
 
-    bool loadRemoveRuleByMsg(const std::string &msg, std::string *error);
-    bool loadRemoveRuleByTag(const std::string &msg, std::string *error);
+    bool loadRemoveRuleByMsg(const std::string &msg, const std::string *error);
+    bool loadRemoveRuleByTag(const std::string &msg, const std::string *error);
 
     bool loadUpdateTargetByMsg(const std::string &msg,
         std::unique_ptr<std::vector<std::unique_ptr<variables::Variable> > > v,

--- a/src/actions/transformations/utf8_to_unicode.cc
+++ b/src/actions/transformations/utf8_to_unicode.cc
@@ -46,7 +46,7 @@ static inline bool encode(std::string &value) {
         int unicode_len = 0;
         unsigned int d = 0;
         unsigned char c;
-        auto utf = &input[i];
+        const auto* utf = &input[i];
 
         c = *utf;
 

--- a/src/operators/fuzzy_hash.cc
+++ b/src/operators/fuzzy_hash.cc
@@ -82,11 +82,6 @@ bool FuzzyHash::init(const std::string &param2, std::string *error) {
 #endif
 }
 
-FuzzyHash::~FuzzyHash() {
-
-}
-
-
 bool FuzzyHash::evaluate(Transaction *t, const std::string &str) {
 #ifdef WITH_SSDEEP
     char result[FUZZY_MAX_RESULT];

--- a/src/operators/fuzzy_hash.h
+++ b/src/operators/fuzzy_hash.h
@@ -42,7 +42,7 @@ class FuzzyHash : public Operator {
         : Operator("FuzzyHash", std::move(param)),
         m_threshold(0),
         m_head(NULL) { }
-    ~FuzzyHash() override;
+    ~FuzzyHash() override = default;
 
     bool evaluate(Transaction *transaction, const std::string &std) override;
 

--- a/src/operators/fuzzy_hash.h
+++ b/src/operators/fuzzy_hash.h
@@ -31,8 +31,8 @@ namespace operators {
 
 
 struct fuzzy_hash_chunk {
-    char *data;
-    struct fuzzy_hash_chunk *next;
+    std::shared_ptr<char> data;
+    std::shared_ptr<fuzzy_hash_chunk> next;
 };
 
 class FuzzyHash : public Operator {
@@ -49,7 +49,7 @@ class FuzzyHash : public Operator {
     bool init(const std::string &param, std::string *error) override;
  private:
     int m_threshold;
-    struct fuzzy_hash_chunk *m_head;
+    std::shared_ptr<fuzzy_hash_chunk> m_head;
 };
 
 }  // namespace operators

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -1638,7 +1638,7 @@ bool Multipart::process(const std::string& data, std::string *error,
                     }
                 } else { /* It looks like a boundary but */
                          /* we couldn't match it. */
-                    char *p = NULL;
+                    const char *p = NULL;
 
                     /* Check if an attempt to use quotes around the
                      * boundary was made. */

--- a/src/rules_exceptions.cc
+++ b/src/rules_exceptions.cc
@@ -58,7 +58,7 @@ bool RulesExceptions::loadUpdateActionById(double id,
 
 
 bool RulesExceptions::loadRemoveRuleByMsg(const std::string &msg,
-    std::string *error) {
+    const std::string *error) {
     m_remove_rule_by_msg.push_back(msg);
 
     return true;
@@ -66,7 +66,7 @@ bool RulesExceptions::loadRemoveRuleByMsg(const std::string &msg,
 
 
 bool RulesExceptions::loadRemoveRuleByTag(const std::string &msg,
-    std::string *error) {
+    const std::string *error) {
     m_remove_rule_by_tag.push_back(msg);
 
     return true;


### PR DESCRIPTION
## what

This PR aligns some part of code and fix `cppcheck` issues.

## why

`cppcheck` released a new version: 2.17.1. This versions is more strict and reported few new issues.

## references

See PR merge #3321, especially [this](https://github.com/owasp-modsecurity/ModSecurity/pull/3321#issuecomment-2718914899) comment.
