### PR TITLE
Fix memory/socket leak in `UniqueId::ethernetMacAddress()`

### DIFF
--- a/src/unique_id.cc
+++ b/src/unique_id.cc
@@ -134,7 +134,7 @@ std::string UniqueId::ethernetMacAddress() {
                 (unsigned char)LLADDR(sdl)[3],
                 (unsigned char)LLADDR(sdl)[4],
                 (unsigned char)LLADDR(sdl)[5]);
-            goto end;
+            break;
         }
     }
 
@@ -177,7 +177,7 @@ std::string UniqueId::ethernetMacAddress() {
                 (unsigned char)ifr->ifr_addr.sa_data[4],
                 (unsigned char)ifr->ifr_addr.sa_data[5]);
 
-            goto end;
+            break;
         }
     }
     close(sock);
@@ -219,7 +219,7 @@ std::string UniqueId::ethernetMacAddress() {
                 (unsigned char)pAdapter->Address[3],
                 (unsigned char)pAdapter->Address[4],
                 (unsigned char)pAdapter->Address[5]);
-            goto end;
+            break;
         }
         pAdapter = pAdapter->Next;
     }
@@ -227,9 +227,6 @@ std::string UniqueId::ethernetMacAddress() {
     free(pAdapterInfo);
 #endif
 
-#if defined(__linux__) || defined(__gnu_linux__) || defined(DARWIN) || defined(WIN32)
-end:
-#endif
     return std::string(reinterpret_cast<const char *>(mac));
 #if defined(__linux__) || defined(__gnu_linux__) || defined(DARWIN) || defined(WIN32)
 failed:


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

Don't jump over `close()`/`free()` calls. Release the resources correctly in all code paths.

## why

Currently, there are memory, and, in case of Linux, socket leaks. `goto end` jumps over the calls that are supposed to release the memory/close the socket.

## references

Initially discovered this on v2 - https://github.com/owasp-modsecurity/ModSecurity/pull/3391 - but turns out the code is the same on v3 too.