### PR TITLE
build/*.m4: Remove Bashisms/POSIX-ify the M4 helper macros

### DIFF
--- a/build/curl.m4
+++ b/build/curl.m4
@@ -25,7 +25,7 @@ AC_MSG_CHECKING([for libcurl config script])
 
 for x in ${test_paths}; do
     dnl # Determine if the script was specified and use it directly
-    if test ! -d "$x" -a -e "$x"; then
+    if test ! -d "$x" && test -e "$x"; then
         CURL_CONFIG=$x
         curl_path="no"
         break
@@ -100,7 +100,7 @@ AC_SUBST(CURL_LDFLAGS)
 AC_SUBST(CURL_LDADD)
 AC_SUBST(CURL_USES_GNUTLS)
 
-if test "x${with_curl}" == "xno"; then
+if test "x${with_curl}" = "xno"; then
     CURL_DISABLED=yes
 else
     if test "x${with_curl}" != "x"; then

--- a/build/libgeoip.m4
+++ b/build/libgeoip.m4
@@ -39,12 +39,12 @@ AC_ARG_WITH(
 #    )
 
 
-if test "x${with_geoip}" == "xno"; then
+if test "x${with_geoip}" = "xno"; then
     AC_DEFINE(HAVE_GEOIP, 0, [Support for GeoIP was disabled by the utilization of --without-geoip or --with-geoip=no])
     AC_MSG_NOTICE([Support for GeoIP was disabled by the utilization of --without-geoip or --with-geoip=no])
     GEOIP_DISABLED=yes
 else
-    if test "x${with_geoip}" == "xyes"; then
+    if test "x${with_geoip}" = "xyes"; then
         GEOIP_MANDATORY=yes
         AC_MSG_NOTICE([GeoIP support was marked as mandatory by the utilization of --with-geoip=yes])
     fi
@@ -55,8 +55,8 @@ else
 #            fi
 #        done
 
-#    if test "x${with_geoip}" != "xyes" or test "x${with_geoip}" == "xyes"; then
-        if test "x${with_geoip}" == "x" || test "x${with_geoip}" == "xyes"; then
+#    if test "x${with_geoip}" != "xyes" or test "x${with_geoip}" = "xyes"; then
+        if test "x${with_geoip}" = "x" || test "x${with_geoip}" = "xyes"; then
             # Nothing about GeoIP was informed, using the pkg-config to figure things out.
             if test -n "${PKG_CONFIG}"; then
                 GEOIP_PKG_NAME=""
@@ -170,13 +170,13 @@ AC_DEFUN([CHECK_FOR_GEOIP_AT], [
     fi
 
 
-    if test -n "${geoip_inc_path}" -a -n "${geoip_lib_path}"; then
+    if test -n "${geoip_inc_path}" && test -n "${geoip_lib_path}"; then
 
         AC_MSG_NOTICE([GeoIP headers found at: ${geoip_inc_path}])
         AC_MSG_NOTICE([GeoIP library found at: ${geoip_lib_file}])
     fi
 
-    if test -n "${geoip_lib_path}" -a -n "${geoip_inc_path}"; then
+    if test -n "${geoip_lib_path}" && test -n "${geoip_inc_path}"; then
         # TODO: Compile a piece of code to check the version.
         GEOIP_CFLAGS="-I${geoip_inc_path}"
         GEOIP_LDADD="-l${geoip_lib_name}"

--- a/build/libmaxmind.m4
+++ b/build/libmaxmind.m4
@@ -39,12 +39,12 @@ AC_ARG_WITH(
 #    )
 
 
-if test "x${with_maxmind}" == "xno"; then
+if test "x${with_maxmind}" = "xno"; then
     AC_DEFINE(HAVE_MAXMIND, 0, [Support for MaxMind was disabled by the utilization of --without-maxmind or --with-maxmind=no])
     AC_MSG_NOTICE([Support for MaxMind was disabled by the utilization of --without-maxmind or --with-maxmind=no])
     MAXMIND_DISABLED=yes
 else
-    if test "x${with_maxmind}" == "xyes"; then
+    if test "x${with_maxmind}" = "xyes"; then
         MAXMIND_MANDATORY=yes
         AC_MSG_NOTICE([MaxMind support was marked as mandatory by the utilization of --with-maxmind=yes])
     fi
@@ -55,8 +55,8 @@ else
 #            fi
 #        done
 
-#    if test "x${with_maxmind}" != "xyes" or test "x${with_maxmind}" == "xyes"; then
-        if test "x${with_maxmind}" == "x" || test "x${with_maxmind}" == "xyes"; then
+#    if test "x${with_maxmind}" != "xyes" or test "x${with_maxmind}" = "xyes"; then
+        if test "x${with_maxmind}" = "x" || test "x${with_maxmind}" = "xyes"; then
             # Nothing about MaxMind was informed, using the pkg-config to figure things out.
             if test -n "${PKG_CONFIG}"; then
                 MAXMIND_PKG_NAME=""
@@ -171,13 +171,13 @@ AC_DEFUN([CHECK_FOR_MAXMIND_AT], [
     fi
 
 
-    if test -n "${maxmind_inc_path}" -a -n "${maxmind_lib_path}"; then
+    if test -n "${maxmind_inc_path}" && test -n "${maxmind_lib_path}"; then
 
         AC_MSG_NOTICE([MaxMind headers found at: ${maxmind_inc_path}])
         AC_MSG_NOTICE([MaxMind library found at: ${maxmind_lib_file}])
     fi
 
-    if test -n "${maxmind_lib_path}" -a -n "${maxmind_inc_path}"; then
+    if test -n "${maxmind_lib_path}" && test -n "${maxmind_inc_path}"; then
         # TODO: Compile a piece of code to check the version.
         MAXMIND_CFLAGS="-I${maxmind_inc_path}"
         MAXMIND_LDADD="-l${maxmind_lib_name}"

--- a/build/libxml.m4
+++ b/build/libxml.m4
@@ -10,7 +10,7 @@ AC_MSG_CHECKING([for libxml2 config script])
 
 for x in ${test_paths}; do
     dnl # Determine if the script was specified and use it directly
-    if test ! -d "$x" -a -e "$x"; then
+    if test ! -d "$x" && test -e "$x"; then
         LIBXML2_CONFIG=$x
         libxml2_path="no"
         break
@@ -104,7 +104,7 @@ AC_SUBST(LIBXML2_LDADD)
 AC_SUBST(LIBXML2_LDFLAGS)
 
 
-if test "x${with_libxml}" == "xno"; then
+if test "x${with_libxml}" = "xno"; then
     LIBXML2_DISABLED=yes
 else
     if test "x${with_libxml}" != "x"; then

--- a/build/lmdb.m4
+++ b/build/lmdb.m4
@@ -24,12 +24,12 @@ AC_ARG_WITH(
     [AS_HELP_STRING([--with-lmdb=PATH],[Path to lmdb prefix or config script])]
 )
 
-if test "x${with_lmdb}" == "xno"; then
+if test "x${with_lmdb}" = "xno"; then
     AC_DEFINE(HAVE_LMDB, 0, [Support for LMDB was disabled by the utilization of --without-lmdb or --with-lmdb=no])
     AC_MSG_NOTICE([Support for LMDB was disabled by the utilization of --without-lmdb or --with-lmdb=no])
     LMDB_DISABLED=yes
 else
-    if test "x${with_lmdb}" == "xyes"; then
+    if test "x${with_lmdb}" = "xyes"; then
         LMDB_MANDATORY=yes
         AC_MSG_NOTICE([LMDB support was marked as mandatory by the utilization of --with-lmdb=yes])
     fi
@@ -40,8 +40,8 @@ else
 #            fi
 #        done
 
-#    if test "x${with_lmdb}" != "xyes" or test "x${with_lmdb}" == "xyes"; then
-        if test "x${with_lmdb}" == "x" || test "x${with_lmdb}" == "xyes"; then
+#    if test "x${with_lmdb}" != "xyes" or test "x${with_lmdb}" = "xyes"; then
+        if test "x${with_lmdb}" = "x" || test "x${with_lmdb}" = "xyes"; then
             # Nothing about LMDB was informed, using the pkg-config to figure things out.
             if test -n "${PKG_CONFIG}"; then
                 LMDB_PKG_NAME=""
@@ -170,7 +170,7 @@ AC_DEFUN([CHECK_FOR_LMDB_AT], [
         AC_MSG_NOTICE([LMDB headers found at: ${lmdb_inc_path}])
     fi
 
-    if test -n "${lmdb_lib_path}" -a -n "${lmdb_inc_path}"; then
+    if test -n "${lmdb_lib_path}" && test -n "${lmdb_inc_path}"; then
         # TODO: Compile a piece of code to check the version.
         LMDB_CFLAGS="-I${lmdb_inc_path}"
         LMDB_LDADD="-l${lmdb_lib_name}"

--- a/build/lua.m4
+++ b/build/lua.m4
@@ -26,12 +26,12 @@ AC_ARG_WITH(
 )
 
 
-if test "x${with_lua}" == "xno"; then
+if test "x${with_lua}" = "xno"; then
     AC_DEFINE(HAVE_LUA, 0, [Support for LUA was disabled by the utilization of --without-lua or --with-lua=no])
     AC_MSG_NOTICE([Support for LUA was disabled by the utilization of --without-lua or --with-lua=no])
     LUA_DISABLED=yes
 else
-    if test "x${with_lua}" == "xyes"; then
+    if test "x${with_lua}" = "xyes"; then
         LUA_MANDATORY=yes
         AC_MSG_NOTICE([LUA support was marked as mandatory by the utilization of --with-lua=yes])
     else
@@ -77,7 +77,7 @@ fi
 
 
 if test -z "${LUA_CFLAGS}"; then
-    if test -z "${LUA_MANDATORY}" || test "x${LUA_MANDATORY}" == "xno"; then
+    if test -z "${LUA_MANDATORY}" || test "x${LUA_MANDATORY}" = "xno"; then
         if test -z "${LUA_DISABLED}"; then
             AC_MSG_NOTICE([LUA library was not found])
             LUA_FOUND=0
@@ -89,7 +89,7 @@ if test -z "${LUA_CFLAGS}"; then
        LUA_FOUND=-1
     fi
 else
-    if test -z "${LUA_MANDATORY}" || test "x${LUA_MANDATORY}" == "xno"; then
+    if test -z "${LUA_MANDATORY}" || test "x${LUA_MANDATORY}" = "xno"; then
         LUA_FOUND=1
         AC_MSG_NOTICE([using LUA ${LUA_LDADD}])
         LUA_CFLAGS="-DWITH_LUA ${LUA_CFLAGS}"
@@ -185,7 +185,7 @@ AC_DEFUN([CHECK_FOR_LUA_AT], [
     if test -n "${lua_inc_path}"; then
         AC_MSG_NOTICE([LUA headers found at: ${lua_inc_path}])
     fi
-    if test -n "${lua_lib_path}" -a -n "${lua_inc_path}"; then
+    if test -n "${lua_lib_path}" && test -n "${lua_inc_path}"; then
            LUA_CFLAGS="-I${lua_inc_path}"
            LUA_LDADD="-l${lua_lib_name}"
            LUA_LDFLAGS="-L${lua_lib_path}"

--- a/build/pcre.m4
+++ b/build/pcre.m4
@@ -21,7 +21,7 @@ AC_ARG_WITH(
     [test_paths="${with_pcre}"],
     [test_paths="/usr/local/libpcre /usr/local/pcre /usr/local /opt/libpcre /opt/pcre /opt /usr /opt/local"])
 
-if test "x${with_pcre}" == "x" && test "x${with_pcre}" != "xno"; then
+if test "x${with_pcre}" = "x" && test "x${with_pcre}" != "xno"; then
     AC_MSG_NOTICE([Support for pcre not requested; omitting check for pcre])
 else
 
@@ -39,7 +39,7 @@ else
 
         for x in ${test_paths}; do
             dnl # Determine if the script was specified and use it directly
-            if test ! -d "$x" -a -e "$x"; then
+            if test ! -d "$x" && test -e "$x"; then
                 PCRE_CONFIG=$x
                 pcre_path="no"
                 break

--- a/build/pcre2.m4
+++ b/build/pcre2.m4
@@ -24,14 +24,14 @@ AC_ARG_WITH(
     [AS_HELP_STRING([--with-pcre2=PATH],[Path to pcre2 prefix or config script])]
 )
 
-if test "x${with_pcre2}" == "xno"; then
+if test "x${with_pcre2}" = "xno"; then
     AC_DEFINE(HAVE_PCRE2, 0, [Support for PCRE2 was disabled by the utilization of --without-pcre2 or --with-pcre2=no])
     AC_MSG_NOTICE([Support for PCRE2 was disabled by the utilization of --without-pcre2 or --with-pcre2=no])
     PCRE2_DISABLED=yes
 else
      PCRE2_MANDATORY=yes
      AC_MSG_NOTICE([PCRE2 is enabled by default.])
-#    if test "x${with_pcre2}" == "xyes"; then
+#    if test "x${with_pcre2}" = "xyes"; then
 #        PCRE2_MANDATORY=yes
 #        AC_MSG_NOTICE([PCRE2 support was marked as mandatory by the utilization of --with-pcre2=yes])
 #    fi
@@ -42,8 +42,8 @@ else
 #            fi
 #        done
 
-#    if test "x${with_pcre2}" != "xyes" or test "x${with_pcre2}" == "xyes"; then
-        if test "x${with_pcre2}" == "x" || test "x${with_pcre2}" == "xyes"; then
+#    if test "x${with_pcre2}" != "xyes" or test "x${with_pcre2}" = "xyes"; then
+        if test "x${with_pcre2}" = "x" || test "x${with_pcre2}" = "xyes"; then
             # Nothing about PCRE2 was informed, using the pkg-config to figure things out.
             if test -n "${PKG_CONFIG}"; then
                 PCRE2_PKG_NAME=""
@@ -177,7 +177,7 @@ AC_DEFUN([CHECK_FOR_PCRE2_AT], [
         AC_MSG_NOTICE([PCRE2 headers found at: ${pcre2_inc_path}])
     fi
 
-    if test -n "${pcre2_lib_path}" -a -n "${pcre2_inc_path}"; then
+    if test -n "${pcre2_lib_path}" && test -n "${pcre2_inc_path}"; then
         # TODO: Compile a piece of code to check the version.
         PCRE2_CFLAGS="-I${pcre2_inc_path}"
         PCRE2_LDADD="-l${pcre2_lib_name}"

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 git clean -xfdi
 git submodule foreach --recursive git clean -xfdi
 
-VERSION=`git describe --tags`
+VERSION=$(git describe --tags)
 DIR_NAME="modsecurity-$VERSION"
 TAR_NAME="modsecurity-$VERSION.tar.gz"
 

--- a/build/ssdeep.m4
+++ b/build/ssdeep.m4
@@ -26,12 +26,12 @@ AC_ARG_WITH(
 )
 
 
-if test "x${with_ssdeep}" == "xno"; then
+if test "x${with_ssdeep}" = "xno"; then
     AC_DEFINE(HAVE_SSDEEP, 0, [Support for SSDEEP was disabled by the utilization of --without-ssdeep or --with-ssdeep=no])
     AC_MSG_NOTICE([Support for SSDEEP was disabled by the utilization of --without-ssdeep or --with-ssdeep=no])
     SSDEEP_DISABLED=yes
 else
-    if test "x${with_ssdeep}" == "xyes"; then
+    if test "x${with_ssdeep}" = "xyes"; then
         SSDEEP_MANDATORY=yes
         AC_MSG_NOTICE([SSDEEP support was marked as mandatory by the utilization of --with-ssdeep=yes])
     else
@@ -47,7 +47,7 @@ fi
 
 
 if test -z "${SSDEEP_CFLAGS}"; then
-    if test -z "${SSDEEP_MANDATORY}" || test "x${SSDEEP_MANDATORY}" == "xno"; then
+    if test -z "${SSDEEP_MANDATORY}" || test "x${SSDEEP_MANDATORY}" = "xno"; then
         if test -z "${SSDEEP_DISABLED}"; then
             AC_MSG_NOTICE([SSDEEP library was not found])
             SSDEEP_FOUND=0
@@ -131,7 +131,7 @@ AC_DEFUN([CHECK_FOR_SSDEEP_AT], [
         AC_MSG_NOTICE([SSDEEP headers found at: ${ssdeep_inc_path}])
     fi
 
-    if test -n "${ssdeep_lib_path}" -a -n "${ssdeep_inc_path}"; then
+    if test -n "${ssdeep_lib_path}" && test -n "${ssdeep_inc_path}"; then
         # TODO: Compile a piece of code to check the version.
         SSDEEP_CFLAGS="-I${ssdeep_inc_path}"
         SSDEEP_LDADD="-l${ssdeep_lib_name}"

--- a/build/yajl.m4
+++ b/build/yajl.m4
@@ -24,12 +24,12 @@ AC_ARG_WITH(
     [AS_HELP_STRING([--with-yajl=PATH],[Path to yajl prefix or config script])]
 )
 
-if test "x${with_yajl}" == "xno"; then
+if test "x${with_yajl}" = "xno"; then
     AC_DEFINE(HAVE_YAJL, 0, [Support for YAJL was disabled by the utilization of --without-yajl or --with-yajl=no])
     AC_MSG_NOTICE([Support for YAJL was disabled by the utilization of --without-yajl or --with-yajl=no])
     YAJL_DISABLED=yes
 else
-    if test "x${with_yajl}" == "xyes"; then
+    if test "x${with_yajl}" = "xyes"; then
         YAJL_MANDATORY=yes
         AC_MSG_NOTICE([YAJL support was marked as mandatory by the utilization of --with-yajl=yes])
     fi
@@ -40,8 +40,8 @@ else
 #            fi
 #        done
 
-#    if test "x${with_yajl}" != "xyes" or test "x${with_yajl}" == "xyes"; then
-        if test "x${with_yajl}" == "x" || test "x${with_yajl}" == "xyes"; then
+#    if test "x${with_yajl}" != "xyes" or test "x${with_yajl}" = "xyes"; then
+        if test "x${with_yajl}" = "x" || test "x${with_yajl}" = "xyes"; then
             # Nothing about YAJL was informed, using the pkg-config to figure things out.
             if test -n "${PKG_CONFIG}"; then
                 YAJL_PKG_NAME=""
@@ -182,7 +182,7 @@ AC_DEFUN([CHECK_FOR_YAJL_AT], [
         AC_MSG_NOTICE([YAJL headers found at: ${yajl_inc_path}])
     fi
 
-    if test -n "${yajl_lib_path}" -a -n "${yajl_inc_path}"; then
+    if test -n "${yajl_lib_path}" && test -n "${yajl_inc_path}"; then
         # TODO: Compile a piece of code to check the version.
         YAJL_CFLAGS="-I${yajl_inc_path}"
         YAJL_LDADD="-l${yajl_lib_name}"


### PR DESCRIPTION

This commit makes it possible to build ModSecurity on systems where /bin/sh is a POSIX-compliant shell that is not Bash. Debian, Alpine Linux, and Gentoo Linux with the system shell set to not Bash, are examples of such systems.

Previously, the helper macros contained two types of Bashisms:
 

- The `==` comparison operator. Very easy to change, as the proper POSIX-compliant form is `=`. For example:

```
if test "${var}" == "myvalue"  ->  if test "${var}" = "myvalue"
```

- The '-a' (and) operator in the 'test' builtin. The '-a' and '-o' operators were removed in POSIX 2024 (Issue 8). The correct form is to use the '&&' and '||' operators respectively. For instance:
```
if test -d "${var}" -a -r "${var}/file"  ->  if test -d "${var}" && test -r "${var}/file"
```

Bug: https://bugs.gentoo.org/887135


<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- The Bash `==` operator changed to the POSIX-compliant `=`.
- The obsolete and removed in POSIX 2024 `-a` operator changed to the compliant `&&`.

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Unable to build ModSecurity on systems where `/bin/sh` is not Bash (is dash, ash, etc.). See the Gentoo bug below.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- The Gentoo bug: https://bugs.gentoo.org/887135