### PR TITLE
fix: remove unused condition from msc_status_engine.c

### DIFF
--- a/apache2/msc_status_engine.c
+++ b/apache2/msc_status_engine.c
@@ -173,7 +173,7 @@ int DSOLOCAL msc_status_engine_mac_address (unsigned char *mac)
     for ( ifap = ifaphead; ifap; ifap = ifap->ifa_next ) {
         struct sockaddr_dl* sdl = (struct sockaddr_dl*)ifap->ifa_addr;
         if ( sdl && ( sdl->sdl_family == AF_LINK ) && ( sdl->sdl_type == IFT_ETHER )
-                && mac[0] && mac[1] && mac[2] && i < 6) {
+                && mac[0] && mac[1] && mac[2]) {
 
             apr_snprintf(mac, MAC_ADDRESS_SIZE, "%02x:%02x:%02x:%02x:%02x:%02x",
                 (unsigned char)LLADDR(sdl)[0],


### PR DESCRIPTION
## what

This PR removes an unused condition from `msc_status_engin.c` if the target is `DARWIN`.

## why

In one of a previous [commit](https://github.com/owasp-modsecurity/ModSecurity/commit/9d9a72734988bbd4f101cbea0d5df60eabcc1435#diff-1c8f9a366617177bdf8e978ba4be1230c2086c1f4d2338cb5e14e21b8162504eL167) we removed some unused variables, but it seems like it's still in use.

Unfortunately this was not revealed because that part is only used if the target is `DARWIN`.

## references

* issue: #3410 
* initial [commit](https://github.com/owasp-modsecurity/ModSecurity/blob/0c6a661c696e0cb248cf79e32a20aaccb95c3926/apache2/msc_status_engine.c#L128-L144)
* remove loop which used that variable [commit](https://github.com/owasp-modsecurity/ModSecurity/blob/410aca9d78db14e5c18667377c70e03e37deef1a/apache2/msc_status_engine.c#L157-L178)

Thanks @Greentears.