### PR TITLE
Fix error logging for standalone module

### DIFF
--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -284,12 +284,27 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
         }
         else hostname = "";
 
-#if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
+/* Non-standalone modules use amended format string for logging */
+#if !(defined(VERSION_STANDALONE))
+  #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
 	ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
             "ModSecurity: %s%s [uri \"%s\"]%s", str1, hostname, log_escape(msr->mp, r->uri), unique_id);
-#else
+  #else
         ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r->server,
             "ModSecurity: %s%s [uri \"%s\"]%s", str1, hostname, log_escape(msr->mp, r->uri), unique_id);
+  #endif
+/* Standalone module must use original format string for logging with explicit
+ * "[client %s]" to log client IP address (no Apache to implicitly add this) */
+#else
+  #if AP_SERVER_MAJORVERSION_NUMBER > 1 && AP_SERVER_MINORVERSION_NUMBER > 2
+	ap_log_rerror(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r,
+            "[client %s] ModSecurity: %s%s [uri \"%s\"]%s", r->useragent_ip ? r->useragent_ip : r->connection->client_ip, str1,
+            hostname, log_escape(msr->mp, r->uri), unique_id);
+  #else
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r->server,
+                "[client %s] ModSecurity: %s%s [uri \"%s\"]%s", msr->remote_addr ? msr->remote_addr : r->connection->remote_ip, str1,
+                hostname, log_escape(msr->mp, r->uri), unique_id);
+  #endif
 #endif
 
         /* Add this message to the list. */

--- a/apache2/apache2_util.c
+++ b/apache2/apache2_util.c
@@ -302,8 +302,8 @@ static void internal_log_ex(request_rec *r, directory_config *dcfg, modsec_rec *
             hostname, log_escape(msr->mp, r->uri), unique_id);
   #else
         ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, r->server,
-                "[client %s] ModSecurity: %s%s [uri \"%s\"]%s", msr->remote_addr ? msr->remote_addr : r->connection->remote_ip, str1,
-                hostname, log_escape(msr->mp, r->uri), unique_id);
+            "[client %s] ModSecurity: %s%s [uri \"%s\"]%s", msr->remote_addr ? msr->remote_addr : r->connection->remote_ip, str1,
+            hostname, log_escape(msr->mp, r->uri), unique_id);
   #endif
 #endif
 


### PR DESCRIPTION
## what

This PR:

- Restores the original format string for error logging for ModSecurity _when compiled as a standalone module_.
- The format string has the explicit `[client %s]` back again: this is required for standalone modules as Apache is not present to implicitly log the client source IP address.
- The fix is achieved by adding conditional compilation directives so that for standalone mode the old error logging format strings are used.

## why

It is essential for the client source IP address to be written to the error log. This is required for resolving false positives, monitoring, detecting attacks, and the majority of day to day WAF operations.

This PR fixes the bug introduced in an attempt to tidy error logging for Apache in PR #3192.

## references

closes #3373