### PR TITLE
Simplify code for JSON audit log

### DIFF
--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -311,7 +311,7 @@ class RulesSetProperties {
     };
 
 
-    static const char *ruleEngineStateString(RuleEngine i) {
+    static std::string ruleEngineStateString(RuleEngine i) {
         switch (i) {
         case DisabledRuleEngine:
             return "Disabled";
@@ -322,7 +322,7 @@ class RulesSetProperties {
         case PropertyNotSetRuleEngine:
             return "PropertyNotSet/DetectionOnly";
         }
-        return NULL;
+        return std::string{};
     }
 
 

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -80,14 +80,13 @@ typedef struct Rules_t RulesSet;
 
 #define LOGFY_ADD(a, b) \
     yajl_gen_string(g, reinterpret_cast<const unsigned char*>(a), strlen(a)); \
-    if (b == NULL) { \
+    if (b.data() == NULL) { \
       yajl_gen_string(g, reinterpret_cast<const unsigned char*>(""), \
           strlen("")); \
     } else { \
-      yajl_gen_string(g, reinterpret_cast<const unsigned char*>(b), \
-          strlen(b)); \
+      yajl_gen_string(g, reinterpret_cast<const unsigned char*>(b.data()), \
+          b.length()); \
     }
-
 
 #define LOGFY_ADD_INT(a, b) \
     yajl_gen_string(g, reinterpret_cast<const unsigned char*>(a), strlen(a)); \

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1564,7 +1564,7 @@ std::string Transaction::toJSON(int parts) {
     size_t len;
     yajl_gen g;
     std::string log;
-    std::string ts = utils::string::ascTime(&m_timeStamp).c_str();
+    std::string ts = utils::string::ascTime(&m_timeStamp);
     std::string uniqueId = UniqueId::uniqueId();
 
     g = yajl_gen_alloc(NULL);
@@ -1582,13 +1582,13 @@ std::string Transaction::toJSON(int parts) {
 
     yajl_gen_map_open(g);
     /* Part: A (header mandatory) */
-    LOGFY_ADD("client_ip", m_clientIpAddress.c_str());
-    LOGFY_ADD("time_stamp", ts.c_str());
-    LOGFY_ADD("server_id", uniqueId.c_str());
+    LOGFY_ADD("client_ip", m_clientIpAddress);
+    LOGFY_ADD("time_stamp", ts);
+    LOGFY_ADD("server_id", uniqueId);
     LOGFY_ADD_NUM("client_port", m_clientPort);
-    LOGFY_ADD("host_ip", m_serverIpAddress.c_str());
+    LOGFY_ADD("host_ip", m_serverIpAddress);
     LOGFY_ADD_NUM("host_port", m_serverPort);
-    LOGFY_ADD("unique_id", m_id.c_str());
+    LOGFY_ADD("unique_id", m_id);
 
     /* request */
     yajl_gen_string(g, reinterpret_cast<const unsigned char*>("request"),
@@ -1597,14 +1597,14 @@ std::string Transaction::toJSON(int parts) {
 
     LOGFY_ADD("method",
         utils::string::dash_if_empty(
-            m_variableRequestMethod.evaluate()).c_str());
+            m_variableRequestMethod.evaluate()));
 
     LOGFY_ADD_INT("http_version", m_httpVersion.c_str());
-    LOGFY_ADD("uri", this->m_uri.c_str());
+    LOGFY_ADD("uri", this->m_uri);
 
     if (parts & audit_log::AuditLog::CAuditLogPart) {
         // FIXME: check for the binary content size.
-        LOGFY_ADD("body", this->m_requestBody.str().c_str());
+        LOGFY_ADD("body", this->m_requestBody.str());
     }
 
     /* request headers */
@@ -1616,7 +1616,7 @@ std::string Transaction::toJSON(int parts) {
 
         m_variableRequestHeaders.resolve(&l);
         for (auto &h : l) {
-            LOGFY_ADD(h->getKey().c_str(), h->getValue().c_str());
+            LOGFY_ADD(h->getKey().c_str(), h->getValue());
             delete h;
         }
 
@@ -1633,7 +1633,7 @@ std::string Transaction::toJSON(int parts) {
     yajl_gen_map_open(g);
 
     if (parts & audit_log::AuditLog::EAuditLogPart) {
-        LOGFY_ADD("body", this->m_responseBody.str().c_str());
+        LOGFY_ADD("body", this->m_responseBody.str());
     }
     LOGFY_ADD_NUM("http_code", m_httpCodeReturned);
 
@@ -1646,7 +1646,7 @@ std::string Transaction::toJSON(int parts) {
 
         m_variableResponseHeaders.resolve(&l);
         for (auto &h : l) {
-            LOGFY_ADD(h->getKey().c_str(), h->getValue().c_str());
+            LOGFY_ADD(h->getKey().c_str(), h->getValue());
             delete h;
         }
 
@@ -1663,10 +1663,10 @@ std::string Transaction::toJSON(int parts) {
         yajl_gen_map_open(g);
 
         /* producer > libmodsecurity */
-        LOGFY_ADD("modsecurity", m_ms->whoAmI().c_str());
+        LOGFY_ADD("modsecurity", m_ms->whoAmI());
 
         /* producer > connector */
-        LOGFY_ADD("connector", m_ms->getConnectorInformation().c_str());
+        LOGFY_ADD("connector", m_ms->getConnectorInformation());
 
         /* producer > engine state */
         LOGFY_ADD("secrules_engine",
@@ -1682,7 +1682,7 @@ std::string Transaction::toJSON(int parts) {
         for (const auto &a : m_rules->m_components) {
             yajl_gen_string(g,
                 reinterpret_cast<const unsigned char*>
-                    (a.c_str()), a.length());
+                    (a.data()), a.length());
         }
         yajl_gen_array_close(g);
 
@@ -1696,20 +1696,20 @@ std::string Transaction::toJSON(int parts) {
         yajl_gen_array_open(g);
         for (auto a : m_rulesMessages) {
             yajl_gen_map_open(g);
-            LOGFY_ADD("message", a.m_message.c_str());
+            LOGFY_ADD("message", a.m_message);
             yajl_gen_string(g,
                 reinterpret_cast<const unsigned char*>("details"),
                 strlen("details"));
             yajl_gen_map_open(g);
-            LOGFY_ADD("match", a.m_match.c_str());
-            LOGFY_ADD("reference", a.m_reference.c_str());
-            LOGFY_ADD("ruleId", std::to_string(a.m_rule.m_ruleId).c_str());
-            LOGFY_ADD("file", a.m_rule.getFileName().c_str());
-            LOGFY_ADD("lineNumber", std::to_string(a.m_rule.getLineNumber()).c_str());
-            LOGFY_ADD("data", a.m_data.c_str());
-            LOGFY_ADD("severity", std::to_string(a.m_severity).c_str());
-            LOGFY_ADD("ver", a.m_rule.m_ver.c_str());
-            LOGFY_ADD("rev", a.m_rule.m_rev.c_str());
+            LOGFY_ADD("match", a.m_match);
+            LOGFY_ADD("reference", a.m_reference);
+            LOGFY_ADD("ruleId", std::to_string(a.m_rule.m_ruleId));
+            LOGFY_ADD("file", a.m_rule.getFileName());
+            LOGFY_ADD("lineNumber", std::to_string(a.m_rule.getLineNumber()));
+            LOGFY_ADD("data", a.m_data);
+            LOGFY_ADD("severity", std::to_string(a.m_severity));
+            LOGFY_ADD("ver", a.m_rule.m_ver);
+            LOGFY_ADD("rev", a.m_rule.m_rev);
 
             yajl_gen_string(g,
                 reinterpret_cast<const unsigned char*>("tags"),
@@ -1717,13 +1717,13 @@ std::string Transaction::toJSON(int parts) {
             yajl_gen_array_open(g);
             for (auto b : a.m_tags) {
                 yajl_gen_string(g,
-                    reinterpret_cast<const unsigned char*>(b.c_str()),
-                    strlen(b.c_str()));
+                    reinterpret_cast<const unsigned char*>(b.data()),
+                    b.length());
             }
             yajl_gen_array_close(g);
 
-            LOGFY_ADD("maturity", std::to_string(a.m_rule.m_maturity).c_str());
-            LOGFY_ADD("accuracy", std::to_string(a.m_rule.m_accuracy).c_str());
+            LOGFY_ADD("maturity", std::to_string(a.m_rule.m_maturity));
+            LOGFY_ADD("accuracy", std::to_string(a.m_rule.m_accuracy));
             yajl_gen_map_close(g);
             yajl_gen_map_close(g);
         }

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1599,7 +1599,7 @@ std::string Transaction::toJSON(int parts) {
         utils::string::dash_if_empty(
             m_variableRequestMethod.evaluate()));
 
-    LOGFY_ADD_INT("http_version", m_httpVersion.c_str());
+    LOGFY_ADD("http_version", m_httpVersion);
     LOGFY_ADD("uri", this->m_uri);
 
     if (parts & audit_log::AuditLog::CAuditLogPart) {

--- a/test/test-cases/regression/auditlog.json
+++ b/test/test-cases/regression/auditlog.json
@@ -176,6 +176,65 @@
     "enabled": 1,
     "version_min": 300000,
     "version_max": 0,
+    "title": "auditlog : basic parser test - JSON",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 2313
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "www.modsecurity.org",
+        "User-Agent": "Mozilla\/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.1.5) Gecko\/20091102 Firefox\/3.5.5 (.NET CLR 3.5.30729)",
+        "Accept": "text\/html,application\/xhtml+xml,application\/xml;q=0.9,*\/*;q=0.8",
+        "Accept-Language": "en-us,en;q=0.5",
+        "Accept-Encoding": "gzip,deflate",
+        "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+        "Keep-Alive": "300",
+        "Connection": "keep-alive",
+        "Pragma": "no-cache",
+        "Cache-Control": "no-cache"
+      },
+      "uri": "\/test.pl?param1=   test   &param2=test2",
+      "method": "GET",
+      "http_version": 1.1,
+      "body": ""
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "plain\/text\n\r"
+      },
+      "body": [
+        "test"
+      ]
+    },
+    "expected": {
+      "audit_log": "{\"transaction\":{\"client_ip\":\"200.249.12.31\",\"time_stamp\":\"\\S{3} \\S{3} \\d{2} \\d{2}:\\d{2}:\\d{2} \\d{4}\"",
+      "debug_log": "",
+      "error_log": "",
+      "http_code": 403
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@contains test\" \"id:1,t:trim,deny,auditlog\"",
+      "SecAuditEngine RelevantOnly",
+      "SecAuditLogFormat JSON",
+      "SecAuditLogParts ABCFHZ",
+      "SecAuditLogStorageDir /tmp/test",
+      "SecAuditLog /tmp/audit_test_parallel.log",
+      "SecAuditLogDirMode 0766",
+      "SecAuditLogFileMode 0600",
+      "SecAuditLogType Serial",
+      "SecAuditLogRelevantStatus \"^(?:5|4(?!04))\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "version_max": 0,
     "title": "auditlog : messages verification - nolog,auditlog",
     "client": {
       "ip": "200.249.12.31",


### PR DESCRIPTION
`yajl_gen_string` doesn't require null terminated string, so we don't need to call `strlen`.

This simplifies code for JSON transaction logging.