### PR TITLE
chore: refactor build system to use PCRE2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
         platform: [x32, x64]
         compiler: [gcc, clang]
         configure:
-          - {label: "with pcre, no study, no jit",      opt: "--enable-pcre-study=no" }
-          - {label: "with pcre, with study, no jit",    opt: "--enable-pcre-study=yes" }
-          - {label: "with pcre, no study, with jit",    opt: "--enable-pcre-study=no --enable-pcre-jit" }
-          - {label: "with pcre, with study, with jit",  opt: "--enable-pcre-study=yes --enable-pcre-jit" }
-          - {label: "with pcre2",                       opt: "--with-pcre2 --enable-pcre-study=no" }
-          - {label: "with pcre2, with study, no jit",   opt: "--with-pcre2 --enable-pcre-study=yes" }
-          - {label: "with pcre2, no study, with jit",   opt: "--with-pcre2 --enable-pcre-study=no --enable-pcre-jit" }
-          - {label: "with pcre2, with study, with jit", opt: "--with-pcre2 --enable-pcre-study=yes --enable-pcre-jit" }
-          - {label: "with lua",                         opt: "--with-lua" }
-          - {label: "wo lua",                           opt: "--without-lua" }
+          - {label: "with pcre2, no study, no jit",      opt: "--enable-pcre-study=no" }
+          - {label: "with pcre2, with study, no jit",    opt: "--enable-pcre-study=yes" }
+          - {label: "with pcre2, no study, with jit",    opt: "--enable-pcre-study=no --enable-pcre-jit" }
+          - {label: "with pcre2, with study, with jit",  opt: "--enable-pcre-study=yes --enable-pcre-jit" }
+          - {label: "with pcre",                         opt: "--with-pcre --enable-pcre-study=no" }
+          - {label: "with pcre, with study, no jit",     opt: "--with-pcre --enable-pcre-study=yes" }
+          - {label: "with pcre, no study, with jit",     opt: "--with-pcre --enable-pcre-study=no --enable-pcre-jit" }
+          - {label: "with pcre, with study, with jit",   opt: "--with-pcre --enable-pcre-study=yes --enable-pcre-jit" }
+          - {label: "with lua",                          opt: "--with-lua" }
+          - {label: "wo lua",                            opt: "--without-lua" }
     steps:
       - name: Setup Dependencies
         run: |
@@ -83,16 +83,16 @@ jobs:
         platform: [x32, x64]
         compiler: [gcc, clang]
         configure:
-          - {label: "with pcre, no study, no jit",      opt: "--enable-pcre-study=no" }
-          - {label: "with pcre, with study, no jit",    opt: "--enable-pcre-study=yes" }
-          - {label: "with pcre, no study, with jit",    opt: "--enable-pcre-study=no --enable-pcre-jit" }
-          - {label: "with pcre, with study, with jit",  opt: "--enable-pcre-study=yes --enable-pcre-jit" }
-          - {label: "with pcre2",                       opt: "--with-pcre2 --enable-pcre-study=no" }
-          - {label: "with pcre2, with study, no jit",   opt: "--with-pcre2 --enable-pcre-study=yes" }
-          - {label: "with pcre2, no study, with jit",   opt: "--with-pcre2 --enable-pcre-study=no --enable-pcre-jit" }
-          - {label: "with pcre2, with study, with jit", opt: "--with-pcre2 --enable-pcre-study=yes --enable-pcre-jit" }
-          - {label: "with lua",                         opt: "--with-lua" }
-          - {label: "wo lua",                           opt: "--without-lua" }
+          - {label: "with pcre2, no study, no jit",      opt: "--enable-pcre-study=no" }
+          - {label: "with pcre2, with study, no jit",    opt: "--enable-pcre-study=yes" }
+          - {label: "with pcre2, no study, with jit",    opt: "--enable-pcre-study=no --enable-pcre-jit" }
+          - {label: "with pcre2, with study, with jit",  opt: "--enable-pcre-study=yes --enable-pcre-jit" }
+          - {label: "with pcre",                         opt: "--with-pcre --enable-pcre-study=no" }
+          - {label: "with pcre, with study, no jit",     opt: "--with-pcre --enable-pcre-study=yes" }
+          - {label: "with pcre, no study, with jit",     opt: "--with-pcre --enable-pcre-study=no --enable-pcre-jit" }
+          - {label: "with pcre, with study, with jit",   opt: "--with-pcre --enable-pcre-study=yes --enable-pcre-jit" }
+          - {label: "with lua",                          opt: "--with-lua" }
+          - {label: "wo lua",                            opt: "--without-lua" }
     steps:
       - name: Setup Dependencies
         run: |

