### PR TITLE
fix: change the format of the ascTime() function

### DIFF
--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -74,7 +74,7 @@ inline std::string ascTime(const time_t *t) {
     struct tm timeinfo;
     localtime_r(t, &timeinfo);
     char tstr[std::size("Www Mmm dd hh:mm:ss yyyy")];
-    strftime(tstr, std::size(tstr), "%c", &timeinfo);
+    strftime(tstr, std::size(tstr), "%a %b %d %H:%M:%S %Y", &timeinfo);
     return tstr;
 }
 

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -74,7 +74,11 @@ inline std::string ascTime(const time_t *t) {
     struct tm timeinfo;
     localtime_r(t, &timeinfo);
     char tstr[std::size("Www Mmm dd hh:mm:ss yyyy")];
-    strftime(tstr, std::size(tstr), "%a %b %d %H:%M:%S %Y", &timeinfo);
+    // `%c` is equivalent to `%a %b %e %T %Y` with a fixed length, even though zero-padded
+    // month of day is optional, depending on the locale. This would lead to an empty space, e.g.,
+    // `Sat Jun  7 11:46:23 2025` (notice the two spaces before the day of month).
+    // Use `%d` instead and enforce padding.
+    strftime(tstr, std::size(tstr), "%a %b %d %T %Y", &timeinfo);
     return tstr;
 }
 


### PR DESCRIPTION
## what

This PR changes the format of [utils::string::ascTime()](https://github.com/owasp-modsecurity/ModSecurity/commit/6248ac1c166b22f4de82680c5ceb26377d1d4e72#diff-e71d5c46f8ce20d4b7e76eb815fc9a3866ab8c854d62e54b9e2fa92bee98be13R77).

The function is used only in one place, in [transaction.cc](https://github.com/owasp-modsecurity/ModSecurity/blob/6248ac1c166b22f4de82680c5ceb26377d1d4e72/src/transaction.cc#L1568), it produces the field `time_stamp` if the audit log format is JSON, for eg.:

```json
{"transaction":{"client_ip":"200.249.12.31","time_stamp":"Sat Jun 07 11:46:23 2025"}}
```

## why

The old (actual) format of that function is `%c`, which is the expected format, but as the documentation writes:

_writes **standard date and time string**, e.g. Sun Oct 17 04:41:13 2010 (locale dependent)_

it's **locale dependent**. This means if the locale uses only 1 digit for the day, then the test is failed, see [this](https://github.com/owasp-modsecurity/ModSecurity/pull/3390#issuecomment-2952210396) comment. The log in that case will look like this:

```json
{"transaction":{"client_ip":"200.249.12.31","time_stamp":"Sat Jun  7 11:46:23 2025"}}
```
Please note that there are two spaces and 1 digit.

This modification changes the format and if the day is below 10, then adds a leading zero, without extra space.

## references

C++ reference of [strftime](https://en.cppreference.com/w/c/chrono/strftime).

## other notes

**Please review this PR carefully as it may break audit log file JSON parsers if the server localization uses a single-digit date representation.**
