### PR TITLE
fix: 'make test' is able to run again

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,16 +40,18 @@ msc_test_CFLAGS = @APR_CFLAGS@ \
     @LUA_CFLAGS@ \
     @MODSEC_EXTRA_CFLAGS@ \
     @PCRE_CFLAGS@ \
+    @PCRE2_CFLAGS@ \
     @YAJL_CFLAGS@ \
     @SSDEEP_CFLAGS@
-    
+
 msc_test_CPPFLAGS = -I$(top_srcdir)/apache2 \
     @APR_CPPFLAGS@ \
     @CURL_CPPFLAGS@ \
     @LIBXML2_CFLAGS@ \
     @LIBXML2_CPPFLAGS@ \
-    @PCRE_CPPFLAGS@
-    
+    @PCRE_CPPFLAGS@ \
+    @PCRE2_CPPFLAGS@
+
 msc_test_LDADD = @APR_LDADD@ \
     @APU_LDADD@ \
     @CURL_LDADD@ \
@@ -57,6 +59,7 @@ msc_test_LDADD = @APR_LDADD@ \
     @LIBXML2_LDADD@ \
     @LUA_LDADD@ \
     @PCRE_LDADD@ \
+    @PCRE2_LDADD@ \
     @YAJL_LDADD@ \
     @SSDEEP_CFLAGS@
 
@@ -67,6 +70,7 @@ msc_test_LDFLAGS = @APR_LDFLAGS@ \
     @LIBXML2_LDFLAGS@ \
     @LUA_LDFLAGS@ \
     @PCRE_LDFLAGS@ \
+    @PCRE2_LDFLAGS@ \
     @YAJL_LDFLAGS@ \
     @SSDEEP_LDFLAGS@
 

--- a/tests/msc_test.c
+++ b/tests/msc_test.c
@@ -81,7 +81,7 @@ char DSOLOCAL *real_server_signature = NULL;
 int DSOLOCAL remote_rules_fail_action = REMOTE_RULES_ABORT_ON_FAIL;
 char DSOLOCAL *remote_rules_fail_message = NULL;
 module AP_MODULE_DECLARE_DATA security2_module = {
-    NULL,
+    STANDARD20_MODULE_STUFF,
     NULL,
     NULL,
     NULL,


### PR DESCRIPTION
## what

This patch fixes the command `make test` behavior.

Now we can add a new workflow to GH CI.

Hint: if someone wants to help us, we should build the same matrix as we have already and run `make test`, but we can't use `--enable-assertions`, because there are some test cases where the test is with invalid syntax, therefore `assert()` reports that, and the test case will failed.

## why

Command `make test` is not able with certain build options, eg `--with-pcre2`, and with newer GCC.

