### PR TITLE
chore: remove unnecessary @LIBXML2_CFLAGS@ from linker flags

### DIFF
--- a/apache2/Makefile.am
+++ b/apache2/Makefile.am
@@ -57,7 +57,6 @@ mod_security2_la_CPPFLAGS = @APR_CPPFLAGS@ \
 mod_security2_la_LIBADD = @APR_LDADD@ \
     @APU_LDADD@ \
     @CURL_LDADD@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDADD@ \
     @LUA_LDADD@ \
     @PCRE_LDADD@ \
@@ -70,7 +69,6 @@ mod_security2_la_LDFLAGS = -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -85,7 +83,6 @@ mod_security2_la_LDFLAGS = -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -100,7 +97,6 @@ mod_security2_la_LDFLAGS = -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -115,7 +111,6 @@ mod_security2_la_LDFLAGS = -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -130,7 +125,6 @@ mod_security2_la_LDFLAGS = -no-undefined -module -avoid-version -R @PCRE_LD_PATH
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -145,7 +139,6 @@ mod_security2_la_LDFLAGS = -no-undefined -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -160,7 +153,6 @@ mod_security2_la_LDFLAGS = -no-undefined -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
@@ -175,7 +167,6 @@ mod_security2_la_LDFLAGS = -no-undefined -module -avoid-version \
     @APU_LDFLAGS@ \
     @APXS_LDFLAGS@ \
     @CURL_LDFLAGS@ \
-    @LIBXML2_CFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \


### PR DESCRIPTION
## what

This PR removes the unnecessary `@LIBXML2_CFLAGS@` from flags for linker in `apache2/Makefile.am`.

## why

`CFLAGS` (eg. `-I/usr/include/libxml2` - can be viewed with the `xml2-config --cflags` command) and `LDFLAGS` (eg. `-lxml2` - can be viewed with the `xml2-config --libs` command) serve different purposes.

This may cause a compilation error in newer C compilers.

