### PR TITLE
chore: prepare v2.9.9

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
-(to be released) - 2.9.x
-------------------------
+21 May 2025 - 2.9.9
+-------------------
 
+ * fix: Possible DoS vulnerability
+   [PR from private repo - @theseion, @fzipi, @airween; fixed CVE-2025-47947]
  * chore: log error codes for global mutex failure modes.
    [Issue #3387 - @airween]
  * chore: refactor build system to use PCRE2

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 21 May 2025 - 2.9.9
 -------------------
 
- * fix: Possible DoS vulnerability
+ * fix: DoS vulnerability
    [PR from private repo - @theseion, @fzipi, @airween; fixed CVE-2025-47947]
  * chore: log error codes for global mutex failure modes.
    [Issue #3387 - @airween]

--- a/apache2/msc_release.h
+++ b/apache2/msc_release.h
@@ -38,7 +38,7 @@
 
 #define MODSEC_VERSION_MAJOR       "2"
 #define MODSEC_VERSION_MINOR       "9"
-#define MODSEC_VERSION_MAINT       "8"
+#define MODSEC_VERSION_MAINT       "9"
 #define MODSEC_VERSION_TYPE        ""
 #define MODSEC_VERSION_RELEASE     ""
 


### PR DESCRIPTION
## what

This PR prepares new release of mod_security2: 2.9.9

## why

The source tree has several modifications and a critical bug fix.

See [CVE-2025-47947](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2025-47947).
