### PR TITLE
feat: improved XMLArgs processing

### DIFF
--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -3709,8 +3709,8 @@ static const char *cmd_cache_transformations(cmd_parms *cmd, void *_dcfg,
 * \param _dcfg Pointer to directory configuration
 * \param p1 Pointer to configuration option
 *
-* \retval NULL On failure
-* \retval apr_psprintf On Success
+* \retval NULL On Success
+* \retval apr_psprintf On error
 */
 static const char *cmd_parse_xml_into_args(cmd_parms *cmd, void *_dcfg, const char *p1)
 {

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -166,6 +166,7 @@ void *create_directory_config(apr_pool_t *mp, char *path)
 
     /* xml external entity */
     dcfg->xml_external_entity = NOT_SET;
+    dcfg->parse_xml_into_args = NOT_SET;
 
     return dcfg;
 }
@@ -640,6 +641,8 @@ void *merge_directory_configs(apr_pool_t *mp, void *_parent, void *_child)
     /* xml external entity */
     merged->xml_external_entity = (child->xml_external_entity == NOT_SET
         ? parent->xml_external_entity : child->xml_external_entity);
+    merged->parse_xml_into_args = (child->parse_xml_into_args == NOT_SET
+        ? parent->parse_xml_into_args : child->parse_xml_into_args);
 
     return merged;
 }
@@ -773,6 +776,7 @@ void init_directory_config(directory_config *dcfg)
 
     /* xml external entity */
     if (dcfg->xml_external_entity == NOT_SET) dcfg->xml_external_entity = 0;
+    if (dcfg->parse_xml_into_args == NOT_SET) dcfg->parse_xml_into_args = 0;
 
 }
 
@@ -3698,6 +3702,34 @@ static const char *cmd_cache_transformations(cmd_parms *cmd, void *_dcfg,
     return NULL;
 }
 
+/**
+* \brief Add SecParseXMLIntoArgs configuration option
+*
+* \param cmd Pointer to configuration data
+* \param _dcfg Pointer to directory configuration
+* \param p1 Pointer to configuration option
+*
+* \retval NULL On failure
+* \retval apr_psprintf On Success
+*/
+static const char *cmd_parse_xml_into_args(cmd_parms *cmd, void *_dcfg, const char *p1)
+{
+    assert(cmd != NULL);
+    assert(_dcfg != NULL);
+    assert(p1 != NULL);
+    // Normally useless code, left to be safe for the moment
+    if (_dcfg == NULL) {
+        ap_log_perror(APLOG_MARK, APLOG_EMERG, 0, cmd->pool, "cmd_hash_engine: _dcfg is NULL");
+        return NULL;
+    }
+    directory_config *dcfg = (directory_config *)_dcfg;
+    if (strcasecmp(p1, "on") == 0)       { dcfg->parse_xml_into_args = MSC_XML_ARGS_ON; }
+    else if (strcasecmp(p1, "off") == 0) { dcfg->parse_xml_into_args = MSC_XML_ARGS_OFF; }
+    else if (strcasecmp(p1, "onlyargs") == 0) { dcfg->parse_xml_into_args = MSC_XML_ARGS_ONLYARGS; }
+    else return apr_psprintf(cmd->pool, "ModSecurity: Invalid value for SecParseXMLIntoArgs: %s", p1);
+
+    return NULL;
+}
 
 /* -- Configuration directives definitions -- */
 
