### PR TITLE
Disable Expect when sending audit logs to remote HTTP server

### DIFF
--- a/src/utils/https_client.cc
+++ b/src/utils/https_client.cc
@@ -110,14 +110,17 @@ bool HttpsClient::download(const std::string &uri) {
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "ModSecurity3");
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers_chunk);
 
     /* We want Curl to return error in case there is an HTTP error code */
     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 
     if (m_requestBody.empty() == false) {
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, m_requestBody.c_str());
+        headers_chunk = curl_slist_append(headers_chunk, "Expect:"); // Disable Expect: 100-continue
     }
+
+    /* set HTTP headers for request */
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers_chunk);
 
     res = curl_easy_perform(curl);
 


### PR DESCRIPTION
By default, curl sends `Expect: 100-continue` request HTTP header when sending POST data. This requires another round trip, because then curl waits until receives `HTTP/1.1 100 Continue` from remote server. 

When we disable Expect: 100-continue, sending logs to remote server should be faster.