--- a/apache2/apache2_config.c
+++ b/apache2/apache2_config.c
@@ -1343,7 +1343,7 @@ static const char *cmd_audit_log_relevant_status(cmd_parms *cmd, void *_dcfg,
     assert(p1 != NULL);
     directory_config *dcfg = _dcfg;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     dcfg->auditlog_relevant_regex = msc_pregcomp(cmd->pool, p1, PCRE2_DOTALL, NULL, NULL);
 #else
     dcfg->auditlog_relevant_regex = msc_pregcomp(cmd->pool, p1, PCRE_DOTALL, NULL, NULL);

--- a/apache2/mod_security2.c
+++ b/apache2/mod_security2.c
@@ -116,7 +116,7 @@ static void version(apr_pool_t *mp, server_rec* s) {
         ap_log_error(APLOG_MARK, APLOG_WARNING, 0, s, "ModSecurity: Loaded APR do not match with compiled!");
     }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     pcre_vrs = apr_psprintf(mp,"%d.%d ", PCRE2_MAJOR, PCRE2_MINOR);
     pcre_loaded_vrs = pcre2_loaded_vrs_buffer;
     pcre2_config(PCRE2_CONFIG_VERSION, pcre2_loaded_vrs_buffer);
@@ -126,7 +126,7 @@ static void version(apr_pool_t *mp, server_rec* s) {
 #endif
 
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL,
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
             "ModSecurity: PCRE2 compiled version=\"%s\"; "
 #else
             "ModSecurity: PCRE compiled version=\"%s\"; "

--- a/apache2/modsecurity.c
+++ b/apache2/modsecurity.c
@@ -584,7 +584,7 @@ static int is_response_status_relevant(modsec_rec *msr, int status) {
 
     rc = msc_regexec(msr->txcfg->auditlog_relevant_regex, buf, strlen(buf), &my_error_msg);
     if (rc >= 0) return 1;
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     if (rc == PCRE2_ERROR_NOMATCH) return 0;
 #else
     if (rc == PCRE_ERROR_NOMATCH) return 0;

--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -388,7 +388,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                 case HASH_URL_HREF_HASH_RX:
                     if(em[i]->type == HASH_URL_HREF_HASH_RX)   {
                         rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -421,7 +421,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                 msr_log(msr, 4, "%s.", error_msg);
                             return -1;
                         }
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
                         if (rc != PCRE_ERROR_NOMATCH) { /* Match. */
@@ -451,7 +451,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                 case HASH_URL_FACTION_HASH_RX:
                     if(em[i]->type == HASH_URL_FACTION_HASH_RX)   {
                         rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -484,7 +484,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                 msr_log(msr, 4, "%s.", error_msg);
                             return -1;
                         }
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
                         if (rc != PCRE_ERROR_NOMATCH) { /* Match. */
@@ -514,7 +514,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                 case HASH_URL_LOCATION_HASH_RX:
                     if(em[i]->type == HASH_URL_LOCATION_HASH_RX)   {
                         rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -547,7 +547,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                 msr_log(msr, 4, "%s.", error_msg);
                             return -1;
                         }
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
                         if (rc != PCRE_ERROR_NOMATCH) { /* Match. */
@@ -577,7 +577,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                 case HASH_URL_IFRAMESRC_HASH_RX:
                     if(em[i]->type == HASH_URL_IFRAMESRC_HASH_RX)   {
                         rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -610,7 +610,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                 msr_log(msr, 4, "%s.", error_msg);
                             return -1;
                         }
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
                         if (rc != PCRE_ERROR_NOMATCH) { /* Match. */
@@ -640,7 +640,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                 case HASH_URL_FRAMESRC_HASH_RX:
                     if(em[i]->type == HASH_URL_FRAMESRC_HASH_RX)   {
                         rc = msc_regexec_capture(em[i]->param_data, link, strlen(link), ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
                         if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -673,7 +673,7 @@ int do_hash_method(modsec_rec *msr, char *link, int type)   {
                                 msr_log(msr, 4, "%s.", error_msg);
                             return -1;
                         }
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
                         if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
                         if (rc != PCRE_ERROR_NOMATCH) { /* Match. */

--- a/apache2/msc_pcre.c
+++ b/apache2/msc_pcre.c
@@ -20,7 +20,7 @@
  */
 static apr_status_t msc_pcre_cleanup(msc_regex_t *regex) {
     if (regex != NULL) {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         if (regex->match_context != NULL) {
             pcre2_match_context_free(regex->match_context);
             regex->match_context = NULL;
@@ -55,7 +55,7 @@ static apr_status_t msc_pcre_cleanup(msc_regex_t *regex) {
 void *msc_pregcomp_ex(apr_pool_t *pool, const char *pattern, int options,
                       const char **_errptr, int *_erroffset,
                       int match_limit, int match_limit_recursion)
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 {
     msc_regex_t *regex = NULL;
     PCRE2_SPTR pcre2_pattern;
@@ -239,7 +239,7 @@ int msc_regexec_ex(msc_regex_t *regex, const char *s, unsigned int slen,
     if (error_msg == NULL) return -1000; /* To differentiate from PCRE as it already uses -1. */
     *error_msg = NULL;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     {
         PCRE2_SPTR pcre2_s;
         int pcre2_ret;
@@ -319,7 +319,7 @@ int msc_regexec(msc_regex_t *regex, const char *s, unsigned int slen,
  */
 int msc_fullinfo(msc_regex_t *regex, int what, void *where)
 {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     return pcre2_pattern_info(regex->re, (uint32_t)what, where);
 #else
     return pcre_fullinfo(regex->re, regex->pe, what, where);

--- a/apache2/msc_pcre.h
+++ b/apache2/msc_pcre.h
@@ -17,7 +17,7 @@
 
 typedef struct msc_regex_t msc_regex_t;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include "pcre2.h"
 #else
@@ -42,7 +42,7 @@ typedef struct msc_regex_t msc_regex_t;
 #include "modsecurity.h"
 
 struct msc_regex_t {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     pcre2_code          *re;
     pcre2_match_context *match_context;
 #ifdef WITH_PCRE_JIT

--- a/apache2/msc_status_engine.c
+++ b/apache2/msc_status_engine.c
@@ -349,7 +349,7 @@ int DSOLOCAL msc_beacon_string (char *beacon_string, int beacon_string_max_len) 
 
     apr = APR_VERSION_STRING;
     apr_loaded = apr_version_string();
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     apr_snprintf(pcre, 7, "%d.%d", PCRE2_MAJOR, PCRE2_MINOR);
     pcre_loaded = ""; /* complete this if/when status reactivated */
 #else

--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -39,7 +39,7 @@
 
 #ifdef WITH_PCRE_STUDY
 #ifdef WITH_PCRE_JIT
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 /**
  * @brief Set the JIT compile return code and JIT compile status.
  * \param regex regex structure
@@ -730,7 +730,7 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
 
     /* Compile pattern */
     if(strstr(pattern,"%{") == NULL)    {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         int options = PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY;
 #else
         int options = PCRE_DOTALL | PCRE_DOLLAR_ENDONLY;
@@ -744,7 +744,7 @@ static int msre_op_validateHash_param_init(msre_rule *rule, char **error_msg) {
 
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
-                #ifdef WITH_PCRE2
+                #ifndef WITH_PCRE
         msc_op_set_jitrc(regex, &rc, &jit);
                 #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -834,7 +834,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
                 msr_log(msr, 6, "Escaping pattern [%s]",pattern);
             }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
             options = PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY;
 #else
             options = PCRE_DOTALL | PCRE_DOLLAR_ENDONLY;
@@ -850,7 +850,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
             #ifdef WITH_PCRE_STUDY
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
-                    #ifdef WITH_PCRE2
+                    #ifndef WITH_PCRE
                 msc_op_set_jitrc(regex, &rc, &jit);
                     #else
                 rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -888,7 +888,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
      * and no memory has to be allocated for any backreferences.
      */
     rc = msc_regexec_capture(regex, target, target_length, ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
     if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -922,7 +922,7 @@ static int msre_op_validateHash_execute(modsec_rec *msr, msre_rule *rule, msre_v
         return -1;
     }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
     if (rc != PCRE_ERROR_NOMATCH) { /* Match. */
@@ -1007,7 +1007,7 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
 
     /* Compile pattern */
     if(strstr(pattern,"%{") == NULL)    {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         int options = PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY;
 #else
         int options = PCRE_DOTALL | PCRE_DOLLAR_ENDONLY;
@@ -1021,7 +1021,7 @@ static int msre_op_rx_param_init(msre_rule *rule, char **error_msg) {
 
         #ifdef WITH_PCRE_STUDY
             #ifdef WITH_PCRE_JIT
-                #ifdef WITH_PCRE2
+                #ifndef WITH_PCRE
         msc_op_set_jitrc(regex, &rc, &jit);
                 #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -1104,7 +1104,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
                 msr_log(msr, 6, "Expanded-macro pattern [%s]",pattern);
             }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         options = PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY;
 #else
         options = PCRE_DOTALL | PCRE_DOLLAR_ENDONLY;
@@ -1119,7 +1119,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
             #ifdef WITH_PCRE_STUDY
                 #ifdef WITH_PCRE_JIT
             if (msr->txcfg->debuglog_level >= 4) {
-                    #ifdef WITH_PCRE2
+                    #ifndef WITH_PCRE
                 msc_op_set_jitrc(regex, &rc, &jit);
                     #else
                 rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -1171,7 +1171,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
     /* Show when the regex captures but "capture" is not set */
     if (msr->txcfg->debuglog_level >= 6) {
         int capcount = 0;
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         rc = msc_fullinfo(regex, PCRE2_INFO_CAPTURECOUNT, &capcount);
 #else
         rc = msc_fullinfo(regex, PCRE_INFO_CAPTURECOUNT, &capcount);
@@ -1187,7 +1187,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
      * and no memory has to be allocated for any backreferences.
      */
     rc = msc_regexec_capture(regex, target, target_length, ovector, 30, &my_error_msg);
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     if ((rc == PCRE2_ERROR_MATCHLIMIT) || (rc == PCRE2_ERROR_RECURSIONLIMIT)) {
 #else
     if ((rc == PCRE_ERROR_MATCHLIMIT) || (rc == PCRE_ERROR_RECURSIONLIMIT)) {
@@ -1282,7 +1282,7 @@ static int msre_op_rx_execute(modsec_rec *msr, msre_rule *rule, msre_var *var, c
         }
     }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     if (rc != PCRE2_ERROR_NOMATCH) { /* Match. */
 #else
     if (rc != PCRE_ERROR_NOMATCH) { /* Match. */
@@ -1752,7 +1752,7 @@ static int msre_op_gsbLookup_param_init(msre_rule *rule, char **error_msg) {
     *error_msg = NULL;
 
     /* Compile rule->op_param */
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     options = PCRE2_DOTALL | PCRE2_MULTILINE;
 #else
     options = PCRE_DOTALL | PCRE_MULTILINE;
@@ -1830,7 +1830,7 @@ static int msre_op_gsbLookup_execute(modsec_rec *msr, msre_rule *rule, msre_var 
 
     memcpy(data,var->value,var->value_len);
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     options = PCRE2_NOTEMPTY;
 #else
     options = PCRE_NOTEMPTY;
@@ -2953,7 +2953,7 @@ static int msre_op_verifyCC_init(msre_rule *rule, char **error_msg) {
     if (error_msg == NULL) return -1;
     *error_msg = NULL;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     options = PCRE2_DOTALL | PCRE2_MULTILINE;
 #else
     options = PCRE_DOTALL | PCRE_MULTILINE;
@@ -3010,7 +3010,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
-            #ifdef WITH_PCRE2
+            #ifndef WITH_PCRE
         msc_op_set_jitrc(regex, &rc, &jit);
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -3050,7 +3050,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
             }
         }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         options = PCRE2_NOTEMPTY;
 #else
         options = PCRE_NOTEMPTY;
@@ -3058,7 +3058,7 @@ static int msre_op_verifyCC_execute(modsec_rec *msr, msre_rule *rule, msre_var *
         rc = msc_regexec_ex(regex, target, target_length, offset, options, ovector, 30, &my_error_msg);
 
         /* If there was no match, then we are done. */
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         if (rc == PCRE2_ERROR_NOMATCH) {
 #else
         if (rc == PCRE_ERROR_NOMATCH) {
@@ -3280,7 +3280,7 @@ static int msre_op_verifyCPF_init(msre_rule *rule, char **error_msg) {
 
     *error_msg = NULL;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     options = PCRE2_DOTALL | PCRE2_MULTILINE;
 #else
     options = PCRE_DOTALL | PCRE_MULTILINE;
@@ -3349,7 +3349,7 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
-            #ifdef WITH_PCRE2
+            #ifndef WITH_PCRE
         msc_op_set_jitrc(regex, &rc, &jit);
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -3388,7 +3388,7 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
             }
         }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         options = PCRE2_NOTEMPTY;
 #else
         options = PCRE_NOTEMPTY;
@@ -3396,7 +3396,7 @@ static int msre_op_verifyCPF_execute(modsec_rec *msr, msre_rule *rule, msre_var 
         rc = msc_regexec_ex(regex, target, target_length, offset, options, ovector, 30, &my_error_msg);
 
         /* If there was no match, then we are done. */
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         if (rc == PCRE2_ERROR_NOMATCH) {
 #else
         if (rc == PCRE_ERROR_NOMATCH) {
@@ -3603,7 +3603,7 @@ static int msre_op_verifySSN_init(msre_rule *rule, char **error_msg) {
     if (error_msg == NULL) return -1;
     *error_msg = NULL;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     options = PCRE2_DOTALL | PCRE2_MULTILINE;
 #else
     options = PCRE_DOTALL | PCRE_MULTILINE;
@@ -3674,7 +3674,7 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
     #ifdef WITH_PCRE_STUDY
         #ifdef WITH_PCRE_JIT
     if (msr->txcfg->debuglog_level >= 4) {
-            #ifdef WITH_PCRE2
+            #ifndef WITH_PCRE
         msc_op_set_jitrc(regex, &rc, &jit);
             #else
         rc = msc_fullinfo(regex, PCRE_INFO_JIT, &jit);
@@ -3713,7 +3713,7 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
             }
         }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         options = PCRE2_NOTEMPTY;
 #else
         options = PCRE_NOTEMPTY;
@@ -3721,7 +3721,7 @@ static int msre_op_verifySSN_execute(modsec_rec *msr, msre_rule *rule, msre_var 
         rc = msc_regexec_ex(regex, target, target_length, offset, options, ovector, 30, &my_error_msg);
 
         /* If there was no match, then we are done. */
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         if (rc == PCRE2_ERROR_NOMATCH) {
 #else
         if (rc == PCRE_ERROR_NOMATCH) {

--- a/apache2/re_variables.c
+++ b/apache2/re_variables.c
@@ -22,7 +22,7 @@
 
 #include "libxml/xpathInternals.h"
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 #define PCRE_ERROR_NOMATCH PCRE2_ERROR_NOMATCH
 #endif
 /**
@@ -80,7 +80,7 @@ static char *var_generic_list_validate(msre_ruleset *ruleset, msre_var *var) {
         pattern = apr_pstrmemdup(ruleset->mp, var->param + 1, strlen(var->param + 1) - 1);
         if (pattern == NULL) return FATAL_ERROR;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         options = PCRE2_DOTALL | PCRE2_CASELESS | PCRE2_DOLLAR_ENDONLY;
 #else
         options = PCRE_DOTALL | PCRE_CASELESS | PCRE_DOLLAR_ENDONLY;

--- a/build/find_pcre.m4
+++ b/build/find_pcre.m4
@@ -29,7 +29,7 @@ AS_CASE(["${with_pcre}"],
 if test "x${with_pcre}" = "x" || test "x${with_pcre}" = "xno"; then
     AC_MSG_NOTICE([pcre not specified; omitting check for pcre])
 else
-    AC_MSG_CHECKING([for libpcre configig script])
+    AC_MSG_CHECKING([for libpcre config script])
 
     for x in ${test_paths}; do
         dnl # Determine if the script was specified and use it directly

--- a/build/find_pcre.m4
+++ b/build/find_pcre.m4
@@ -19,19 +19,17 @@ AC_ARG_WITH(
     pcre,
     [AS_HELP_STRING([--with-pcre=PATH],[Path to pcre prefix or config script])],
     [test_paths="${with_pcre}"],
-    [test_paths="/usr/local/libpcre /usr/local/pcre /usr/local /opt/libpcre /opt/pcre /opt /usr"])
+    [with_pcre="no"])
 
-if test "x${with_pcre2}" != "x" && test "x${with_pcre2}" != "xno"; then
-    AC_MSG_NOTICE([pcre2 specified; omitting check for pcre])
+AS_CASE(["${with_pcre}"],
+    [no], [test_paths=],
+    [yes], [test_paths="/usr/local/libpcre /usr/local/pcre /usr/local /opt/libpcre /opt/pcre /opt /usr"],
+    [test_paths="${with_pcre}"])
+
+if test "x${with_pcre}" = "x" || test "x${with_pcre}" = "xno"; then
+    AC_MSG_NOTICE([pcre not specified; omitting check for pcre])
 else
-    AC_MSG_CHECKING([for libpcre config script])
-
-    dnl # Determine pcre lib directory
-    if test -z "${with_pcre}"; then
-        test_paths="/usr/local/pcre /usr/local /usr"
-    else
-        test_paths="${with_pcre}"
-    fi
+    AC_MSG_CHECKING([for libpcre configig script])
 
     for x in ${test_paths}; do
         dnl # Determine if the script was specified and use it directly
@@ -87,7 +85,8 @@ else
         AC_MSG_NOTICE([*** pcre library not found.])
     else
         AC_MSG_NOTICE([using pcre v${PCRE_VERSION}])
-        ifelse([$1], , , $1) 
-    fi 
+        PCRE_CFLAGS="-DWITH_PCRE ${PCRE_CFLAGS}"
+        ifelse([$1], , , $1)
+    fi
 fi
 ])

--- a/build/find_pcre2.m4
+++ b/build/find_pcre2.m4
@@ -18,17 +18,17 @@ AC_DEFUN([CHECK_PCRE2],
 AC_ARG_WITH(
     pcre2,
     [AS_HELP_STRING([--with-pcre2=PATH],[Path to pcre2 prefix or config script])],
-    , with_pcre2=no)
+    [test_paths="${with_pcre2}"],
+    [with_pcre2="yes"])
 
 AS_CASE(["${with_pcre2}"],
-  [no], [test_paths=],
-  [yes], [test_paths="/usr/local/libpcre2 /usr/local/pcre2 /usr/local /opt/libpcre2 /opt/pcre2 /opt /usr"],
-  [test_paths="${with_pcre2}"])
+    [no], [test_paths=],
+    [yes], [test_paths="/usr/local/libpcre2 /usr/local/pcre2 /usr/local /opt/libpcre2 /opt/pcre2 /opt /usr"],
+    [test_paths="${with_pcre2}"])
 
-if test "x${with_pcre2}" = "x" || test "x${with_pcre2}" = "xno"; then
-    AC_MSG_NOTICE([pcre2 not specified; omitting check])
+if test "x${with_pcre}" != "x" || test "x${with_pcre}" != "xno"; then
+    AC_MSG_NOTICE([pcre specified; omitting check for pcre2])
 else
-
     AC_MSG_CHECKING([for libpcre2 config script])
 
     for x in ${test_paths}; do
@@ -86,8 +86,8 @@ else
         ifelse([$2], , AC_MSG_ERROR([pcre2 library is required]), $2)
     else
         AC_MSG_NOTICE([using pcre2 v${PCRE2_VERSION}])
-        PCRE2_CFLAGS="-DWITH_PCRE2 ${PCRE2_CFLAGS}"
-        ifelse([$1], , , $1) 
+        PCRE2_CFLAGS="${PCRE2_CFLAGS}"
+        ifelse([$1], , , $1)
     fi 
 fi
 ])

--- a/build/find_pcre2.m4
+++ b/build/find_pcre2.m4
@@ -26,7 +26,7 @@ AS_CASE(["${with_pcre2}"],
     [yes], [test_paths="/usr/local/libpcre2 /usr/local/pcre2 /usr/local /opt/libpcre2 /opt/pcre2 /opt /usr"],
     [test_paths="${with_pcre2}"])
 
-if test "x${with_pcre}" != "x" || test "x${with_pcre}" != "xno"; then
+if test "x${with_pcre}" != "x" && test "x${with_pcre}" != "xno"; then
     AC_MSG_NOTICE([pcre specified; omitting check for pcre2])
 else
     AC_MSG_CHECKING([for libpcre2 config script])

--- a/mlogc/mlogc.c
+++ b/mlogc/mlogc.c
@@ -28,7 +28,7 @@
 #if APR_HAVE_UNISTD_H
 #include <unistd.h>         /* for getpid() */
 #endif
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
 #else
@@ -152,7 +152,7 @@ static int                    keep_alive = 150;           /* Not used yet. */
 static int                    keep_alive_timeout = 300;   /* Not used yet. */
 static int                    keep_entries = 0;
 static const char            *log_repository = NULL;
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 static pcre2_code            *logline_regex = NULL;
 static pcre2_code            *requestline_regex = NULL;
 #else
@@ -1218,7 +1218,7 @@ static void logc_init(void)
     int i, erroffset;
     /* cURL major, minor and patch version */
     short cmaj, cmin, cpat = 0;
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     int pcre2_errorcode = 0;
     PCRE2_SIZE pcre2_erroffset = 0;
 #endif
@@ -1325,7 +1325,7 @@ static void logc_init(void)
     	error_log(LOG_DEBUG2, NULL, "TLSv1.2 is unsupported in cURL %d.%d.%d",  cmaj, cmin, cpat);
     }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     logline_regex = pcre2_compile(logline_pattern, PCRE2_ZERO_TERMINATED, PCRE2_CASELESS,
                                  &pcre2_errorcode, &pcre2_erroffset, NULL);
 #else
@@ -1338,7 +1338,7 @@ static void logc_init(void)
         logc_shutdown(1);
     }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     requestline_regex = pcre2_compile(requestline_pattern, PCRE2_ZERO_TERMINATED, PCRE2_CASELESS,
                                      &pcre2_errorcode, &pcre2_erroffset, NULL);
 #else
@@ -1455,7 +1455,7 @@ static void * APR_THREAD_FUNC thread_worker(apr_thread_t *thread, void *data)
     apr_status_t rc;
     apr_finfo_t finfo;
     int capturevector[CAPTUREVECTORSIZE];
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     pcre2_match_data *pcre2_match_data = NULL;
 #endif
     int take_new = 1;
@@ -1563,7 +1563,7 @@ static void * APR_THREAD_FUNC thread_worker(apr_thread_t *thread, void *data)
             num_requests++;
         }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
         pcre2_match_data  = pcre2_match_data_create_from_pattern(logline_regex, NULL);
         rc = pcre2_match(logline_regex, entry->line, entry->line_size, 0, 0,
             pcre2_match_data, NULL);
@@ -2334,7 +2334,7 @@ static void usage(void) {
  * Version text.
  */
 static void version(void) {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     char pcre2_loaded_version_buffer[80] ={0};
     char *pcre_loaded_version = pcre2_loaded_version_buffer;
     pcre2_config(PCRE2_CONFIG_VERSION, pcre_loaded_version);
@@ -2346,7 +2346,7 @@ static void version(void) {
             "loaded=\"%s\"\n", APR_VERSION_STRING, apr_version_string());
     fprintf(stderr,
             "  PCRE: compiled=\"%d.%d\"; "
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
             "loaded=\"%s\"\n", PCRE2_MAJOR, PCRE2_MINOR, pcre_loaded_version);
 #else
             "loaded=\"%s\"\n", PCRE_MAJOR, PCRE_MINOR, pcre_version());

--- a/standalone/regex.c
+++ b/standalone/regex.c
@@ -61,7 +61,7 @@ AP_DECLARE(ap_regex_t *) ap_pregcomp(apr_pool_t *p, const char *pattern,
 
 AP_DECLARE(void) ap_regfree(ap_regex_t *preg)
 {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 (pcre2_code_free)(preg->re_pcre);
 #else
 (pcre_free)(preg->re_pcre);
@@ -75,7 +75,7 @@ int erroffset;
 int options = 0;
 int nsub = 0;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 if ((cflags & AP_REG_ICASE) != 0) options |= PCRE2_CASELESS;
 if ((cflags & AP_REG_NEWLINE) != 0) options |= PCRE2_MULTILINE;
 int error_number = 0;
@@ -120,7 +120,7 @@ int *ovector = NULL;
 int small_ovector[POSIX_MALLOC_THRESHOLD * 3];
 int allocated_ovector = 0;
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 if ((eflags & AP_REG_NOTBOL) != 0) options |= PCRE2_NOTBOL;
 if ((eflags & AP_REG_NOTEOL) != 0) options |= PCRE2_NOTEOL;
 #else
@@ -144,7 +144,7 @@ if (nmatch > 0)
     }
   }
 
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
 {
   PCRE2_SPTR pcre2_s;
   int pcre2_ret;
@@ -202,7 +202,7 @@ else
   if (allocated_ovector) free(ovector);
   switch(rc)
     {
-#ifdef WITH_PCRE2
+#ifndef WITH_PCRE
     case PCRE2_ERROR_NOMATCH: return AP_REG_NOMATCH;
     case PCRE2_ERROR_NULL: return AP_REG_INVARG;
     case PCRE2_ERROR_BADOPTION: return AP_REG_INVARG;


### PR DESCRIPTION
## what

This PR refactors the build system and the relevant source files to make the PCRE2 library as default. If you wish to continue building with the legacy PCRE library, you must explicitly specify it using the following command:
configure `--with-pcre`. Without that the default will be PCRE2.

The PR also changes the GH worfklow build matrix.

## why

Old PCRE library is deprecated, it's time to change to PCRE2.

## references

See the same change in [v3](https://github.com/owasp-modsecurity/ModSecurity/pull/3321).

This PR is based on #3345, but that wasn't finished.

