### PR TITLE
Fix resource leaks in `msc_status_engine_mac_address`

### DIFF
--- a/apache2/msc_status_engine.c
+++ b/apache2/msc_status_engine.c
@@ -182,7 +182,7 @@ int DSOLOCAL msc_status_engine_mac_address (unsigned char *mac)
                 (unsigned char)LLADDR(sdl)[3],
                 (unsigned char)LLADDR(sdl)[4],
                 (unsigned char)LLADDR(sdl)[5]);
-            goto end;
+            break;
         }
     }
 
@@ -225,7 +225,7 @@ int DSOLOCAL msc_status_engine_mac_address (unsigned char *mac)
                 (unsigned char)ifr->ifr_addr.sa_data[4],
                 (unsigned char)ifr->ifr_addr.sa_data[5]);
 
-            goto end;
+            break;
         }
     }
     close( sock );
@@ -268,7 +268,7 @@ int DSOLOCAL msc_status_engine_mac_address (unsigned char *mac)
                 (unsigned char)pAdapter->Address[3],
                 (unsigned char)pAdapter->Address[4],
                 (unsigned char)pAdapter->Address[5]);
-            goto end;
+            break;
         }
         pAdapter = pAdapter->Next;
     }
@@ -276,7 +276,6 @@ int DSOLOCAL msc_status_engine_mac_address (unsigned char *mac)
     free(pAdapterInfo);
 #endif
 
-end:
     return 0;
 failed:
     return -1;


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

Close the socket created and free the memory allocated in `msc_status_engine_mac_address()` in all code paths.

## why

Linux:

The socket is used only temporarily. Current implementation leaks the socket. For example, if `SecRemoteRules` is used anywhere in the config, `systemctl reload httpd`/`systemctl reload apache2` increases the count of open sockets in all Apache processes (well, it happens in the main process, and forked ones just inherit the problem).

Other platforms:

`goto end` just jumped over the calls freeing the memory.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
