### PR TITLE
feat: add 'make test' to v2's workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,39 @@ jobs:
       - name: Show mod_security2 audit log
         if: always()
         run: sudo cat /var/log/apache2/modsec_audit.log
+
+  test-linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        platform: [x32, x64]
+        compiler: [gcc, clang]
+        configure:
+          - {label: "with pcre, no study, no jit",      opt: "--enable-pcre-study=no" }
+          - {label: "with pcre, with study, no jit",    opt: "--enable-pcre-study=yes" }
+          - {label: "with pcre, no study, with jit",    opt: "--enable-pcre-study=no --enable-pcre-jit" }
+          - {label: "with pcre, with study, with jit",  opt: "--enable-pcre-study=yes --enable-pcre-jit" }
+          - {label: "with pcre2",                       opt: "--with-pcre2 --enable-pcre-study=no" }
+          - {label: "with pcre2, with study, no jit",   opt: "--with-pcre2 --enable-pcre-study=yes" }
+          - {label: "with pcre2, no study, with jit",   opt: "--with-pcre2 --enable-pcre-study=no --enable-pcre-jit" }
+          - {label: "with pcre2, with study, with jit", opt: "--with-pcre2 --enable-pcre-study=yes --enable-pcre-jit" }
+          - {label: "with lua",                         opt: "--with-lua" }
+          - {label: "wo lua",                           opt: "--without-lua" }
+    steps:
+      - name: Setup Dependencies
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y apache2-dev libxml2-dev liblua5.1-0-dev libcurl4-gnutls-dev libpcre2-dev pkg-config libyajl-dev apache2 apache2-bin apache2-data
+      - uses: actions/checkout@v2
+      - name: autogen.sh
+        run: ./autogen.sh
+      - name: configure ${{ matrix.configure.label }}
+        run: ./configure ${{ matrix.configure.opt }} 'CFLAGS=-Werror=format-security'
+      - uses: ammaraskar/gcc-problem-matcher@master
+      - name: make
+        run: make -j `nproc`
+      - name: install module
+        run: sudo make install
+      - name: run tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Dependencies
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install -y apache2-dev libxml2-dev liblua5.1-0-dev libcurl4-gnutls-dev libpcre2-dev pkg-config libyajl-dev apache2 apache2-bin apache2-data
+          sudo apt-get install -y --no-install-recommends apache2-dev libxml2-dev liblua5.1-0-dev libcurl4-gnutls-dev libpcre2-dev pkg-config libyajl-dev apache2 apache2-bin apache2-data
       - uses: actions/checkout@v2
       - name: autogen.sh
         run: ./autogen.sh


### PR DESCRIPTION
## what

This PR adds mod_security2 module's own test cases to the GH workflow.

The new job uses the same matrix as the existing one, but we can't use `--enable-assertions` configure option (which is important with the valid configuration, where we do not use invalid values), because then the test cases which check invalid values would throw an assert error.

## why

The module's `make tests` command hasn't been working for some time, because the PCRE2 modifications weren't applied that code. With some recent PR's those part of code were aligned, so `make test` works again.
