### PR TITLE
fix: add msc_fullinfo() to check JIT compilation

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -37,6 +37,8 @@
 
 #include "libinjection/libinjection.h"
 
+#ifdef WITH_PCRE_STUDY
+#ifdef WITH_PCRE_JIT
 #ifdef WITH_PCRE2
 /**
  * @brief Set the JIT compile return code and JIT compile status.
@@ -53,6 +55,8 @@ static void msc_op_set_jitrc(msc_regex_t *regex, int *rc, int *jit) {
     }
     return;
 }
+#endif
+#endif
 #endif
 
 /**

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -725,6 +725,10 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
             #ifdef WITH_PCRE_JIT
                 #ifdef WITH_PCRE2
         rc = regex->jit_compile_rc;
+        if (rc == 0) {
+            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+            jit = (jit > 0) ? 1 : 0;
+        }
                 #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                 #endif
@@ -831,6 +835,10 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
             if (msr->txcfg->debuglog_level >= 4) {
                     #ifdef WITH_PCRE2
                 rc = regex->jit_compile_rc;
+                if (rc == 0) {
+                    msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+                    jit = (jit > 0) ? 1 : 0;
+                }
                     #else
                 rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                     #endif
@@ -1002,6 +1010,10 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
             #ifdef WITH_PCRE_JIT
                 #ifdef WITH_PCRE2
         rc = regex->jit_compile_rc;
+        if (rc == 0) {
+            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+            jit = (jit > 0) ? 1 : 0;
+        }
                 #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                 #endif
@@ -1100,6 +1112,10 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
             if (msr->txcfg->debuglog_level >= 4) {
                     #ifdef WITH_PCRE2
                 rc = regex->jit_compile_rc;
+                if (rc == 0) {
+                    msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+                    jit = (jit > 0) ? 1 : 0;
+                }
                     #else
                 rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                     #endif
@@ -2991,6 +3007,10 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
     if (msr->txcfg->debuglog_level >= 4) {
             #ifdef WITH_PCRE2
         rc = regex->jit_compile_rc;
+        if (rc == 0) {
+            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+            jit = (jit > 0) ? 1 : 0;
+        }
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
             #endif
@@ -3330,6 +3350,10 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
     if (msr->txcfg->debuglog_level >= 4) {
             #ifdef WITH_PCRE2
         rc = regex->jit_compile_rc;
+        if (rc == 0) {
+            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+            jit = (jit > 0) ? 1 : 0;
+        }
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
             #endif
@@ -3655,6 +3679,10 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
     if (msr->txcfg->debuglog_level >= 4) {
             #ifdef WITH_PCRE2
         rc = regex->jit_compile_rc;
+        if (rc == 0) {
+            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
+            jit = (jit > 0) ? 1 : 0;
+        }
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
             #endif

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -37,6 +37,21 @@
 
 #include "libinjection/libinjection.h"
 
+/**
+ * @brief Set the JIT compile return code and JIT compile status.
+ * \param regex regex structure
+ * \param rc return code of the JIT compile
+ * \param jit JIT compile status
+ * \return void
+ */
+static void msc_op_set_jitrc(msc_regex_t *regex, int *rc, int *jit) {
+    *rc = regex->jit_compile_rc;
+    if (*rc == 0) {
+        msc_fullinfo(regex, PCRE2_INFO_JITSIZE, jit);
+        *jit = (*jit > 0) ? 1 : 0;
+    }
+    return;
+}
 
 /**
  *
@@ -724,11 +739,7 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
                 #ifdef WITH_PCRE2
-        rc = regex->jit_compile_rc;
-        if (rc == 0) {
-            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-            jit = (jit > 0) ? 1 : 0;
-        }
+        msc_op_set_jitrc(regex, &rc, &jit);
                 #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                 #endif
@@ -834,11 +845,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
                     #ifdef WITH_PCRE2
-                rc = regex->jit_compile_rc;
-                if (rc == 0) {
-                    msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-                    jit = (jit > 0) ? 1 : 0;
-                }
+                msc_op_set_jitrc(regex, &rc, &jit);
                     #else
                 rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                     #endif
@@ -1009,11 +1016,7 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
                 #ifdef WITH_PCRE2
-        rc = regex->jit_compile_rc;
-        if (rc == 0) {
-            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-            jit = (jit > 0) ? 1 : 0;
-        }
+        msc_op_set_jitrc(regex, &rc, &jit);
                 #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                 #endif
@@ -1111,11 +1114,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
                     #ifdef WITH_PCRE2
-                rc = regex->jit_compile_rc;
-                if (rc == 0) {
-                    msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-                    jit = (jit > 0) ? 1 : 0;
-                }
+                msc_op_set_jitrc(regex, &rc, &jit);
                     #else
                 rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
                     #endif
@@ -3006,11 +3005,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
             #ifdef WITH_PCRE2
-        rc = regex->jit_compile_rc;
-        if (rc == 0) {
-            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-            jit = (jit > 0) ? 1 : 0;
-        }
+        msc_op_set_jitrc(regex, &rc, &jit);
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
             #endif
@@ -3349,11 +3344,7 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
             #ifdef WITH_PCRE2
-        rc = regex->jit_compile_rc;
-        if (rc == 0) {
-            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-            jit = (jit > 0) ? 1 : 0;
-        }
+        msc_op_set_jitrc(regex, &rc, &jit);
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
             #endif
@@ -3678,11 +3669,7 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
             #ifdef WITH_PCRE2
-        rc = regex->jit_compile_rc;
-        if (rc == 0) {
-            msc_fullinfo(regex, PCRE2_INFO_JITSIZE, &jit);
-            jit = (jit > 0) ? 1 : 0;
-        }
+        msc_op_set_jitrc(regex, &rc, &jit);
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
             #endif

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -37,6 +37,7 @@
 
 #include "libinjection/libinjection.h"
 
+#ifdef WITH_PCRE2
 /**
  * @brief Set the JIT compile return code and JIT compile status.
  * \param regex regex structure
@@ -52,6 +53,7 @@ static void msc_op_set_jitrc(msc_regex_t *regex, int *rc, int *jit) {
     }
     return;
 }
+#endif
 
 /**
  *


### PR DESCRIPTION
## what

I usually use mod_security2 Apache module with these build options:

```
./configure --enable-pcre-study=yes --enable-pcre-jit=yes --with-pcre2
```

During an issue investigation I ran into an interesting message. Consider this rule:
```
SecRule ARGS "@verifyCC \d{13,16}" "id:1,phase:2,log,capture,pass"
```
and this payload:
```
$ cat jsonpayload.json
[1234567890123456,1234567890123456,1234567890123456]
```
When I send this request:
```
curl -H "Content-Type: application/json" -X POST -d @jsonpayload.json http://localhost
```
I see these messages in debug.log:
```
Rule 7fbd7d71a6d0 [id "1"][file "test.conf"][line "476"] - Execution error - Does not support JIT (0).
```
Which is not true.

## why

The problem is that the regex engine (in case of using PCRE2) does not handle the `jit` variable correctly (in case of `verifyCC` operator this variable is [here](https://github.com/owasp-modsecurity/ModSecurity/blob/6be2ee534a8b50f518f7856b7508d56dc94ceb42/apache2/re_operators.c#L2974), as you can see it's initialized with `0`).

Let's see what happens when the engine runs any of the relevant codes (and user used the same build options).

The engine has its own `regex` structure which has a member with [name](https://github.com/owasp-modsecurity/ModSecurity/blob/ecab91a74e4d5d85071144b74202c45fbcae70b3/apache2/msc_pcre.h#L49) `jit_compile_rc`. This stores the information about the engine is able to use JIT or not.

When a rule use the PCRE engine, it fills the `regex` object and set `jit_compile_rc` member [here](https://github.com/owasp-modsecurity/ModSecurity/blob/ecab91a74e4d5d85071144b74202c45fbcae70b3/apache2/msc_pcre.c#L92).

```C
#ifdef WITH_PCRE_JIT
    regex->jit_compile_rc = pcre2_jit_compile(regex->re, PCRE2_JIT_COMPLETE);
#endif
```

As I wrote above, at the operator the `jit` variable is initialized with `0`, and in case of PCRE2 it does not change during the execution.

The condition is [here](https://github.com/owasp-modsecurity/ModSecurity/blob/6be2ee534a8b50f518f7856b7508d56dc94ceb42/apache2/re_operators.c#L2997):
```C
        if ((rc != 0) || (jit != 1)) {
            *error_msg = apr_psprintf(msr->mp,
                    "Rule %pp [id \"%s\"][file \"%s\"][line \"%d\"] - "
                    "Execution error - "
                    ... other part of error message...
        }
```
The variable `rc` is set [here](https://github.com/owasp-modsecurity/ModSecurity/blob/6be2ee534a8b50f518f7856b7508d56dc94ceb42/apache2/re_operators.c#L2993):
```C
            #ifdef WITH_PCRE2
        rc = regex->jit_compile_rc;
            #else
```
so the `rc` will hold the value of `pcre2_jit_compile()`'s return value. Let's [see](https://www.pcre.org/current/doc/html/pcre2_jit_compile.html) what is the return value of this function:

> "Such a call returns zero if JIT is available and has a working allocator"

So the variable `rc` will be `0` (if JIT is available). But what about the variable `jit`? It's still `0`. As you can see in case of old PCRE code, it [calls](https://github.com/owasp-modsecurity/ModSecurity/blob/ecab91a74e4d5d85071144b74202c45fbcae70b3/apache2/msc_pcre.c#L323) `msc_fullinfo()`, which in case of PCRE2 decides JIT is usable or not with calling the [function](https://www.pcre.org/current/doc/html/pcre2_pattern_info.html) `pcre2_pattern_info()`. See how does it work:

> "A non-zero result means that JIT compilation was successful. A result of 0 means that JIT support is not available, or the pattern was not processed by pcre2_jit_compile()"

This is necessary to get a full description of JIT status in current call, and sets the correct value of `jit`.
