### PR TITLE
Buildsystem fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,7 @@ cppcheck:
 		--enable=warning,style,performance,portability,unusedFunction,missingInclude \
 		--inconclusive \
 		--template="warning: {file},{line},{severity},{id},{message}" \
-		-I headers -I . -I others -I src -I others/mbedtls/include \
+		-I headers -I . -I $(top_srcdir)/others -I $(top_srcdir)/src -I $(top_srcdir)/others/mbedtls/include \
 		--error-exitcode=1 \
 		-i "src/parser/seclang-parser.cc" -i "src/parser/seclang-scanner.cc" \
 		-i others \

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_PREFIX_DEFAULT([/usr/local/modsecurity])
 
 
 # General automake options.
-AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
 
 
 # Check for dependencies (C++, AR, Lex, Yacc and Make)

--- a/others/Makefile.am
+++ b/others/Makefile.am
@@ -28,6 +28,6 @@ libmbedtls_la_SOURCES = \
 	mbedtls/library/sha1.c \
 	mbedtls/library/platform_util.c
 
-libmbedtls_la_CFLAGS = -DMBEDTLS_CONFIG_FILE=\"mbedtls/mbedtls_config.h\" -Imbedtls/include
+libmbedtls_la_CFLAGS = -DMBEDTLS_CONFIG_FILE=\"mbedtls/mbedtls_config.h\" -I$(top_srcdir)/others/mbedtls/include
 libmbedtls_la_CPPFLAGS =
 libmbedtls_la_LIBADD =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -68,21 +68,21 @@ libmodsecurity_includesub_actions_HEADERS = \
 
 
 noinst_HEADERS = \
-	actions/*.h \
-	actions/ctl/*.h \
-	actions/data/*.h \
-	actions/disruptive/*.h \
-	actions/transformations/*.h \
-	debug_log/*.h \
-	audit_log/writer/*.h \
-	collection/backend/*.h \
-	operators/*.h \
-	parser/*.h \
-	request_body_processor/*.h \
-	utils/*.h \
-	variables/*.h \
-	engine/*.h \
-	*.h
+	$(wildcard actions/*.h) \
+	$(wildcard actions/ctl/*.h) \
+	$(wildcard actions/data/*.h) \
+	$(wildcard actions/disruptive/*.h) \
+	$(wildcard actions/transformations/*.h) \
+	$(wildcard debug_log/*.h) \
+	$(wildcard audit_log/writer/*.h) \
+	$(wildcard collection/backend/*.h) \
+	$(wildcard operators/*.h) \
+	$(wildcard parser/*.h) \
+	$(wildcard request_body_processor/*.h) \
+	$(wildcard utils/*.h) \
+	$(wildcard variables/*.h) \
+	$(wildcard engine/*.h) \
+	$(wildcard *.h)
 
 
 ENGINES = \
@@ -308,13 +308,14 @@ libmodsecurity_la_CFLAGS =
 
 
 libmodsecurity_la_CPPFLAGS = \
-	-I.. \
+	-I$(top_srcdir) \
+	-I$(top_builddir) \
 	-g \
-	-I../others \
-	-I../others/mbedtls/include \
+	-I$(top_srcdir)/others \
+	-I$(top_srcdir)/others/mbedtls/include \
 	-fPIC \
 	-O3 \
-	-I../headers \
+	-I$(top_srcdir)/headers \
 	$(CURL_CFLAGS) \
 	$(GEOIP_CFLAGS) \
 	$(GLOBAL_CPPFLAGS) \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -72,7 +72,7 @@ unit_tests_LDFLAGS = \
 
 unit_tests_CPPFLAGS = \
 	-Icommon \
-	-I$(srcdir)/../ \
+	-I$(top_srcdir)/ \
 	-g \
 	-I$(top_builddir)/headers \
 	$(CURL_CFLAGS) \
@@ -127,7 +127,7 @@ regression_tests_LDFLAGS = \
 
 regression_tests_CPPFLAGS = \
 	-Icommon \
-	-I$(srcdir)../ \
+	-I$(top_srcdir) \
 	-g \
 	-I$(top_builddir)/headers \
 	$(CURL_CFLAGS) \
@@ -179,7 +179,7 @@ rules_optimization_LDFLAGS = \
 
 rules_optimization_CPPFLAGS = \
 	-Icommon \
-	-I$(srcdir)/../ \
+	-I$(top_srcdir)/ \
 	-g \
 	-I$(top_builddir)/headers \
 	$(CURL_CFLAGS) \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -72,7 +72,7 @@ unit_tests_LDFLAGS = \
 
 unit_tests_CPPFLAGS = \
 	-Icommon \
-	-I../ \
+	-I$(srcdir)/../ \
 	-g \
 	-I$(top_builddir)/headers \
 	$(CURL_CFLAGS) \
@@ -127,7 +127,7 @@ regression_tests_LDFLAGS = \
 
 regression_tests_CPPFLAGS = \
 	-Icommon \
-	-I../ \
+	-I$(srcdir)../ \
 	-g \
 	-I$(top_builddir)/headers \
 	$(CURL_CFLAGS) \
@@ -179,7 +179,7 @@ rules_optimization_LDFLAGS = \
 
 rules_optimization_CPPFLAGS = \
 	-Icommon \
-	-I../ \
+	-I$(srcdir)/../ \
 	-g \
 	-I$(top_builddir)/headers \
 	$(CURL_CFLAGS) \

--- a/tools/rules-check/Makefile.am
+++ b/tools/rules-check/Makefile.am
@@ -26,7 +26,8 @@ modsec_rules_check_LDFLAGS = \
 	$(LMDB_LDFLAGS) \
 	$(LUA_LDFLAGS) \
 	$(SSDEEP_LDFLAGS) \
-	$(YAJL_LDFLAGS)
+	$(YAJL_LDFLAGS) \
+	$(LIBXML2_LDFLAGS)
 
 modsec_rules_check_CPPFLAGS = \
 	-I$(top_builddir)/headers \


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

* These changes fix the build for srcdir != builddir.  At several points in the buildsystem relative (to the Makefile) paths were used. this does not work if a clean builddir is used, as the Makefile and generated headers reside in the builddir. auttools provide the variables `$(top_srcdir)` and `$(top_builddir)` to refer to the srcdir and builddir respectively
* If libxml2 is installed in a non-default location linking to libxml2 fails due to a missing LIBXML2_LDFLAGS
* autotools don't support wildcards (see link to documentation below). 

* Note: Because these fixes use a GNU make extension, the build for non-GNU make is broken. If non-GNU make is supported by modsecurity, most likely the files need to be added explicitly. automake warns about this portability, thats why Werror was removed from automake options
* Note2: I only fixed my configuration, there might be other optional parts of modsecurity, that make the same assumptions, which I did not touch. 

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why


<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

* https://www.gnu.org/software/automake/manual/html_node/Wildcards.html  Automake documentation, why wildcards are not supported.

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
