### PR TITLE
Plug memory leak when msre_op_validateSchema_execute() exits normally (validateSchema)

### DIFF
--- a/apache2/re_operators.c
+++ b/apache2/re_operators.c
@@ -2898,6 +2898,7 @@ static int msre_op_validateSchema_execute(modsec_rec *msr, msre_rule *rule, msre
 
     xmlSchemaFree(schema);
     xmlSchemaFreeValidCtxt(validCtx);
+    xmlSchemaFreeParserCtxt(parserCtx);
 
     return 0;
 }


### PR DESCRIPTION

<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

validateSchema rule leaks memory under normal exit

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Add explicit xmlSchemaFreeParserCtxt call

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Because sometimes memory is not an infinite resource

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
