### PR TITLE
Add hostname to JSON log

### DIFF
--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1601,6 +1601,7 @@ std::string Transaction::toJSON(int parts) {
             m_variableRequestMethod.evaluate()));
 
     LOGFY_ADD("http_version", m_httpVersion);
+    LOGFY_ADD("hostname", m_requestHostName);
     LOGFY_ADD("uri", this->m_uri);
 
     if (parts & audit_log::AuditLog::CAuditLogPart) {


### PR DESCRIPTION
## what

Add hostname to JSON log

## why

Hostname that is set by `msc_set_request_hostname` method is not included in JSON log.