@@ -4464,6 +4496,14 @@ const command_rec module_directives[] = {
         NULL,
         CMD_SCOPE_ANY,
         "Set Hash parameter"
+    ),
+
+    AP_INIT_TAKE1 (
+        "SecParseXMLintoArgs",
+        cmd_parse_xml_into_args,
+        NULL,
+        CMD_SCOPE_ANY,
+        "On, Off or OnlyArgs"
     ),
 
     { NULL }

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -3719,7 +3719,7 @@ static const char *cmd_parse_xml_into_args(cmd_parms *cmd, void *_dcfg, const ch
     assert(p1 != NULL);
     // Normally useless code, left to be safe for the moment
     if (_dcfg == NULL) {
-        ap_log_perror(APLOG_MARK, APLOG_EMERG, 0, cmd->pool, "cmd_hash_engine: _dcfg is NULL");
+        ap_log_perror(APLOG_MARK, APLOG_EMERG, 0, cmd->pool, "cmd_parse_xml_into_args: _dcfg is NULL");
         return NULL;
     }
     directory_config *dcfg = (directory_config *)_dcfg;

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -3703,7 +3703,7 @@ static const char *cmd_cache_transformations(cmd_parms *cmd, void *_dcfg,
 }
 
 /**
-* \brief Add SecParseXMLIntoArgs configuration option
+* \brief Add SecParseXmlIntoArgs configuration option
 *
 * \param cmd Pointer to configuration data
 * \param _dcfg Pointer to directory configuration
@@ -3726,7 +3726,7 @@ static const char *cmd_parse_xml_into_args(cmd_parms *cmd, void *_dcfg, const ch
     if (strcasecmp(p1, "on") == 0)       { dcfg->parse_xml_into_args = MSC_XML_ARGS_ON; }
     else if (strcasecmp(p1, "off") == 0) { dcfg->parse_xml_into_args = MSC_XML_ARGS_OFF; }
     else if (strcasecmp(p1, "onlyargs") == 0) { dcfg->parse_xml_into_args = MSC_XML_ARGS_ONLYARGS; }
-    else return apr_psprintf(cmd->pool, "ModSecurity: Invalid value for SecParseXMLIntoArgs: %s", p1);
+    else return apr_psprintf(cmd->pool, "ModSecurity: Invalid value for SecParseXmlIntoArgs: %s", p1);
 
     return NULL;
 }
@@ -4499,7 +4499,7 @@ const command_rec module_directives[] = {
     ),
 
     AP_INIT_TAKE1 (
-        "SecParseXMLintoArgs",
+        "SecParseXmlIntoArgs",
         cmd_parse_xml_into_args,
         NULL,
         CMD_SCOPE_ANY,

--- a/apache2/modsecurity.h
+++ b/apache2/modsecurity.h
@@ -243,6 +243,10 @@ extern DSOLOCAL int *unicode_map_table;
 #define RULE_EXCEPTION_REMOVE_MSG       4
 #define RULE_EXCEPTION_REMOVE_TAG       5
 
+#define MSC_XML_ARGS_OFF                0
+#define MSC_XML_ARGS_ON                 1
+#define MSC_XML_ARGS_ONLYARGS           2
+
 #define NBSP                            160
 
 struct rule_exception {
@@ -643,6 +647,7 @@ struct directory_config {
 
     /* xml */
     int                 xml_external_entity;
+    int                 parse_xml_into_args;
 
     /* This will be used whenever ModSecurity will be ready
      * to ask the server for newer rules.

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -14,6 +14,108 @@
 
 #include "msc_xml.h"
 
+static void msc_xml_on_start_elementns(
+    void *ctx,
+    const xmlChar *localname,
+    const xmlChar *prefix,
+    const xmlChar *URI,
+    int nb_namespaces,
+    const xmlChar **namespaces,
+    int nb_attributes,
+    int nb_defaulted,
+    const xmlChar **attributes
+) {
+
+    // get the length of XML tag (localname)
+    size_t taglen = strlen((const char *)localname);
+    modsec_rec * msr = (modsec_rec *)ctx;
+    msc_xml_parser_state * xml_parser_state = msr->xml->xml_parser_state;
+
+    // pathlen contains the concatenated strings of tags with '.'
+    // eg xml.root.level1.leaf
+    xml_parser_state->pathlen += (taglen + 1);
+    char *newpath = apr_pstrcat(msr->mp, xml_parser_state->currpath, ".", (char *)localname, NULL);
+    xml_parser_state->currpath = newpath;
+
+    int *new_stack_item = (int *)apr_array_push(xml_parser_state->has_child_stack);
+    *new_stack_item = 0;
+    xml_parser_state->depth++;
+
+    // if there is an item before the current one we set that has a child
+    if (xml_parser_state->depth > 1) {
+        int *parent_stack_item = &((int *)xml_parser_state->has_child_stack->elts)[xml_parser_state->has_child_stack->nelts - 2];
+        *parent_stack_item = 1;
+    }
+
+}
+
+static void msc_xml_on_end_elementns(
+    void* ctx,
+    const xmlChar* localname,
+    const xmlChar* prefix,
+    const xmlChar* URI
+) {
+
+    size_t taglen = strlen((const char *)localname);
+    modsec_rec * msr = (modsec_rec *)ctx;
+    msc_xml_parser_state * xml_parser_state = msr->xml->xml_parser_state;
+
+    // if the node is a leaf we add it as argument
+    // get the top item from the stack which tells this info
+    int * top_stack_item = apr_array_pop(xml_parser_state->has_child_stack);
+    if (*top_stack_item == 0) {
+
+        if (apr_table_elts(msr->arguments)->nelts >= msr->txcfg->arguments_limit) {
+            if (msr->txcfg->debuglog_level >= 4) {
+                msr_log(msr, 4, "Skipping request argument, over limit (XML): name \"%s\", value \"%s\"",
+                        log_escape_ex(msr->mp, xml_parser_state->currpath, strlen(xml_parser_state->currpath)),
+                        log_escape_ex(msr->mp, xml_parser_state->currval, strlen(xml_parser_state->currval)));
+            }
+            msr->msc_reqbody_error = 1;
+            msr->xml->xml_error = apr_psprintf(msr->mp, "More than %ld XML keys", msr->txcfg->arguments_limit);
+            xmlStopParser((xmlParserCtxtPtr)msr->xml->parsing_ctx_arg);
+        }
+        else {
+
+            msc_arg * arg = (msc_arg *) apr_pcalloc(msr->mp, sizeof(msc_arg));
+
+            arg->name = xml_parser_state->currpath;
+            arg->name_len = strlen(arg->name);
+            arg->value = xml_parser_state->currval;
+            arg->value_len = strlen(xml_parser_state->currval);
+            arg->value_origin_len = arg->value_len;
+            //arg->value_origin_offset = value-base_offset;
+            arg->origin = "XML";
+
+            if (msr->txcfg->debuglog_level >= 9) {
+                msr_log(msr, 9, "Adding XML argument '%s' with value '%s'",
+                    xml_parser_state->currpath, xml_parser_state->currval);
+            }
+
+            apr_table_addn(msr->arguments,
+                log_escape_nq_ex(msr->mp, arg->name, arg->name_len), (void *) arg);
+        } // end else
+    } // end top_stack_item == 0
+
+    // decrease the length of current path length - +1 because of the '\0'
+    xml_parser_state->pathlen -= (taglen + 1);
+
+    // -1 need because we don't need the '.'
+    char * newpath = apr_pstrndup(msr->mp, xml_parser_state->currpath, xml_parser_state->pathlen - 1);
+    xml_parser_state->currpath = newpath;
+
+    xml_parser_state->depth--;
+}
+
+static void msc_xml_on_characters(void *ctx, const xmlChar *ch, int len) {
+
+    modsec_rec * msr = (modsec_rec *)ctx;
+    msc_xml_parser_state * xml_parser_state = msr->xml->xml_parser_state;
+
+    xml_parser_state->currval = apr_pstrndup(msr->mp, (const char *)ch, len);
+}
+
+
 static xmlParserInputBufferPtr
 xml_unload_external_entity(const char *URI, xmlCharEncoding enc)    {
     return NULL;
@@ -35,6 +137,33 @@ int xml_init(modsec_rec *msr, char **error_msg) {
 
     if(msr->txcfg->xml_external_entity == 0)    {
         entity = xmlParserInputBufferCreateFilenameDefault(xml_unload_external_entity);
+    }
+
+    if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
+
+        msr->xml->sax_handler = (xmlSAXHandler *)apr_pcalloc(msr->mp, sizeof(xmlSAXHandler));
+        memset(msr->xml->sax_handler, 0, sizeof(xmlSAXHandler));
+        if (msr->xml->sax_handler == NULL) {
+            *error_msg = apr_psprintf(msr->mp, "XML: Failed to create SAX handler.");
+            return -1;
+        }
+
+        msr->xml->sax_handler->initialized = XML_SAX2_MAGIC;
+        msr->xml->sax_handler->startElementNs = msc_xml_on_start_elementns;
+        msr->xml->sax_handler->endElementNs = msc_xml_on_end_elementns;
+        msr->xml->sax_handler->characters = msc_xml_on_characters;
+
+        // set the parser state struct
+        msr->xml->xml_parser_state                  = apr_pcalloc(msr->mp, sizeof(msc_xml_parser_state));
+        msr->xml->xml_parser_state->depth           = 0;
+        msr->xml->xml_parser_state->pathlen         = 4; // "xml\0"
+        msr->xml->xml_parser_state->currpath        = apr_pstrdup(msr->mp, "xml");
+        msr->xml->xml_parser_state->currval         = NULL;
+        msr->xml->xml_parser_state->currpathbufflen = 4;
+        // initialize the stack with item of 10
+        // this will store the information about nodes
+        // 10 is just an initial value, it can be automatically incremented
+        msr->xml->xml_parser_state->has_child_stack = apr_array_make(msr->mp, 10, sizeof(int));
     }
 
     return 1;
@@ -68,7 +197,7 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
      * enable us to pass it the first chunk of data so that
      * it can attempt to auto-detect the encoding.
      */
-    if (msr->xml->parsing_ctx == NULL) {
+    if (msr->xml->parsing_ctx == NULL && msr->xml->parsing_ctx_arg == NULL) {
 
         /* First invocation. */
 
@@ -86,18 +215,50 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
 
         */
 
-        msr->xml->parsing_ctx = xmlCreatePushParserCtxt(NULL, NULL, buf, size, "body.xml");
-        if (msr->xml->parsing_ctx == NULL) {
-            *error_msg = apr_psprintf(msr->mp, "XML: Failed to create parsing context.");
-            return -1;
+        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
+            msr->xml->parsing_ctx = xmlCreatePushParserCtxt(NULL, NULL, buf, size, "body.xml");
+            if (msr->xml->parsing_ctx == NULL) {
+                *error_msg = apr_psprintf(msr->mp, "XML: Failed to create parsing context.");
+                return -1;
+            }
+        }
+        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
+            msr->xml->parsing_ctx_arg = xmlCreatePushParserCtxt(
+                msr->xml->sax_handler,
+                msr,
+                buf,
+                size,
+                NULL);
+            if (msr->xml->parsing_ctx_arg == NULL) {
+                *error_msg = apr_psprintf(msr->mp, "XML: Failed to create parsing context for ARGS.");
+                return -1;
+            }
         }
     } else {
 
         /* Not a first invocation. */
+        msr_log(msr, 4, "XML: Continue parsing.");
+        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
+            xmlParseChunk(msr->xml->parsing_ctx, buf, size, 0);
+            if (msr->xml->parsing_ctx->wellFormed != 1) {
+                *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
+                return -1;
+            }
+        }
 
-        xmlParseChunk(msr->xml->parsing_ctx, buf, size, 0);
-        if (msr->xml->parsing_ctx->wellFormed != 1) {
-            *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
+        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
+            if (xmlParseChunk(msr->xml->parsing_ctx_arg, buf, size, 0) != 0) {
+                if (msr->xml->xml_error) {
+                    *error_msg = msr->xml->xml_error;
+                }
+                else {
+                    *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document for ARGS.");
+                }
+                return -1;
+            }
+        }
+        if (msr->xml->xml_error) {
+            *error_msg = msr->xml->xml_error;
             return -1;
         }
     }
