### PR TITLE
fix: clean matched vars after chained and non-chained rule

### DIFF
--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -355,6 +355,9 @@ end_exec:
 
     /* last rule in the chain. */
     performLogging(trans, ruleMessage, true, true);
+    if (m_ruleId > 0) {
+        cleanMatchedVars(trans);
+    }
     return true;
 }
 

--- a/test/test-cases/regression/variable-MATCHED_VAR.json
+++ b/test/test-cases/regression/variable-MATCHED_VAR.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR (1/2)",
+    "title":"Testing Variables :: MATCHED_VAR (1/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -42,7 +42,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR (2/2)",
+    "title":"Testing Variables :: MATCHED_VAR (2/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -80,6 +80,129 @@
 
       "SecRule MATCHED_VAR \"@contains other_value\" \"id:29,pass\"",
       "SecRule MATCHED_VAR \"@contains other_value\" \"id:30,pass\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR (3/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR \"@eq 1\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR (4/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR \"@eq 2\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR (5/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VAR \"@eq 2\""
     ]
   }
 ]

--- a/test/test-cases/regression/variable-MATCHED_VARS.json
+++ b/test/test-cases/regression/variable-MATCHED_VARS.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS (1/2)",
+    "title":"Testing Variables :: MATCHED_VARS (1/6)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -43,7 +43,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS (2/2)",
+    "title":"Testing Variables :: MATCHED_VARS (2/6)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -80,6 +80,170 @@
       "SecRule ARGS:keyII \"@contains other_value\" \"chain\"",
       "SecRule MATCHED_VARS \"@contains asdf\" \"\"",
       "SecRule MATCHED_VARS \"@contains value\" \"id:29\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (3/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS \"@contains 1\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (4/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS \"@contains 2\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (5/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS \"@within 1 2\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (6/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VARS \"@eq 2\""
     ]
   }
 ]

--- a/test/test-cases/regression/variable-MATCHED_VARS_NAMES.json
+++ b/test/test-cases/regression/variable-MATCHED_VARS_NAMES.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS_NAMES (1/2)",
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (1/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -43,7 +43,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS_NAMES (2/2)",
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (2/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -80,6 +80,129 @@
       "SecRule ARGS:keyII \"@contains other_value\" \"chain\"",
       "SecRule MATCHED_VARS_NAMES \"@contains asdf\" \"\"",
       "SecRule MATCHED_VARS_NAMES \"@contains value\" \"id:29\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (3/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS_NAMES \"@within ARGS:foo ARGS:bar ARGS:baz\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (4/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VARS_NAMES \"@strEq ARGS:foo\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (5/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VARS_NAMES \"@within ARGS:bar ARGS:baz\""
     ]
   }
 ]

--- a/test/test-cases/regression/variable-MATCHED_VAR_NAME.json
+++ b/test/test-cases/regression/variable-MATCHED_VAR_NAME.json
@@ -283,7 +283,7 @@
       "SecRuleEngine On",
       "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
       "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
-      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:baz\""
+      "SecRule MATCHED_VAR_NAME \"@within ARGS:baz ARGS:bar\""
     ]
   }
 ]

--- a/test/test-cases/regression/variable-MATCHED_VAR_NAME.json
+++ b/test/test-cases/regression/variable-MATCHED_VAR_NAME.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR_NAME (1/3)",
+    "title":"Testing Variables :: MATCHED_VAR_NAME (1/7)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -43,7 +43,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR_NAME (2/3)",
+    "title":"Testing Variables :: MATCHED_VAR_NAME (2/7)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -85,7 +85,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR_NAME (3/3)",
+    "title":"Testing Variables :: MATCHED_VAR_NAME (3/7)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -121,6 +121,169 @@
       "SecRule ARGS_NAMES \"@contains ey1\" \"chain,id:30,pass\"",
       "SecRule MATCHED_VAR_NAME \"@contains key1\" \"id:31\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (4/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:foo\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (5/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:bar\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (6/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:baz\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (7/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:baz\""
+    ]
   }
 ]
-


### PR DESCRIPTION
## what

This PR changes the code behavior: now the engine cleans the `MATCHED_VAR*` variables after chained and non-chained rules too.

## why

Until now if there was a single (non-chained) rule, and if any of the `MATCHED_VAR*` variable were filled, then the next rule which used them accessed the filled value, even the rule does not use `chain` action.

## references

See issue #3382.

This PR fixes #3382.

## other notes

please see commit [5572ac0](https://github.com/airween/ModSecurity/commit/5572ac0798c2afb728c5bc665900636edb8db91c); I added this change because the first test on Windows was [failed](https://github.com/airween/ModSecurity/actions/runs/16276603396/job/45956909406#step:8:309). It seems like the argument processing order is non-deterministic, at least it's different on Windows (see the log: the first argument is the last from the `QUERY_STRING`, and the tests were success on all other platforms).