@@ -114,23 +275,42 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
     *error_msg = NULL;
 
     /* Only if we have a context, meaning we've done some work. */
-    if (msr->xml->parsing_ctx != NULL) {
-        /* This is how we signalise the end of parsing to libxml. */
-        xmlParseChunk(msr->xml->parsing_ctx, NULL, 0, 1);
+    if (msr->xml->parsing_ctx != NULL || msr->xml->parsing_ctx_arg != NULL) {
+        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
+            /* This is how we signalise the end of parsing to libxml. */
+            xmlParseChunk(msr->xml->parsing_ctx, NULL, 0, 1);
 
-        /* Preserve the results for our reference. */
-        msr->xml->well_formed = msr->xml->parsing_ctx->wellFormed;
-        msr->xml->doc = msr->xml->parsing_ctx->myDoc;
+            /* Preserve the results for our reference. */
+            msr->xml->well_formed = msr->xml->parsing_ctx->wellFormed;
+            msr->xml->doc = msr->xml->parsing_ctx->myDoc;
 
-        /* Clean up everything else. */
-        xmlFreeParserCtxt(msr->xml->parsing_ctx);
-        msr->xml->parsing_ctx = NULL;
-        msr_log(msr, 4, "XML: Parsing complete (well_formed %u).", msr->xml->well_formed);
+            /* Clean up everything else. */
+            xmlFreeParserCtxt(msr->xml->parsing_ctx);
+            msr->xml->parsing_ctx = NULL;
+            msr_log(msr, 4, "XML: Parsing complete (well_formed %u).", msr->xml->well_formed);
 
-        if (msr->xml->well_formed != 1) {
-            *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
-            return -1;
+            if (msr->xml->well_formed != 1) {
+                *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
+                return -1;
+            }
         }
+
+        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
+            if (xmlParseChunk(msr->xml->parsing_ctx_arg, NULL, 0, 1) != 0) {
+                if (msr->xml->xml_error) {
+                    *error_msg = msr->xml->xml_error;
+                }
+                else {
+                    *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document for ARGS.");
+                }
+                xmlFreeParserCtxt(msr->xml->parsing_ctx_arg);
+                msr->xml->parsing_ctx_arg = NULL;
+                return -1;
+            }
+            xmlFreeParserCtxt(msr->xml->parsing_ctx_arg);
+            msr->xml->parsing_ctx_arg = NULL;
+        }
+
     }
 
     return 1;
@@ -151,6 +331,15 @@ apr_status_t xml_cleanup(modsec_rec *msr) {
         }
         xmlFreeParserCtxt(msr->xml->parsing_ctx);
         msr->xml->parsing_ctx = NULL;
+    }
+    if (msr->xml->parsing_ctx_arg != NULL) {
+
+        if (msr->xml->parsing_ctx_arg->myDoc) {
+            xmlFreeDoc(msr->xml->parsing_ctx_arg->myDoc);
+        }
+
+        xmlFreeParserCtxt(msr->xml->parsing_ctx_arg);
+        msr->xml->parsing_ctx_arg = NULL;
     }
     if (msr->xml->doc != NULL) {
         xmlFreeDoc(msr->xml->doc);

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -279,7 +279,7 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
     if (msr->xml->parsing_ctx != NULL || msr->xml->parsing_ctx_arg != NULL) {
         if (msr->xml->parsing_ctx != NULL &&
             msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
-            /* This is how we signalise the end of parsing to libxml. */
+            /* This is how we signal the end of parsing to libxml. */
             xmlParseChunk(msr->xml->parsing_ctx, NULL, 0, 1);
 
             /* Preserve the results for our reference. */

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -253,7 +253,7 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
                     *error_msg = msr->xml->xml_error;
                 }
                 else {
-                    *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document for ARGS.");
+                    *error_msg = apr_psprintf(msr->mp, "XML: Failed to parse document for ARGS.");
                 }
                 return -1;
             }

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -99,7 +99,7 @@ static void msc_xml_on_end_elementns(
     // decrease the length of current path length - +1 because of the '\0'
     xml_parser_state->pathlen -= (taglen + 1);
 
-    // -1 need because we don't need the '.'
+    // -1 is needed because we don't need the last '.'
     char * newpath = apr_pstrndup(msr->mp, xml_parser_state->currpath, xml_parser_state->pathlen - 1);
     xml_parser_state->currpath = newpath;
 

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -40,7 +40,7 @@ static void msc_xml_on_start_elementns(
     int *new_stack_item = (int *)apr_array_push(xml_parser_state->has_child_stack);
     *new_stack_item = 0;
     xml_parser_state->depth++;
-    // set null to the current value
+    // set the current value to null
     // this is necessary because if there is any text between the tags (new line, etc)
     // it will be added to the current value
     xml_parser_state->currval = NULL;

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -72,7 +72,7 @@ static void msc_xml_on_end_elementns(
                         log_escape_ex(msr->mp, xml_parser_state->currval, strlen(xml_parser_state->currval)));
             }
             msr->msc_reqbody_error = 1;
-            msr->xml->xml_error = apr_psprintf(msr->mp, "More than %ld XML keys", msr->txcfg->arguments_limit);
+            msr->xml->xml_error = apr_psprintf(msr->mp, "More than %ld ARGS (GET + XML)", msr->txcfg->arguments_limit);
             xmlStopParser((xmlParserCtxtPtr)msr->xml->parsing_ctx_arg);
         }
         else {

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -304,7 +304,7 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
                     *error_msg = msr->xml->xml_error;
                 }
                 else {
-                    *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document for ARGS.");
+                    *error_msg = apr_psprintf(msr->mp, "XML: Failed to parse document for ARGS.");
                 }
                 xmlFreeParserCtxt(msr->xml->parsing_ctx_arg);
                 msr->xml->parsing_ctx_arg = NULL;

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -84,7 +84,6 @@ static void msc_xml_on_end_elementns(
             arg->value = xml_parser_state->currval;
             arg->value_len = strlen(xml_parser_state->currval);
             arg->value_origin_len = arg->value_len;
-            //arg->value_origin_offset = value-base_offset;
             arg->origin = "XML";
 
             if (msr->txcfg->debuglog_level >= 9) {

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -292,7 +292,7 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
             msr_log(msr, 4, "XML: Parsing complete (well_formed %u).", msr->xml->well_formed);
 
             if (msr->xml->well_formed != 1) {
-                *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
+                *error_msg = apr_psprintf(msr->mp, "XML: Failed to parse document.");
                 return -1;
             }
         }

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -241,7 +241,7 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
             msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
             xmlParseChunk(msr->xml->parsing_ctx, buf, size, 0);
             if (msr->xml->parsing_ctx->wellFormed != 1) {
-                *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
+                *error_msg = apr_psprintf(msr->mp, "XML: Failed to parse document.");
                 return -1;
             }
         }

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -40,6 +40,10 @@ static void msc_xml_on_start_elementns(
     int *new_stack_item = (int *)apr_array_push(xml_parser_state->has_child_stack);
     *new_stack_item = 0;
     xml_parser_state->depth++;
+    // set null to the current value
+    // this is necessary because if there is any text between the tags (new line, etc)
+    // it will be added to the current value
+    xml_parser_state->currval = NULL;
 
     // if there is an item before the current one we set that has a child
     if (xml_parser_state->depth > 1) {
@@ -104,6 +108,7 @@ static void msc_xml_on_end_elementns(
     xml_parser_state->currpath = newpath;
 
     xml_parser_state->depth--;
+    xml_parser_state->currval = NULL;
 }
 
 static void msc_xml_on_characters(void *ctx, const xmlChar *ch, int len) {
@@ -111,7 +116,19 @@ static void msc_xml_on_characters(void *ctx, const xmlChar *ch, int len) {
     modsec_rec * msr = (modsec_rec *)ctx;
     msc_xml_parser_state * xml_parser_state = msr->xml->xml_parser_state;
 
-    xml_parser_state->currval = apr_pstrndup(msr->mp, (const char *)ch, len);
+    // libxml2 SAX parser will call this function multiple times
+    // during the parsing of a single node, if the value has multibyte
+    // characters, so we need to concatenate the values
+    xml_parser_state->currval = apr_pstrcat(msr->mp,
+                                            ((xml_parser_state->currval != NULL) ? xml_parser_state->currval : ""),
+                                            apr_pstrndup(msr->mp, (const char *)ch, len),
+                                            NULL);
+    // check if the memory allocation was successful
+    if (xml_parser_state->currval == NULL) {
+        msr->xml->xml_error = apr_psprintf(msr->mp, "Failed to allocate memory for XML value.");
+        xmlStopParser((xmlParserCtxtPtr)msr->xml->parsing_ctx_arg);
+    }
+
 }
 
 

--- a/apache2/msc_xml.c
+++ b/apache2/msc_xml.c
@@ -238,7 +238,8 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
 
         /* Not a first invocation. */
         msr_log(msr, 4, "XML: Continue parsing.");
-        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
+        if (msr->xml->parsing_ctx != NULL &&
+            msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
             xmlParseChunk(msr->xml->parsing_ctx, buf, size, 0);
             if (msr->xml->parsing_ctx->wellFormed != 1) {
                 *error_msg = apr_psprintf(msr->mp, "XML: Failed parsing document.");
@@ -246,7 +247,8 @@ int xml_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char 
             }
         }
 
-        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
+        if (msr->xml->parsing_ctx_arg != NULL &&
+            msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
             if (xmlParseChunk(msr->xml->parsing_ctx_arg, buf, size, 0) != 0) {
                 if (msr->xml->xml_error) {
                     *error_msg = msr->xml->xml_error;
@@ -276,7 +278,8 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
 
     /* Only if we have a context, meaning we've done some work. */
     if (msr->xml->parsing_ctx != NULL || msr->xml->parsing_ctx_arg != NULL) {
-        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
+        if (msr->xml->parsing_ctx != NULL &&
+            msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_ONLYARGS) {
             /* This is how we signalise the end of parsing to libxml. */
             xmlParseChunk(msr->xml->parsing_ctx, NULL, 0, 1);
 
@@ -295,7 +298,8 @@ int xml_complete(modsec_rec *msr, char **error_msg) {
             }
         }
 
-        if (msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
+        if (msr->xml->parsing_ctx_arg != NULL &&
+            msr->txcfg->parse_xml_into_args != MSC_XML_ARGS_OFF) {
             if (xmlParseChunk(msr->xml->parsing_ctx_arg, NULL, 0, 1) != 0) {
                 if (msr->xml->xml_error) {
                     *error_msg = msr->xml->xml_error;

--- a/apache2/msc_xml.h
+++ b/apache2/msc_xml.h
@@ -46,7 +46,7 @@ struct xml_data {
     /* error reporting and XML array flag */
     char                   *xml_error;
 
-    /* another parser context for arguments */
+    /* additional parser context for arguments */
     xmlParserCtxtPtr        parsing_ctx_arg;
     /* parser state for SAX parser */
     msc_xml_parser_state    *xml_parser_state;

--- a/apache2/msc_xml.h
+++ b/apache2/msc_xml.h
@@ -20,8 +20,21 @@ typedef struct xml_data xml_data;
 #include "modsecurity.h"
 #include <libxml/xmlschemas.h>
 #include <libxml/xpath.h>
+#include <libxml/SAX.h>
 
 /* Structures */
+
+struct msc_xml_parser_state {
+    apr_array_header_t * has_child_stack;
+    unsigned int         depth;
+    unsigned int         pathlen;
+    char               * currpath;
+    char               * currval;
+    size_t               currpathbufflen;
+    apr_pool_t         * mp;
+};
+
+typedef struct msc_xml_parser_state msc_xml_parser_state;
 
 struct xml_data {
     xmlSAXHandler           *sax_handler;
@@ -29,6 +42,14 @@ struct xml_data {
     xmlDocPtr               doc;
 
     unsigned int            well_formed;
+
+    /* error reporting and XML array flag */
+    char                   *xml_error;
+
+    /* another parser context for arguments */
+    xmlParserCtxtPtr        parsing_ctx_arg;
+    /* parser state for SAX parser */
+    msc_xml_parser_state    *xml_parser_state;
 };
 
 /* Functions */

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1028,7 +1028,7 @@ static char *msre_action_ctl_validate(msre_engine *engine, apr_pool_t *mp, msre_
         if (strcasecmp(value, "on") == 0) return NULL;
         if (strcasecmp(value, "off") == 0) return NULL;
         if (strcasecmp(value, "onlyargs") == 0) return NULL;
-        return apr_psprintf(mp, "Invalid setting for ctl name parseXMLintoArgs: %s", value);
+        return apr_psprintf(mp, "Invalid setting for ctl name parseXmlIntoArgs: %s", value);
      } else {
             return apr_psprintf(mp, "Invalid ctl name setting: %s", name);
      }

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1024,7 +1024,7 @@ static char *msre_action_ctl_validate(msre_engine *engine, apr_pool_t *mp, msre_
         return apr_psprintf(mp, "Invalid setting for ctl name HashEngine: %s", value);
      }
      else
-        if (strcasecmp(name, "parseXMLintoArgs") == 0) {
+        if (strcasecmp(name, "parseXmlIntoArgs") == 0) {
         if (strcasecmp(value, "on") == 0) return NULL;
         if (strcasecmp(value, "off") == 0) return NULL;
         if (strcasecmp(value, "onlyargs") == 0) return NULL;

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1386,7 +1386,7 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
         apr_table_addn(msr->removed_targets, apr_pstrdup(msr->mp, p2), (void *)re);
         return 1;
     } else
-    if (strcasecmp(name, "parseXMLintoArgs") == 0) {
+    if (strcasecmp(name, "parseXmlIntoArgs") == 0) {
 
         if (strcasecmp(value, "on") == 0) {
             msr->txcfg->parse_xml_into_args   = MSC_XML_ARGS_ON;

--- a/apache2/re_actions.c
+++ b/apache2/re_actions.c
@@ -1022,6 +1022,13 @@ static char *msre_action_ctl_validate(msre_engine *engine, apr_pool_t *mp, msre_
         if (strcasecmp(value, "on") == 0) return NULL;
         if (strcasecmp(value, "off") == 0) return NULL;
         return apr_psprintf(mp, "Invalid setting for ctl name HashEngine: %s", value);
+     }
+     else
+        if (strcasecmp(name, "parseXMLintoArgs") == 0) {
+        if (strcasecmp(value, "on") == 0) return NULL;
+        if (strcasecmp(value, "off") == 0) return NULL;
+        if (strcasecmp(value, "onlyargs") == 0) return NULL;
+        return apr_psprintf(mp, "Invalid setting for ctl name parseXMLintoArgs: %s", value);
      } else {
             return apr_psprintf(mp, "Invalid ctl name setting: %s", name);
      }
@@ -1377,6 +1384,29 @@ static apr_status_t msre_action_ctl_execute(modsec_rec *msr, apr_pool_t *mptmp,
             return -1;
         }
         apr_table_addn(msr->removed_targets, apr_pstrdup(msr->mp, p2), (void *)re);
+        return 1;
+    } else
+    if (strcasecmp(name, "parseXMLintoArgs") == 0) {
+
+        if (strcasecmp(value, "on") == 0) {
+            msr->txcfg->parse_xml_into_args   = MSC_XML_ARGS_ON;
+            msr->usercfg->parse_xml_into_args = MSC_XML_ARGS_ON;
+        }
+        else
+        if (strcasecmp(value, "off") == 0) {
+            msr->txcfg->parse_xml_into_args   = MSC_XML_ARGS_OFF;
+            msr->usercfg->parse_xml_into_args = MSC_XML_ARGS_OFF;
+        }
+        else
+        if (strcasecmp(value, "onlyargs") == 0) {
+            msr->txcfg->parse_xml_into_args   = MSC_XML_ARGS_ONLYARGS;
+            msr->usercfg->parse_xml_into_args = MSC_XML_ARGS_ONLYARGS;
+        }
+
+        if (msr->txcfg->debuglog_level >= 4) {
+            msr_log(msr, 4, "Ctl: Set parseXmlIntoArgs to %s.", value);
+        }
+
         return 1;
     }
 


### PR DESCRIPTION
## what

This PR adds a new feature within XML processing.

**Old (current) behavior**: in case of `XML:/*` target the body processor expands the node values from the XML payload. Eg.:
```XML
<?xml version="1.0" encoding="UTF-8"?>
<root>
  <level1>
    <level2>
      <node>foo1</node>
      <node>bar1</node>
    </level2>
    <level2>
      <node>foo2</node>
      <node>bar2</node>
    </level2>
  </level1>
</root>
```
will produce this value:
```
[/post][9] Target value: "  foo1  bar1  foo2  bar2"
```

In this case, there is no option to exclude any node. For example, if a node contains a term that a rule is looking for, the administrator could not create an exclusion. The only solution is to exclude the whole rule.

**New behavior**: there is a new configuration keyword, `SecParseXMLintoArgs` with possible values `On`, `Off` and `OnlyArgs`. The default value is `Off`. This won't change anything. If the administrator set this to `On`, then the engine will parse the XML into `ARGS` **AND** the `XML:/*` target will still contain the only text content as before. If the value is `OnlyArgs` then only the parsed content will appear in `ARGS` target; the `XML:/*` target won't contain the parsed content anymore.

If administrator sets it to `On`, then the node values will appear in `ARGS`, and it's easy to make any exclusion against the named target.

## why

A customer request has been received to solve this.

## references

See #3178.
