### PR TITLE
Fix SecRequestBody(NoFiles)Limit overflow

### DIFF
--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -71,9 +71,9 @@ using modsecurity::audit_log::AuditLog;
 /** @ingroup ModSecurity_CPP_API */
 class ConfigInt {
  public:
-    ConfigInt() : m_set(false), m_value(0) { }
-    bool m_set;
-    int m_value;
+    bool m_set = false;
+    int m_value = 0;
+    ConfigInt() = default;
 
     void merge(const ConfigInt *from) {
         if (m_set == true || from->m_set == false) {
@@ -87,9 +87,9 @@ class ConfigInt {
 
 class ConfigUnsignedInt {
  public:
-    ConfigUnsignedInt() : m_set(false), m_value(0) { }
-    bool m_set;
-    unsigned int m_value;
+    bool m_set = false;
+    unsigned int m_value = 0;
+    ConfigUnsignedInt() = default;
 
     void merge(const ConfigUnsignedInt *from) {
         if (m_set == true || from->m_set == false) {
@@ -104,9 +104,9 @@ class ConfigUnsignedInt {
 
 class ConfigDouble {
  public:
-    ConfigDouble() : m_set(false), m_value(0) { }
-    bool m_set;
-    double m_value;
+    bool m_set = false;
+    double m_value = 0.0;
+    ConfigDouble() = default;
 
     void merge(const ConfigDouble *from) {
         if (m_set == true || from->m_set == false) {
@@ -121,9 +121,9 @@ class ConfigDouble {
 
 class ConfigString {
  public:
-    ConfigString() : m_set(false), m_value("") { }
-    bool m_set;
-    std::string m_value;
+    bool m_set = false;
+    std::string m_value = "";
+    ConfigString() = default;
 
     void merge(const ConfigString *from) {
         if (m_set == true || from->m_set == false) {
@@ -138,10 +138,10 @@ class ConfigString {
 
 class ConfigSet {
  public:
-    ConfigSet() : m_set(false), m_clear(false) { }
-    bool m_set;
-    bool m_clear;
+    bool m_set = false;
+    bool m_clear = false;
     std::set<std::string> m_value;
+    ConfigSet() = default;
 };
 
 

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -85,6 +85,22 @@ class ConfigInt {
     }
 };
 
+class ConfigUnsignedInt {
+ public:
+    ConfigUnsignedInt() : m_set(false), m_value(0) { }
+    bool m_set;
+    unsigned int m_value;
+
+    void merge(const ConfigUnsignedInt *from) {
+        if (m_set == true || from->m_set == false) {
+            return;
+        }
+        m_set = true;
+        m_value = from->m_value;
+        return;
+    }
+};
+
 
 class ConfigDouble {
  public:
@@ -506,9 +522,9 @@ class RulesSetProperties {
     ConfigBoolean m_uploadKeepFiles;
     ConfigDouble m_argumentsLimit;
     ConfigDouble m_requestBodyJsonDepthLimit;
-    ConfigDouble m_requestBodyLimit;
-    ConfigDouble m_requestBodyNoFilesLimit;
-    ConfigDouble m_responseBodyLimit;
+    ConfigUnsignedInt m_requestBodyLimit;
+    ConfigUnsignedInt m_requestBodyNoFilesLimit;
+    ConfigUnsignedInt m_responseBodyLimit;
     ConfigInt m_pcreMatchLimit;
     ConfigInt m_uploadFileLimit;
     ConfigInt m_uploadFileMode;

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -3046,22 +3046,30 @@ namespace yy {
 #line 1610 "seclang-parser.yy"
       {
         driver.m_requestBodyLimit.m_set = true;
-        driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
+        if (modsecurity::utils::string::parse_unsigned_int(yystack_[0].value.as < std::string > (), &driver.m_requestBodyLimit.m_value) != 1) {
+          std::stringstream ss;
+          ss << "Failed to parse SecRequestBodyLimit value as an unsigned integer.";
+          driver.error(yystack_[1].location, ss.str());
+        }
       }
-#line 3052 "seclang-parser.cc"
+#line 3056 "seclang-parser.cc"
     break;
 
   case 131: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
-#line 1615 "seclang-parser.yy"
+#line 1619 "seclang-parser.yy"
       {
         driver.m_requestBodyNoFilesLimit.m_set = true;
-        driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
+        if (modsecurity::utils::string::parse_unsigned_int(yystack_[0].value.as < std::string > (), &driver.m_requestBodyNoFilesLimit.m_value) != 1) {
+          std::stringstream ss;
+          ss << "Failed to parse SecRequestBodyNoFilesLimit value as an unsigned integer.";
+          driver.error(yystack_[1].location, ss.str());
+        }
       }
-#line 3061 "seclang-parser.cc"
+#line 3069 "seclang-parser.cc"
     break;
 
   case 132: // expression: "CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT"
-#line 1620 "seclang-parser.yy"
+#line 1628 "seclang-parser.yy"
       {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -3070,77 +3078,77 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 3074 "seclang-parser.cc"
+#line 3082 "seclang-parser.cc"
     break;
 
   case 133: // expression: "CONFIG_DIR_RES_BODY_LIMIT"
-#line 1629 "seclang-parser.yy"
+#line 1637 "seclang-parser.yy"
       {
         driver.m_responseBodyLimit.m_set = true;
         driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3083 "seclang-parser.cc"
-    break;
-
-  case 134: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1634 "seclang-parser.yy"
-      {
-        driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
-      }
 #line 3091 "seclang-parser.cc"
     break;
 
-  case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1638 "seclang-parser.yy"
+  case 134: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
+#line 1642 "seclang-parser.yy"
       {
-        driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
+        driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
 #line 3099 "seclang-parser.cc"
     break;
 
-  case 136: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1642 "seclang-parser.yy"
+  case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
+#line 1646 "seclang-parser.yy"
       {
-        driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
+        driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
 #line 3107 "seclang-parser.cc"
     break;
 
-  case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1646 "seclang-parser.yy"
+  case 136: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
+#line 1650 "seclang-parser.yy"
       {
-        driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
+        driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
 #line 3115 "seclang-parser.cc"
     break;
 
-  case 138: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
-#line 1650 "seclang-parser.yy"
+  case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
+#line 1654 "seclang-parser.yy"
       {
-        driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
+        driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
 #line 3123 "seclang-parser.cc"
     break;
 
-  case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
-#line 1654 "seclang-parser.yy"
+  case 138: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
+#line 1658 "seclang-parser.yy"
       {
-        driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
+        driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
 #line 3131 "seclang-parser.cc"
     break;
 
+  case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
+#line 1662 "seclang-parser.yy"
+      {
+        driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
+      }
+#line 3139 "seclang-parser.cc"
+    break;
+
   case 141: // expression: "CONFIG_DIR_PCRE_MATCH_LIMIT"
-#line 1663 "seclang-parser.yy"
+#line 1671 "seclang-parser.yy"
       {
         driver.m_pcreMatchLimit.m_set = true;
         driver.m_pcreMatchLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3140 "seclang-parser.cc"
+#line 3148 "seclang-parser.cc"
     break;
 
   case 142: // expression: "CONGIG_DIR_RESPONSE_BODY_MP"
-#line 1668 "seclang-parser.yy"
+#line 1676 "seclang-parser.yy"
       {
         std::istringstream buf(yystack_[0].value.as < std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -3152,61 +3160,61 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 3156 "seclang-parser.cc"
+#line 3164 "seclang-parser.cc"
     break;
 
   case 143: // expression: "CONGIG_DIR_RESPONSE_BODY_MP_CLEAR"
-#line 1680 "seclang-parser.yy"
+#line 1688 "seclang-parser.yy"
       {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 3166 "seclang-parser.cc"
-    break;
-
-  case 144: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
-#line 1686 "seclang-parser.yy"
-      {
-        driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
-      }
 #line 3174 "seclang-parser.cc"
     break;
 
-  case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
-#line 1690 "seclang-parser.yy"
+  case 144: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
+#line 1694 "seclang-parser.yy"
       {
-        driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
+        driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
 #line 3182 "seclang-parser.cc"
     break;
 
-  case 146: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
-#line 1694 "seclang-parser.yy"
+  case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
+#line 1698 "seclang-parser.yy"
       {
-        driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::OnlyArgsConfigXMLParseXmlIntoArgs;
+        driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
 #line 3190 "seclang-parser.cc"
     break;
 
-  case 147: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
-#line 1698 "seclang-parser.yy"
+  case 146: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
+#line 1702 "seclang-parser.yy"
       {
-        driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::FalseConfigXMLParseXmlIntoArgs;
+        driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::OnlyArgsConfigXMLParseXmlIntoArgs;
       }
 #line 3198 "seclang-parser.cc"
     break;
 
-  case 148: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
-#line 1702 "seclang-parser.yy"
+  case 147: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
+#line 1706 "seclang-parser.yy"
       {
-        driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::TrueConfigXMLParseXmlIntoArgs;
+        driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::FalseConfigXMLParseXmlIntoArgs;
       }
 #line 3206 "seclang-parser.cc"
     break;
 
+  case 148: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
+#line 1710 "seclang-parser.yy"
+      {
+        driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::TrueConfigXMLParseXmlIntoArgs;
+      }
+#line 3214 "seclang-parser.cc"
+    break;
+
   case 149: // expression: "CONGIG_DIR_SEC_TMP_DIR"
-#line 1706 "seclang-parser.yy"
+#line 1714 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
         std::stringstream ss;
@@ -3217,31 +3225,31 @@ namespace yy {
         YYERROR;
 */
       }
-#line 3221 "seclang-parser.cc"
+#line 3229 "seclang-parser.cc"
     break;
 
   case 152: // expression: "CONGIG_DIR_SEC_COOKIE_FORMAT"
-#line 1727 "seclang-parser.yy"
+#line 1735 "seclang-parser.yy"
       {
         if (atoi(yystack_[0].value.as < std::string > ().c_str()) == 1) {
           driver.error(yystack_[1].location, "SecCookieFormat 1 is not yet supported.");
           YYERROR;
         }
       }
-#line 3232 "seclang-parser.cc"
+#line 3240 "seclang-parser.cc"
     break;
 
   case 153: // expression: "CONFIG_SEC_COOKIEV0_SEPARATOR"
-#line 1734 "seclang-parser.yy"
+#line 1742 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCookieV0Separator is not yet supported.");
         YYERROR;
       }
-#line 3241 "seclang-parser.cc"
+#line 3249 "seclang-parser.cc"
     break;
 
   case 155: // expression: "CONFIG_DIR_UNICODE_MAP_FILE"
-#line 1744 "seclang-parser.yy"
+#line 1752 "seclang-parser.yy"
       {
         std::string error;
         std::vector<std::string> param;
@@ -3295,31 +3303,31 @@ namespace yy {
         }
 
       }
-#line 3299 "seclang-parser.cc"
+#line 3307 "seclang-parser.cc"
     break;
 
   case 156: // expression: "CONFIG_SEC_COLLECTION_TIMEOUT"
-#line 1798 "seclang-parser.yy"
+#line 1806 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default CRS installations with crs-setup.conf-recommended
         driver.error(@0, "SecCollectionTimeout is not yet supported.");
         YYERROR;
 */
       }
-#line 3310 "seclang-parser.cc"
+#line 3318 "seclang-parser.cc"
     break;
 
   case 157: // expression: "CONFIG_SEC_HTTP_BLKEY"
-#line 1805 "seclang-parser.yy"
+#line 1813 "seclang-parser.yy"
       {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 3319 "seclang-parser.cc"
+#line 3327 "seclang-parser.cc"
     break;
 
   case 158: // variables: variables_pre_process
-#line 1813 "seclang-parser.yy"
+#line 1821 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable> > > originalList = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> newList(new std::vector<std::unique_ptr<Variable>>());
@@ -3353,2425 +3361,2425 @@ namespace yy {
         }
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(newNewList);
       }
-#line 3357 "seclang-parser.cc"
-    break;
-
-  case 159: // variables_pre_process: variables_may_be_quoted
-#line 1850 "seclang-parser.yy"
-      {
-        yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
-      }
 #line 3365 "seclang-parser.cc"
     break;
 
-  case 160: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
-#line 1854 "seclang-parser.yy"
+  case 159: // variables_pre_process: variables_may_be_quoted
+#line 1858 "seclang-parser.yy"
       {
-        yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
+        yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
 #line 3373 "seclang-parser.cc"
     break;
 
+  case 160: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
+#line 1862 "seclang-parser.yy"
+      {
+        yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
+      }
+#line 3381 "seclang-parser.cc"
+    break;
+
   case 161: // variables_may_be_quoted: variables_may_be_quoted PIPE var
-#line 1861 "seclang-parser.yy"
+#line 1869 "seclang-parser.yy"
       {
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3382 "seclang-parser.cc"
+#line 3390 "seclang-parser.cc"
     break;
 
   case 162: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_EXCLUSION var
-#line 1866 "seclang-parser.yy"
+#line 1874 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3392 "seclang-parser.cc"
+#line 3400 "seclang-parser.cc"
     break;
 
   case 163: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_COUNT var
-#line 1872 "seclang-parser.yy"
+#line 1880 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3402 "seclang-parser.cc"
+#line 3410 "seclang-parser.cc"
     break;
 
   case 164: // variables_may_be_quoted: var
-#line 1878 "seclang-parser.yy"
+#line 1886 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3412 "seclang-parser.cc"
+#line 3420 "seclang-parser.cc"
     break;
 
   case 165: // variables_may_be_quoted: VAR_EXCLUSION var
-#line 1884 "seclang-parser.yy"
+#line 1892 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3423 "seclang-parser.cc"
+#line 3431 "seclang-parser.cc"
     break;
 
   case 166: // variables_may_be_quoted: VAR_COUNT var
-#line 1891 "seclang-parser.yy"
+#line 1899 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3434 "seclang-parser.cc"
-    break;
-
-  case 167: // var: VARIABLE_ARGS "Dictionary element"
-#line 1901 "seclang-parser.yy"
-      {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
-      }
 #line 3442 "seclang-parser.cc"
     break;
 
-  case 168: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
-#line 1905 "seclang-parser.yy"
+  case 167: // var: VARIABLE_ARGS "Dictionary element"
+#line 1909 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3450 "seclang-parser.cc"
     break;
 
-  case 169: // var: VARIABLE_ARGS
-#line 1909 "seclang-parser.yy"
+  case 168: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
+#line 1913 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3458 "seclang-parser.cc"
     break;
 
-  case 170: // var: VARIABLE_ARGS_POST "Dictionary element"
-#line 1913 "seclang-parser.yy"
+  case 169: // var: VARIABLE_ARGS
+#line 1917 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
       }
 #line 3466 "seclang-parser.cc"
     break;
 
-  case 171: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
-#line 1917 "seclang-parser.yy"
+  case 170: // var: VARIABLE_ARGS_POST "Dictionary element"
+#line 1921 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3474 "seclang-parser.cc"
     break;
 
-  case 172: // var: VARIABLE_ARGS_POST
-#line 1921 "seclang-parser.yy"
+  case 171: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
+#line 1925 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3482 "seclang-parser.cc"
     break;
 
-  case 173: // var: VARIABLE_ARGS_GET "Dictionary element"
-#line 1925 "seclang-parser.yy"
+  case 172: // var: VARIABLE_ARGS_POST
+#line 1929 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
       }
 #line 3490 "seclang-parser.cc"
     break;
 
-  case 174: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
-#line 1929 "seclang-parser.yy"
+  case 173: // var: VARIABLE_ARGS_GET "Dictionary element"
+#line 1933 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3498 "seclang-parser.cc"
     break;
 
-  case 175: // var: VARIABLE_ARGS_GET
-#line 1933 "seclang-parser.yy"
+  case 174: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
+#line 1937 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3506 "seclang-parser.cc"
     break;
 
-  case 176: // var: VARIABLE_FILES_SIZES "Dictionary element"
-#line 1937 "seclang-parser.yy"
+  case 175: // var: VARIABLE_ARGS_GET
+#line 1941 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
       }
 #line 3514 "seclang-parser.cc"
     break;
 
-  case 177: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
-#line 1941 "seclang-parser.yy"
+  case 176: // var: VARIABLE_FILES_SIZES "Dictionary element"
+#line 1945 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3522 "seclang-parser.cc"
     break;
 
-  case 178: // var: VARIABLE_FILES_SIZES
-#line 1945 "seclang-parser.yy"
+  case 177: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
+#line 1949 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3530 "seclang-parser.cc"
     break;
 
-  case 179: // var: VARIABLE_FILES_NAMES "Dictionary element"
-#line 1949 "seclang-parser.yy"
+  case 178: // var: VARIABLE_FILES_SIZES
+#line 1953 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
       }
 #line 3538 "seclang-parser.cc"
     break;
 
-  case 180: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
-#line 1953 "seclang-parser.yy"
+  case 179: // var: VARIABLE_FILES_NAMES "Dictionary element"
+#line 1957 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3546 "seclang-parser.cc"
     break;
 
-  case 181: // var: VARIABLE_FILES_NAMES
-#line 1957 "seclang-parser.yy"
+  case 180: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
+#line 1961 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3554 "seclang-parser.cc"
     break;
 
-  case 182: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
-#line 1961 "seclang-parser.yy"
+  case 181: // var: VARIABLE_FILES_NAMES
+#line 1965 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
       }
 #line 3562 "seclang-parser.cc"
     break;
 
-  case 183: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
-#line 1965 "seclang-parser.yy"
+  case 182: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
+#line 1969 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3570 "seclang-parser.cc"
     break;
 
-  case 184: // var: VARIABLE_FILES_TMP_CONTENT
-#line 1969 "seclang-parser.yy"
+  case 183: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
+#line 1973 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3578 "seclang-parser.cc"
     break;
 
-  case 185: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
-#line 1973 "seclang-parser.yy"
+  case 184: // var: VARIABLE_FILES_TMP_CONTENT
+#line 1977 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
       }
 #line 3586 "seclang-parser.cc"
     break;
 
-  case 186: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
-#line 1977 "seclang-parser.yy"
+  case 185: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
+#line 1981 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3594 "seclang-parser.cc"
     break;
 
-  case 187: // var: VARIABLE_MULTIPART_FILENAME
-#line 1981 "seclang-parser.yy"
+  case 186: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
+#line 1985 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3602 "seclang-parser.cc"
     break;
 
-  case 188: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
-#line 1985 "seclang-parser.yy"
+  case 187: // var: VARIABLE_MULTIPART_FILENAME
+#line 1989 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
       }
 #line 3610 "seclang-parser.cc"
     break;
 
-  case 189: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
-#line 1989 "seclang-parser.yy"
+  case 188: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
+#line 1993 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3618 "seclang-parser.cc"
     break;
 
-  case 190: // var: VARIABLE_MULTIPART_NAME
-#line 1993 "seclang-parser.yy"
+  case 189: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
+#line 1997 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3626 "seclang-parser.cc"
     break;
 
-  case 191: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
-#line 1997 "seclang-parser.yy"
+  case 190: // var: VARIABLE_MULTIPART_NAME
+#line 2001 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
       }
 #line 3634 "seclang-parser.cc"
     break;
 
-  case 192: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
-#line 2001 "seclang-parser.yy"
+  case 191: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
+#line 2005 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3642 "seclang-parser.cc"
     break;
 
-  case 193: // var: VARIABLE_MATCHED_VARS_NAMES
-#line 2005 "seclang-parser.yy"
+  case 192: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
+#line 2009 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3650 "seclang-parser.cc"
     break;
 
-  case 194: // var: VARIABLE_MATCHED_VARS "Dictionary element"
-#line 2009 "seclang-parser.yy"
+  case 193: // var: VARIABLE_MATCHED_VARS_NAMES
+#line 2013 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
       }
 #line 3658 "seclang-parser.cc"
     break;
 
-  case 195: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
-#line 2013 "seclang-parser.yy"
+  case 194: // var: VARIABLE_MATCHED_VARS "Dictionary element"
+#line 2017 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3666 "seclang-parser.cc"
     break;
 
-  case 196: // var: VARIABLE_MATCHED_VARS
-#line 2017 "seclang-parser.yy"
+  case 195: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
+#line 2021 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3674 "seclang-parser.cc"
     break;
 
-  case 197: // var: VARIABLE_FILES "Dictionary element"
-#line 2021 "seclang-parser.yy"
+  case 196: // var: VARIABLE_MATCHED_VARS
+#line 2025 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
       }
 #line 3682 "seclang-parser.cc"
     break;
 
-  case 198: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
-#line 2025 "seclang-parser.yy"
+  case 197: // var: VARIABLE_FILES "Dictionary element"
+#line 2029 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3690 "seclang-parser.cc"
     break;
 
-  case 199: // var: VARIABLE_FILES
-#line 2029 "seclang-parser.yy"
+  case 198: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
+#line 2033 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3698 "seclang-parser.cc"
     break;
 
-  case 200: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
-#line 2033 "seclang-parser.yy"
+  case 199: // var: VARIABLE_FILES
+#line 2037 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
       }
 #line 3706 "seclang-parser.cc"
     break;
 
-  case 201: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
-#line 2037 "seclang-parser.yy"
+  case 200: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
+#line 2041 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3714 "seclang-parser.cc"
     break;
 
-  case 202: // var: VARIABLE_REQUEST_COOKIES
-#line 2041 "seclang-parser.yy"
+  case 201: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
+#line 2045 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3722 "seclang-parser.cc"
     break;
 
-  case 203: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
-#line 2045 "seclang-parser.yy"
+  case 202: // var: VARIABLE_REQUEST_COOKIES
+#line 2049 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
       }
 #line 3730 "seclang-parser.cc"
     break;
 
-  case 204: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
-#line 2049 "seclang-parser.yy"
+  case 203: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
+#line 2053 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3738 "seclang-parser.cc"
     break;
 
-  case 205: // var: VARIABLE_REQUEST_HEADERS
-#line 2053 "seclang-parser.yy"
+  case 204: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
+#line 2057 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3746 "seclang-parser.cc"
     break;
 
-  case 206: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
-#line 2057 "seclang-parser.yy"
+  case 205: // var: VARIABLE_REQUEST_HEADERS
+#line 2061 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
       }
 #line 3754 "seclang-parser.cc"
     break;
 
-  case 207: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
-#line 2061 "seclang-parser.yy"
+  case 206: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
+#line 2065 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3762 "seclang-parser.cc"
     break;
 
-  case 208: // var: VARIABLE_RESPONSE_HEADERS
-#line 2065 "seclang-parser.yy"
+  case 207: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
+#line 2069 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3770 "seclang-parser.cc"
     break;
 
-  case 209: // var: VARIABLE_GEO "Dictionary element"
-#line 2069 "seclang-parser.yy"
+  case 208: // var: VARIABLE_RESPONSE_HEADERS
+#line 2073 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
       }
 #line 3778 "seclang-parser.cc"
     break;
 
-  case 210: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
-#line 2073 "seclang-parser.yy"
+  case 209: // var: VARIABLE_GEO "Dictionary element"
+#line 2077 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3786 "seclang-parser.cc"
     break;
 
-  case 211: // var: VARIABLE_GEO
-#line 2077 "seclang-parser.yy"
+  case 210: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
+#line 2081 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3794 "seclang-parser.cc"
     break;
 
-  case 212: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
-#line 2081 "seclang-parser.yy"
+  case 211: // var: VARIABLE_GEO
+#line 2085 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
       }
 #line 3802 "seclang-parser.cc"
     break;
 
-  case 213: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
-#line 2085 "seclang-parser.yy"
+  case 212: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
+#line 2089 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3810 "seclang-parser.cc"
     break;
 
-  case 214: // var: VARIABLE_REQUEST_COOKIES_NAMES
-#line 2089 "seclang-parser.yy"
+  case 213: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
+#line 2093 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3818 "seclang-parser.cc"
     break;
 
-  case 215: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element"
-#line 2093 "seclang-parser.yy"
+  case 214: // var: VARIABLE_REQUEST_COOKIES_NAMES
+#line 2097 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
       }
 #line 3826 "seclang-parser.cc"
     break;
 
-  case 216: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element, selected by regexp"
-#line 2097 "seclang-parser.yy"
+  case 215: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element"
+#line 2101 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3834 "seclang-parser.cc"
     break;
 
-  case 217: // var: VARIABLE_MULTIPART_PART_HEADERS
-#line 2101 "seclang-parser.yy"
+  case 216: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element, selected by regexp"
+#line 2105 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3842 "seclang-parser.cc"
     break;
 
-  case 218: // var: VARIABLE_RULE "Dictionary element"
-#line 2105 "seclang-parser.yy"
+  case 217: // var: VARIABLE_MULTIPART_PART_HEADERS
+#line 2109 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_NoDictElement());
       }
 #line 3850 "seclang-parser.cc"
     break;
 
-  case 219: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
-#line 2109 "seclang-parser.yy"
+  case 218: // var: VARIABLE_RULE "Dictionary element"
+#line 2113 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3858 "seclang-parser.cc"
     break;
 
-  case 220: // var: VARIABLE_RULE
-#line 2113 "seclang-parser.yy"
+  case 219: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
+#line 2117 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3866 "seclang-parser.cc"
     break;
 
-  case 221: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
-#line 2117 "seclang-parser.yy"
+  case 220: // var: VARIABLE_RULE
+#line 2121 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
       }
 #line 3874 "seclang-parser.cc"
     break;
 
-  case 222: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
-#line 2121 "seclang-parser.yy"
+  case 221: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
+#line 2125 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
 #line 3882 "seclang-parser.cc"
     break;
 
-  case 223: // var: "RUN_TIME_VAR_ENV"
-#line 2125 "seclang-parser.yy"
+  case 222: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
+#line 2129 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
 #line 3890 "seclang-parser.cc"
     break;
 
-  case 224: // var: "RUN_TIME_VAR_XML" "Dictionary element"
-#line 2129 "seclang-parser.yy"
+  case 223: // var: "RUN_TIME_VAR_ENV"
+#line 2133 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
       }
 #line 3898 "seclang-parser.cc"
     break;
 
-  case 225: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
-#line 2133 "seclang-parser.yy"
+  case 224: // var: "RUN_TIME_VAR_XML" "Dictionary element"
+#line 2137 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
 #line 3906 "seclang-parser.cc"
     break;
 
-  case 226: // var: "RUN_TIME_VAR_XML"
-#line 2137 "seclang-parser.yy"
+  case 225: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
+#line 2141 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
 #line 3914 "seclang-parser.cc"
     break;
 
-  case 227: // var: "FILES_TMPNAMES" "Dictionary element"
-#line 2141 "seclang-parser.yy"
+  case 226: // var: "RUN_TIME_VAR_XML"
+#line 2145 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
       }
 #line 3922 "seclang-parser.cc"
     break;
 
-  case 228: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
-#line 2145 "seclang-parser.yy"
+  case 227: // var: "FILES_TMPNAMES" "Dictionary element"
+#line 2149 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3930 "seclang-parser.cc"
     break;
 
-  case 229: // var: "FILES_TMPNAMES"
-#line 2149 "seclang-parser.yy"
+  case 228: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
+#line 2153 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3938 "seclang-parser.cc"
     break;
 
-  case 230: // var: "RESOURCE" run_time_string
-#line 2153 "seclang-parser.yy"
+  case 229: // var: "FILES_TMPNAMES"
+#line 2157 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
       }
 #line 3946 "seclang-parser.cc"
     break;
 
-  case 231: // var: "RESOURCE" "Dictionary element"
-#line 2157 "seclang-parser.yy"
+  case 230: // var: "RESOURCE" run_time_string
+#line 2161 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 3954 "seclang-parser.cc"
     break;
 
-  case 232: // var: "RESOURCE" "Dictionary element, selected by regexp"
-#line 2161 "seclang-parser.yy"
+  case 231: // var: "RESOURCE" "Dictionary element"
+#line 2165 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3962 "seclang-parser.cc"
     break;
 
-  case 233: // var: "RESOURCE"
-#line 2165 "seclang-parser.yy"
+  case 232: // var: "RESOURCE" "Dictionary element, selected by regexp"
+#line 2169 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 3970 "seclang-parser.cc"
     break;
 
-  case 234: // var: "VARIABLE_IP" run_time_string
-#line 2169 "seclang-parser.yy"
+  case 233: // var: "RESOURCE"
+#line 2173 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
       }
 #line 3978 "seclang-parser.cc"
     break;
 
-  case 235: // var: "VARIABLE_IP" "Dictionary element"
-#line 2173 "seclang-parser.yy"
+  case 234: // var: "VARIABLE_IP" run_time_string
+#line 2177 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 3986 "seclang-parser.cc"
     break;
 
-  case 236: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
-#line 2177 "seclang-parser.yy"
+  case 235: // var: "VARIABLE_IP" "Dictionary element"
+#line 2181 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 3994 "seclang-parser.cc"
     break;
 
-  case 237: // var: "VARIABLE_IP"
-#line 2181 "seclang-parser.yy"
+  case 236: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
+#line 2185 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4002 "seclang-parser.cc"
     break;
 
-  case 238: // var: "VARIABLE_GLOBAL" run_time_string
-#line 2185 "seclang-parser.yy"
+  case 237: // var: "VARIABLE_IP"
+#line 2189 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
       }
 #line 4010 "seclang-parser.cc"
     break;
 
-  case 239: // var: "VARIABLE_GLOBAL" "Dictionary element"
-#line 2189 "seclang-parser.yy"
+  case 238: // var: "VARIABLE_GLOBAL" run_time_string
+#line 2193 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 4018 "seclang-parser.cc"
     break;
 
-  case 240: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
-#line 2193 "seclang-parser.yy"
+  case 239: // var: "VARIABLE_GLOBAL" "Dictionary element"
+#line 2197 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4026 "seclang-parser.cc"
     break;
 
-  case 241: // var: "VARIABLE_GLOBAL"
-#line 2197 "seclang-parser.yy"
+  case 240: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
+#line 2201 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4034 "seclang-parser.cc"
     break;
 
-  case 242: // var: "VARIABLE_USER" run_time_string
-#line 2201 "seclang-parser.yy"
+  case 241: // var: "VARIABLE_GLOBAL"
+#line 2205 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
       }
 #line 4042 "seclang-parser.cc"
     break;
 
-  case 243: // var: "VARIABLE_USER" "Dictionary element"
-#line 2205 "seclang-parser.yy"
+  case 242: // var: "VARIABLE_USER" run_time_string
+#line 2209 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 4050 "seclang-parser.cc"
     break;
 
-  case 244: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
-#line 2209 "seclang-parser.yy"
+  case 243: // var: "VARIABLE_USER" "Dictionary element"
+#line 2213 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4058 "seclang-parser.cc"
     break;
 
-  case 245: // var: "VARIABLE_USER"
-#line 2213 "seclang-parser.yy"
+  case 244: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
+#line 2217 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4066 "seclang-parser.cc"
     break;
 
-  case 246: // var: "VARIABLE_TX" run_time_string
-#line 2217 "seclang-parser.yy"
+  case 245: // var: "VARIABLE_USER"
+#line 2221 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
       }
 #line 4074 "seclang-parser.cc"
     break;
 
-  case 247: // var: "VARIABLE_TX" "Dictionary element"
-#line 2221 "seclang-parser.yy"
+  case 246: // var: "VARIABLE_TX" run_time_string
+#line 2225 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 4082 "seclang-parser.cc"
     break;
 
-  case 248: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
-#line 2225 "seclang-parser.yy"
+  case 247: // var: "VARIABLE_TX" "Dictionary element"
+#line 2229 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4090 "seclang-parser.cc"
     break;
 
-  case 249: // var: "VARIABLE_TX"
-#line 2229 "seclang-parser.yy"
+  case 248: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
+#line 2233 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4098 "seclang-parser.cc"
     break;
 
-  case 250: // var: "VARIABLE_SESSION" run_time_string
-#line 2233 "seclang-parser.yy"
+  case 249: // var: "VARIABLE_TX"
+#line 2237 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
       }
 #line 4106 "seclang-parser.cc"
     break;
 
-  case 251: // var: "VARIABLE_SESSION" "Dictionary element"
-#line 2237 "seclang-parser.yy"
+  case 250: // var: "VARIABLE_SESSION" run_time_string
+#line 2241 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 4114 "seclang-parser.cc"
     break;
 
-  case 252: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
-#line 2241 "seclang-parser.yy"
+  case 251: // var: "VARIABLE_SESSION" "Dictionary element"
+#line 2245 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4122 "seclang-parser.cc"
     break;
 
-  case 253: // var: "VARIABLE_SESSION"
-#line 2245 "seclang-parser.yy"
+  case 252: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
+#line 2249 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4130 "seclang-parser.cc"
     break;
 
-  case 254: // var: "Variable ARGS_NAMES" "Dictionary element"
-#line 2249 "seclang-parser.yy"
+  case 253: // var: "VARIABLE_SESSION"
+#line 2253 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
       }
 #line 4138 "seclang-parser.cc"
     break;
 
-  case 255: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
-#line 2253 "seclang-parser.yy"
+  case 254: // var: "Variable ARGS_NAMES" "Dictionary element"
+#line 2257 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4146 "seclang-parser.cc"
     break;
 
-  case 256: // var: "Variable ARGS_NAMES"
-#line 2257 "seclang-parser.yy"
+  case 255: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
+#line 2261 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4154 "seclang-parser.cc"
     break;
 
-  case 257: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
-#line 2261 "seclang-parser.yy"
+  case 256: // var: "Variable ARGS_NAMES"
+#line 2265 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
       }
 #line 4162 "seclang-parser.cc"
     break;
 
-  case 258: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
-#line 2265 "seclang-parser.yy"
+  case 257: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
+#line 2269 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4170 "seclang-parser.cc"
     break;
 
-  case 259: // var: VARIABLE_ARGS_GET_NAMES
-#line 2269 "seclang-parser.yy"
+  case 258: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
+#line 2273 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4178 "seclang-parser.cc"
     break;
 
-  case 260: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
-#line 2274 "seclang-parser.yy"
+  case 259: // var: VARIABLE_ARGS_GET_NAMES
+#line 2277 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
       }
 #line 4186 "seclang-parser.cc"
     break;
 
-  case 261: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
-#line 2278 "seclang-parser.yy"
+  case 260: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
+#line 2282 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4194 "seclang-parser.cc"
     break;
 
-  case 262: // var: VARIABLE_ARGS_POST_NAMES
-#line 2282 "seclang-parser.yy"
+  case 261: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
+#line 2286 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4202 "seclang-parser.cc"
     break;
 
-  case 263: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
-#line 2287 "seclang-parser.yy"
+  case 262: // var: VARIABLE_ARGS_POST_NAMES
+#line 2290 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
       }
 #line 4210 "seclang-parser.cc"
     break;
 
-  case 264: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2291 "seclang-parser.yy"
+  case 263: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
+#line 2295 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4218 "seclang-parser.cc"
     break;
 
-  case 265: // var: VARIABLE_REQUEST_HEADERS_NAMES
-#line 2295 "seclang-parser.yy"
+  case 264: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
+#line 2299 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4226 "seclang-parser.cc"
     break;
 
-  case 266: // var: VARIABLE_RESPONSE_CONTENT_TYPE
-#line 2300 "seclang-parser.yy"
+  case 265: // var: VARIABLE_REQUEST_HEADERS_NAMES
+#line 2303 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
       }
 #line 4234 "seclang-parser.cc"
     break;
 
-  case 267: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
-#line 2305 "seclang-parser.yy"
+  case 266: // var: VARIABLE_RESPONSE_CONTENT_TYPE
+#line 2308 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
       }
 #line 4242 "seclang-parser.cc"
     break;
 
-  case 268: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2309 "seclang-parser.yy"
+  case 267: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
+#line 2313 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
 #line 4250 "seclang-parser.cc"
     break;
 
-  case 269: // var: VARIABLE_RESPONSE_HEADERS_NAMES
-#line 2313 "seclang-parser.yy"
+  case 268: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
+#line 2317 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
 #line 4258 "seclang-parser.cc"
     break;
 
-  case 270: // var: VARIABLE_ARGS_COMBINED_SIZE
-#line 2317 "seclang-parser.yy"
+  case 269: // var: VARIABLE_RESPONSE_HEADERS_NAMES
+#line 2321 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
       }
 #line 4266 "seclang-parser.cc"
     break;
 
-  case 271: // var: "AUTH_TYPE"
-#line 2321 "seclang-parser.yy"
+  case 270: // var: VARIABLE_ARGS_COMBINED_SIZE
+#line 2325 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
       }
 #line 4274 "seclang-parser.cc"
     break;
 
-  case 272: // var: "FILES_COMBINED_SIZE"
-#line 2325 "seclang-parser.yy"
+  case 271: // var: "AUTH_TYPE"
+#line 2329 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
       }
 #line 4282 "seclang-parser.cc"
     break;
 
-  case 273: // var: "FULL_REQUEST"
-#line 2329 "seclang-parser.yy"
+  case 272: // var: "FILES_COMBINED_SIZE"
+#line 2333 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
       }
 #line 4290 "seclang-parser.cc"
     break;
 
-  case 274: // var: "FULL_REQUEST_LENGTH"
-#line 2333 "seclang-parser.yy"
+  case 273: // var: "FULL_REQUEST"
+#line 2337 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
       }
 #line 4298 "seclang-parser.cc"
     break;
 
-  case 275: // var: "INBOUND_DATA_ERROR"
-#line 2337 "seclang-parser.yy"
+  case 274: // var: "FULL_REQUEST_LENGTH"
+#line 2341 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
       }
 #line 4306 "seclang-parser.cc"
     break;
 
-  case 276: // var: "MATCHED_VAR"
-#line 2341 "seclang-parser.yy"
+  case 275: // var: "INBOUND_DATA_ERROR"
+#line 2345 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
       }
 #line 4314 "seclang-parser.cc"
     break;
 
-  case 277: // var: "MATCHED_VAR_NAME"
-#line 2345 "seclang-parser.yy"
+  case 276: // var: "MATCHED_VAR"
+#line 2349 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
       }
 #line 4322 "seclang-parser.cc"
     break;
 
-  case 278: // var: "MSC_PCRE_ERROR"
-#line 2349 "seclang-parser.yy"
+  case 277: // var: "MATCHED_VAR_NAME"
+#line 2353 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
       }
 #line 4330 "seclang-parser.cc"
     break;
 
-  case 279: // var: "MSC_PCRE_LIMITS_EXCEEDED"
-#line 2353 "seclang-parser.yy"
+  case 278: // var: "MSC_PCRE_ERROR"
+#line 2357 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreLimitsExceeded());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreError());
       }
 #line 4338 "seclang-parser.cc"
     break;
 
-  case 280: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
-#line 2357 "seclang-parser.yy"
+  case 279: // var: "MSC_PCRE_LIMITS_EXCEEDED"
+#line 2361 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreLimitsExceeded());
       }
 #line 4346 "seclang-parser.cc"
     break;
 
-  case 281: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
-#line 2361 "seclang-parser.yy"
+  case 280: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
+#line 2365 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
       }
 #line 4354 "seclang-parser.cc"
     break;
 
-  case 282: // var: "MULTIPART_CRLF_LF_LINES"
-#line 2365 "seclang-parser.yy"
+  case 281: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
+#line 2369 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
       }
 #line 4362 "seclang-parser.cc"
     break;
 
-  case 283: // var: "MULTIPART_DATA_AFTER"
-#line 2369 "seclang-parser.yy"
+  case 282: // var: "MULTIPART_CRLF_LF_LINES"
+#line 2373 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
       }
 #line 4370 "seclang-parser.cc"
     break;
 
-  case 284: // var: VARIABLE_MULTIPART_DATA_BEFORE
-#line 2373 "seclang-parser.yy"
+  case 283: // var: "MULTIPART_DATA_AFTER"
+#line 2377 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
       }
 #line 4378 "seclang-parser.cc"
     break;
 
-  case 285: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
-#line 2377 "seclang-parser.yy"
+  case 284: // var: VARIABLE_MULTIPART_DATA_BEFORE
+#line 2381 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
       }
 #line 4386 "seclang-parser.cc"
     break;
 
-  case 286: // var: "MULTIPART_HEADER_FOLDING"
-#line 2381 "seclang-parser.yy"
+  case 285: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
+#line 2385 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
       }
 #line 4394 "seclang-parser.cc"
     break;
 
-  case 287: // var: "MULTIPART_INVALID_HEADER_FOLDING"
-#line 2385 "seclang-parser.yy"
+  case 286: // var: "MULTIPART_HEADER_FOLDING"
+#line 2389 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
       }
 #line 4402 "seclang-parser.cc"
     break;
 
-  case 288: // var: VARIABLE_MULTIPART_INVALID_PART
-#line 2389 "seclang-parser.yy"
+  case 287: // var: "MULTIPART_INVALID_HEADER_FOLDING"
+#line 2393 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
       }
 #line 4410 "seclang-parser.cc"
     break;
 
-  case 289: // var: "MULTIPART_INVALID_QUOTING"
-#line 2393 "seclang-parser.yy"
+  case 288: // var: VARIABLE_MULTIPART_INVALID_PART
+#line 2397 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
       }
 #line 4418 "seclang-parser.cc"
     break;
 
-  case 290: // var: VARIABLE_MULTIPART_LF_LINE
-#line 2397 "seclang-parser.yy"
+  case 289: // var: "MULTIPART_INVALID_QUOTING"
+#line 2401 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
       }
 #line 4426 "seclang-parser.cc"
     break;
 
-  case 291: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
-#line 2401 "seclang-parser.yy"
+  case 290: // var: VARIABLE_MULTIPART_LF_LINE
+#line 2405 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
       }
 #line 4434 "seclang-parser.cc"
     break;
 
-  case 292: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
-#line 2405 "seclang-parser.yy"
+  case 291: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
+#line 2409 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
 #line 4442 "seclang-parser.cc"
     break;
 
-  case 293: // var: "MULTIPART_STRICT_ERROR"
-#line 2409 "seclang-parser.yy"
+  case 292: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
+#line 2413 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
 #line 4450 "seclang-parser.cc"
     break;
 
-  case 294: // var: "MULTIPART_UNMATCHED_BOUNDARY"
-#line 2413 "seclang-parser.yy"
+  case 293: // var: "MULTIPART_STRICT_ERROR"
+#line 2417 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
       }
 #line 4458 "seclang-parser.cc"
     break;
 
-  case 295: // var: "OUTBOUND_DATA_ERROR"
-#line 2417 "seclang-parser.yy"
+  case 294: // var: "MULTIPART_UNMATCHED_BOUNDARY"
+#line 2421 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
       }
 #line 4466 "seclang-parser.cc"
     break;
 
-  case 296: // var: "PATH_INFO"
-#line 2421 "seclang-parser.yy"
+  case 295: // var: "OUTBOUND_DATA_ERROR"
+#line 2425 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
       }
 #line 4474 "seclang-parser.cc"
     break;
 
-  case 297: // var: "QUERY_STRING"
-#line 2425 "seclang-parser.yy"
+  case 296: // var: "PATH_INFO"
+#line 2429 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
       }
 #line 4482 "seclang-parser.cc"
     break;
 
-  case 298: // var: "REMOTE_ADDR"
-#line 2429 "seclang-parser.yy"
+  case 297: // var: "QUERY_STRING"
+#line 2433 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
       }
 #line 4490 "seclang-parser.cc"
     break;
 
-  case 299: // var: "REMOTE_HOST"
-#line 2433 "seclang-parser.yy"
+  case 298: // var: "REMOTE_ADDR"
+#line 2437 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
       }
 #line 4498 "seclang-parser.cc"
     break;
 
-  case 300: // var: "REMOTE_PORT"
-#line 2437 "seclang-parser.yy"
+  case 299: // var: "REMOTE_HOST"
+#line 2441 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
       }
 #line 4506 "seclang-parser.cc"
     break;
 
-  case 301: // var: "REQBODY_ERROR"
-#line 2441 "seclang-parser.yy"
+  case 300: // var: "REMOTE_PORT"
+#line 2445 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
       }
 #line 4514 "seclang-parser.cc"
     break;
 
-  case 302: // var: "REQBODY_ERROR_MSG"
-#line 2445 "seclang-parser.yy"
+  case 301: // var: "REQBODY_ERROR"
+#line 2449 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
       }
 #line 4522 "seclang-parser.cc"
     break;
 
-  case 303: // var: "REQBODY_PROCESSOR"
-#line 2449 "seclang-parser.yy"
+  case 302: // var: "REQBODY_ERROR_MSG"
+#line 2453 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
       }
 #line 4530 "seclang-parser.cc"
     break;
 
-  case 304: // var: "REQBODY_PROCESSOR_ERROR"
-#line 2453 "seclang-parser.yy"
+  case 303: // var: "REQBODY_PROCESSOR"
+#line 2457 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
       }
 #line 4538 "seclang-parser.cc"
     break;
 
-  case 305: // var: "REQBODY_PROCESSOR_ERROR_MSG"
-#line 2457 "seclang-parser.yy"
+  case 304: // var: "REQBODY_PROCESSOR_ERROR"
+#line 2461 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
       }
 #line 4546 "seclang-parser.cc"
     break;
 
-  case 306: // var: "REQUEST_BASENAME"
-#line 2461 "seclang-parser.yy"
+  case 305: // var: "REQBODY_PROCESSOR_ERROR_MSG"
+#line 2465 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
       }
 #line 4554 "seclang-parser.cc"
     break;
 
-  case 307: // var: "REQUEST_BODY"
-#line 2465 "seclang-parser.yy"
+  case 306: // var: "REQUEST_BASENAME"
+#line 2469 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
       }
 #line 4562 "seclang-parser.cc"
     break;
 
-  case 308: // var: "REQUEST_BODY_LENGTH"
-#line 2469 "seclang-parser.yy"
+  case 307: // var: "REQUEST_BODY"
+#line 2473 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
       }
 #line 4570 "seclang-parser.cc"
     break;
 
-  case 309: // var: "REQUEST_FILENAME"
-#line 2473 "seclang-parser.yy"
+  case 308: // var: "REQUEST_BODY_LENGTH"
+#line 2477 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
       }
 #line 4578 "seclang-parser.cc"
     break;
 
-  case 310: // var: "REQUEST_LINE"
-#line 2477 "seclang-parser.yy"
+  case 309: // var: "REQUEST_FILENAME"
+#line 2481 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
       }
 #line 4586 "seclang-parser.cc"
     break;
 
-  case 311: // var: "REQUEST_METHOD"
-#line 2481 "seclang-parser.yy"
+  case 310: // var: "REQUEST_LINE"
+#line 2485 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
       }
 #line 4594 "seclang-parser.cc"
     break;
 
-  case 312: // var: "REQUEST_PROTOCOL"
-#line 2485 "seclang-parser.yy"
+  case 311: // var: "REQUEST_METHOD"
+#line 2489 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
       }
 #line 4602 "seclang-parser.cc"
     break;
 
-  case 313: // var: "REQUEST_URI"
-#line 2489 "seclang-parser.yy"
+  case 312: // var: "REQUEST_PROTOCOL"
+#line 2493 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
       }
 #line 4610 "seclang-parser.cc"
     break;
 
-  case 314: // var: "REQUEST_URI_RAW"
-#line 2493 "seclang-parser.yy"
+  case 313: // var: "REQUEST_URI"
+#line 2497 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
       }
 #line 4618 "seclang-parser.cc"
     break;
 
-  case 315: // var: "RESPONSE_BODY"
-#line 2497 "seclang-parser.yy"
+  case 314: // var: "REQUEST_URI_RAW"
+#line 2501 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
       }
 #line 4626 "seclang-parser.cc"
     break;
 
-  case 316: // var: "RESPONSE_CONTENT_LENGTH"
-#line 2501 "seclang-parser.yy"
+  case 315: // var: "RESPONSE_BODY"
+#line 2505 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
       }
 #line 4634 "seclang-parser.cc"
     break;
 
-  case 317: // var: "RESPONSE_PROTOCOL"
-#line 2505 "seclang-parser.yy"
+  case 316: // var: "RESPONSE_CONTENT_LENGTH"
+#line 2509 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
       }
 #line 4642 "seclang-parser.cc"
     break;
 
-  case 318: // var: "RESPONSE_STATUS"
-#line 2509 "seclang-parser.yy"
+  case 317: // var: "RESPONSE_PROTOCOL"
+#line 2513 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
       }
 #line 4650 "seclang-parser.cc"
     break;
 
-  case 319: // var: "SERVER_ADDR"
-#line 2513 "seclang-parser.yy"
+  case 318: // var: "RESPONSE_STATUS"
+#line 2517 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
       }
 #line 4658 "seclang-parser.cc"
     break;
 
-  case 320: // var: "SERVER_NAME"
-#line 2517 "seclang-parser.yy"
+  case 319: // var: "SERVER_ADDR"
+#line 2521 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
       }
 #line 4666 "seclang-parser.cc"
     break;
 
-  case 321: // var: "SERVER_PORT"
-#line 2521 "seclang-parser.yy"
+  case 320: // var: "SERVER_NAME"
+#line 2525 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
       }
 #line 4674 "seclang-parser.cc"
     break;
 
-  case 322: // var: "SESSIONID"
-#line 2525 "seclang-parser.yy"
+  case 321: // var: "SERVER_PORT"
+#line 2529 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
       }
 #line 4682 "seclang-parser.cc"
     break;
 
-  case 323: // var: "UNIQUE_ID"
-#line 2529 "seclang-parser.yy"
+  case 322: // var: "SESSIONID"
+#line 2533 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
       }
 #line 4690 "seclang-parser.cc"
     break;
 
-  case 324: // var: "URLENCODED_ERROR"
-#line 2533 "seclang-parser.yy"
+  case 323: // var: "UNIQUE_ID"
+#line 2537 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
       }
 #line 4698 "seclang-parser.cc"
     break;
 
-  case 325: // var: "USERID"
-#line 2537 "seclang-parser.yy"
+  case 324: // var: "URLENCODED_ERROR"
+#line 2541 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
       }
 #line 4706 "seclang-parser.cc"
     break;
 
-  case 326: // var: "VARIABLE_STATUS"
-#line 2541 "seclang-parser.yy"
+  case 325: // var: "USERID"
+#line 2545 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
       }
 #line 4714 "seclang-parser.cc"
     break;
 
-  case 327: // var: "VARIABLE_STATUS_LINE"
-#line 2545 "seclang-parser.yy"
+  case 326: // var: "VARIABLE_STATUS"
+#line 2549 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
 #line 4722 "seclang-parser.cc"
     break;
 
-  case 328: // var: "WEBAPPID"
-#line 2549 "seclang-parser.yy"
+  case 327: // var: "VARIABLE_STATUS_LINE"
+#line 2553 "seclang-parser.yy"
       {
-        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
 #line 4730 "seclang-parser.cc"
     break;
 
+  case 328: // var: "WEBAPPID"
+#line 2557 "seclang-parser.yy"
+      {
+        VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
+      }
+#line 4738 "seclang-parser.cc"
+    break;
+
   case 329: // var: "RUN_TIME_VAR_DUR"
-#line 2553 "seclang-parser.yy"
+#line 2561 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4741 "seclang-parser.cc"
+#line 4749 "seclang-parser.cc"
     break;
 
   case 330: // var: "RUN_TIME_VAR_BLD"
-#line 2561 "seclang-parser.yy"
+#line 2569 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4752 "seclang-parser.cc"
+#line 4760 "seclang-parser.cc"
     break;
 
   case 331: // var: "RUN_TIME_VAR_HSV"
-#line 2568 "seclang-parser.yy"
+#line 2576 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4763 "seclang-parser.cc"
+#line 4771 "seclang-parser.cc"
     break;
 
   case 332: // var: "RUN_TIME_VAR_REMOTE_USER"
-#line 2575 "seclang-parser.yy"
+#line 2583 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4774 "seclang-parser.cc"
+#line 4782 "seclang-parser.cc"
     break;
 
   case 333: // var: "RUN_TIME_VAR_TIME"
-#line 2582 "seclang-parser.yy"
+#line 2590 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4785 "seclang-parser.cc"
+#line 4793 "seclang-parser.cc"
     break;
 
   case 334: // var: "RUN_TIME_VAR_TIME_DAY"
-#line 2589 "seclang-parser.yy"
+#line 2597 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4796 "seclang-parser.cc"
+#line 4804 "seclang-parser.cc"
     break;
 
   case 335: // var: "RUN_TIME_VAR_TIME_EPOCH"
-#line 2596 "seclang-parser.yy"
+#line 2604 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4807 "seclang-parser.cc"
+#line 4815 "seclang-parser.cc"
     break;
 
   case 336: // var: "RUN_TIME_VAR_TIME_HOUR"
-#line 2603 "seclang-parser.yy"
+#line 2611 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4818 "seclang-parser.cc"
+#line 4826 "seclang-parser.cc"
     break;
 
   case 337: // var: "RUN_TIME_VAR_TIME_MIN"
-#line 2610 "seclang-parser.yy"
+#line 2618 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4829 "seclang-parser.cc"
+#line 4837 "seclang-parser.cc"
     break;
 
   case 338: // var: "RUN_TIME_VAR_TIME_MON"
-#line 2617 "seclang-parser.yy"
+#line 2625 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4840 "seclang-parser.cc"
+#line 4848 "seclang-parser.cc"
     break;
 
   case 339: // var: "RUN_TIME_VAR_TIME_SEC"
-#line 2624 "seclang-parser.yy"
+#line 2632 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4851 "seclang-parser.cc"
+#line 4859 "seclang-parser.cc"
     break;
 
   case 340: // var: "RUN_TIME_VAR_TIME_WDAY"
-#line 2631 "seclang-parser.yy"
+#line 2639 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4862 "seclang-parser.cc"
+#line 4870 "seclang-parser.cc"
     break;
 
   case 341: // var: "RUN_TIME_VAR_TIME_YEAR"
-#line 2638 "seclang-parser.yy"
+#line 2646 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4873 "seclang-parser.cc"
-    break;
-
-  case 342: // act: "Accuracy"
-#line 2648 "seclang-parser.yy"
-      {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
-      }
 #line 4881 "seclang-parser.cc"
     break;
 
-  case 343: // act: "Allow"
-#line 2652 "seclang-parser.yy"
+  case 342: // act: "Accuracy"
+#line 2656 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
       }
 #line 4889 "seclang-parser.cc"
     break;
 
-  case 344: // act: "Append"
-#line 2656 "seclang-parser.yy"
+  case 343: // act: "Allow"
+#line 2660 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
       }
 #line 4897 "seclang-parser.cc"
     break;
 
-  case 345: // act: "AuditLog"
-#line 2660 "seclang-parser.yy"
+  case 344: // act: "Append"
+#line 2664 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
+        ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
 #line 4905 "seclang-parser.cc"
     break;
 
-  case 346: // act: "Block"
-#line 2664 "seclang-parser.yy"
+  case 345: // act: "AuditLog"
+#line 2668 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
       }
 #line 4913 "seclang-parser.cc"
     break;
 
-  case 347: // act: "Capture"
-#line 2668 "seclang-parser.yy"
+  case 346: // act: "Block"
+#line 2672 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
       }
 #line 4921 "seclang-parser.cc"
     break;
 
-  case 348: // act: "Chain"
-#line 2672 "seclang-parser.yy"
+  case 347: // act: "Capture"
+#line 2676 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
       }
 #line 4929 "seclang-parser.cc"
     break;
 
+  case 348: // act: "Chain"
+#line 2680 "seclang-parser.yy"
+      {
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
+      }
+#line 4937 "seclang-parser.cc"
+    break;
+
   case 349: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_ON"
-#line 2676 "seclang-parser.yy"
+#line 2684 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=on"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4938 "seclang-parser.cc"
-    break;
-
-  case 350: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
-#line 2681 "seclang-parser.yy"
-      {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
-      }
 #line 4946 "seclang-parser.cc"
     break;
 
+  case 350: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
+#line 2689 "seclang-parser.yy"
+      {
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
+      }
+#line 4954 "seclang-parser.cc"
+    break;
+
   case 351: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 2685 "seclang-parser.yy"
+#line 2693 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=relevantonly"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4955 "seclang-parser.cc"
-    break;
-
-  case 352: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
-#line 2690 "seclang-parser.yy"
-      {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
-      }
 #line 4963 "seclang-parser.cc"
     break;
 
-  case 353: // act: "ACTION_CTL_BDY_JSON"
-#line 2694 "seclang-parser.yy"
+  case 352: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
+#line 2698 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
       }
 #line 4971 "seclang-parser.cc"
     break;
 
-  case 354: // act: "ACTION_CTL_BDY_XML"
-#line 2698 "seclang-parser.yy"
+  case 353: // act: "ACTION_CTL_BDY_JSON"
+#line 2702 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
       }
 #line 4979 "seclang-parser.cc"
     break;
 
-  case 355: // act: "ACTION_CTL_BDY_URLENCODED"
-#line 2702 "seclang-parser.yy"
+  case 354: // act: "ACTION_CTL_BDY_XML"
+#line 2706 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
       }
 #line 4987 "seclang-parser.cc"
     break;
 
+  case 355: // act: "ACTION_CTL_BDY_URLENCODED"
+#line 2710 "seclang-parser.yy"
+      {
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
+      }
+#line 4995 "seclang-parser.cc"
+    break;
+
   case 356: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
-#line 2706 "seclang-parser.yy"
+#line 2714 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 4996 "seclang-parser.cc"
+#line 5004 "seclang-parser.cc"
     break;
 
   case 357: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
-#line 2711 "seclang-parser.yy"
+#line 2719 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
-      }
-#line 5005 "seclang-parser.cc"
-    break;
-
-  case 358: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
-#line 2716 "seclang-parser.yy"
-      {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=on"));
       }
 #line 5013 "seclang-parser.cc"
     break;
 
-  case 359: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
-#line 2720 "seclang-parser.yy"
+  case 358: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
+#line 2724 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=off"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=on"));
       }
 #line 5021 "seclang-parser.cc"
     break;
 
-  case 360: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
-#line 2724 "seclang-parser.yy"
+  case 359: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
+#line 2728 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=onlyargs"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=off"));
       }
 #line 5029 "seclang-parser.cc"
     break;
 
-  case 361: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
-#line 2728 "seclang-parser.yy"
+  case 360: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
+#line 2732 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=onlyargs"));
       }
 #line 5037 "seclang-parser.cc"
     break;
 
-  case 362: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
-#line 2732 "seclang-parser.yy"
+  case 361: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
+#line 2736 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
       }
 #line 5045 "seclang-parser.cc"
     break;
 
-  case 363: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
-#line 2736 "seclang-parser.yy"
+  case 362: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
+#line 2740 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
       }
 #line 5053 "seclang-parser.cc"
     break;
 
-  case 364: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
-#line 2740 "seclang-parser.yy"
+  case 363: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
+#line 2744 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
 #line 5061 "seclang-parser.cc"
     break;
 
-  case 365: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
-#line 2744 "seclang-parser.yy"
+  case 364: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
+#line 2748 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
 #line 5069 "seclang-parser.cc"
     break;
 
-  case 366: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
-#line 2748 "seclang-parser.yy"
+  case 365: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
+#line 2752 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
 #line 5077 "seclang-parser.cc"
     break;
 
-  case 367: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
-#line 2752 "seclang-parser.yy"
+  case 366: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
+#line 2756 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
       }
 #line 5085 "seclang-parser.cc"
     break;
 
-  case 368: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
-#line 2756 "seclang-parser.yy"
+  case 367: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
+#line 2760 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
       }
 #line 5093 "seclang-parser.cc"
     break;
 
-  case 369: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
-#line 2760 "seclang-parser.yy"
+  case 368: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
+#line 2764 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
       }
 #line 5101 "seclang-parser.cc"
     break;
 
-  case 370: // act: "Deny"
-#line 2764 "seclang-parser.yy"
+  case 369: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
+#line 2768 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
       }
 #line 5109 "seclang-parser.cc"
     break;
 
-  case 371: // act: "DeprecateVar"
-#line 2768 "seclang-parser.yy"
+  case 370: // act: "Deny"
+#line 2772 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
       }
 #line 5117 "seclang-parser.cc"
     break;
 
-  case 372: // act: "Drop"
-#line 2772 "seclang-parser.yy"
+  case 371: // act: "DeprecateVar"
+#line 2776 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
+        ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
 #line 5125 "seclang-parser.cc"
     break;
 
-  case 373: // act: "Exec"
-#line 2776 "seclang-parser.yy"
+  case 372: // act: "Drop"
+#line 2780 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
       }
 #line 5133 "seclang-parser.cc"
     break;
 
-  case 374: // act: "ExpireVar" run_time_string
-#line 2780 "seclang-parser.yy"
+  case 373: // act: "Exec"
+#line 2784 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ExpireVar(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
       }
 #line 5141 "seclang-parser.cc"
     break;
 
-  case 375: // act: "Id"
-#line 2784 "seclang-parser.yy"
+  case 374: // act: "ExpireVar" run_time_string
+#line 2788 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ExpireVar(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5149 "seclang-parser.cc"
     break;
 
-  case 376: // act: "InitCol" run_time_string
-#line 2788 "seclang-parser.yy"
+  case 375: // act: "Id"
+#line 2792 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
       }
 #line 5157 "seclang-parser.cc"
     break;
 
-  case 377: // act: "LogData" run_time_string
-#line 2792 "seclang-parser.yy"
+  case 376: // act: "InitCol" run_time_string
+#line 2796 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5165 "seclang-parser.cc"
     break;
 
-  case 378: // act: "Log"
-#line 2796 "seclang-parser.yy"
+  case 377: // act: "LogData" run_time_string
+#line 2800 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5173 "seclang-parser.cc"
     break;
 
-  case 379: // act: "Maturity"
-#line 2800 "seclang-parser.yy"
+  case 378: // act: "Log"
+#line 2804 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
       }
 #line 5181 "seclang-parser.cc"
     break;
 
-  case 380: // act: "Msg" run_time_string
-#line 2804 "seclang-parser.yy"
+  case 379: // act: "Maturity"
+#line 2808 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
       }
 #line 5189 "seclang-parser.cc"
     break;
 
-  case 381: // act: "MultiMatch"
-#line 2808 "seclang-parser.yy"
+  case 380: // act: "Msg" run_time_string
+#line 2812 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5197 "seclang-parser.cc"
     break;
 
-  case 382: // act: "NoAuditLog"
-#line 2812 "seclang-parser.yy"
+  case 381: // act: "MultiMatch"
+#line 2816 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
       }
 #line 5205 "seclang-parser.cc"
     break;
 
-  case 383: // act: "NoLog"
-#line 2816 "seclang-parser.yy"
+  case 382: // act: "NoAuditLog"
+#line 2820 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
       }
 #line 5213 "seclang-parser.cc"
     break;
 
-  case 384: // act: "Pass"
-#line 2820 "seclang-parser.yy"
+  case 383: // act: "NoLog"
+#line 2824 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
       }
 #line 5221 "seclang-parser.cc"
     break;
 
-  case 385: // act: "Pause"
-#line 2824 "seclang-parser.yy"
+  case 384: // act: "Pass"
+#line 2828 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
       }
 #line 5229 "seclang-parser.cc"
     break;
 
-  case 386: // act: "Phase"
-#line 2828 "seclang-parser.yy"
+  case 385: // act: "Pause"
+#line 2832 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
+        ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
 #line 5237 "seclang-parser.cc"
     break;
 
-  case 387: // act: "Prepend"
-#line 2832 "seclang-parser.yy"
+  case 386: // act: "Phase"
+#line 2836 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
       }
 #line 5245 "seclang-parser.cc"
     break;
 
-  case 388: // act: "Proxy"
-#line 2836 "seclang-parser.yy"
+  case 387: // act: "Prepend"
+#line 2840 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
+        ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
 #line 5253 "seclang-parser.cc"
     break;
 
-  case 389: // act: "Redirect" run_time_string
-#line 2840 "seclang-parser.yy"
+  case 388: // act: "Proxy"
+#line 2844 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
 #line 5261 "seclang-parser.cc"
     break;
 
-  case 390: // act: "Rev"
-#line 2844 "seclang-parser.yy"
+  case 389: // act: "Redirect" run_time_string
+#line 2848 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5269 "seclang-parser.cc"
     break;
 
-  case 391: // act: "SanitiseArg"
-#line 2848 "seclang-parser.yy"
+  case 390: // act: "Rev"
+#line 2852 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
       }
 #line 5277 "seclang-parser.cc"
     break;
 
-  case 392: // act: "SanitiseMatched"
-#line 2852 "seclang-parser.yy"
+  case 391: // act: "SanitiseArg"
+#line 2856 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
+        ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
       }
 #line 5285 "seclang-parser.cc"
     break;
 
-  case 393: // act: "SanitiseMatchedBytes"
-#line 2856 "seclang-parser.yy"
+  case 392: // act: "SanitiseMatched"
+#line 2860 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
+        ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
       }
 #line 5293 "seclang-parser.cc"
     break;
 
-  case 394: // act: "SanitiseRequestHeader"
-#line 2860 "seclang-parser.yy"
+  case 393: // act: "SanitiseMatchedBytes"
+#line 2864 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
+        ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
       }
 #line 5301 "seclang-parser.cc"
     break;
 
-  case 395: // act: "SanitiseResponseHeader"
-#line 2864 "seclang-parser.yy"
+  case 394: // act: "SanitiseRequestHeader"
+#line 2868 "seclang-parser.yy"
       {
-        ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
+        ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
       }
 #line 5309 "seclang-parser.cc"
     break;
 
-  case 396: // act: "SetEnv" run_time_string
-#line 2868 "seclang-parser.yy"
+  case 395: // act: "SanitiseResponseHeader"
+#line 2872 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
       }
 #line 5317 "seclang-parser.cc"
     break;
 
-  case 397: // act: "SetRsc" run_time_string
-#line 2872 "seclang-parser.yy"
+  case 396: // act: "SetEnv" run_time_string
+#line 2876 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5325 "seclang-parser.cc"
     break;
 
-  case 398: // act: "SetSid" run_time_string
-#line 2876 "seclang-parser.yy"
+  case 397: // act: "SetRsc" run_time_string
+#line 2880 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5333 "seclang-parser.cc"
     break;
 
-  case 399: // act: "SetUID" run_time_string
-#line 2880 "seclang-parser.yy"
+  case 398: // act: "SetSid" run_time_string
+#line 2884 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5341 "seclang-parser.cc"
     break;
 
-  case 400: // act: "SetVar" setvar_action
-#line 2884 "seclang-parser.yy"
+  case 399: // act: "SetUID" run_time_string
+#line 2888 "seclang-parser.yy"
       {
-        yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5349 "seclang-parser.cc"
     break;
 
-  case 401: // act: "Severity"
-#line 2888 "seclang-parser.yy"
+  case 400: // act: "SetVar" setvar_action
+#line 2892 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
+        yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
       }
 #line 5357 "seclang-parser.cc"
     break;
 
-  case 402: // act: "Skip"
-#line 2892 "seclang-parser.yy"
+  case 401: // act: "Severity"
+#line 2896 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
       }
 #line 5365 "seclang-parser.cc"
     break;
 
-  case 403: // act: "SkipAfter"
-#line 2896 "seclang-parser.yy"
+  case 402: // act: "Skip"
+#line 2900 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
       }
 #line 5373 "seclang-parser.cc"
     break;
 
-  case 404: // act: "Status"
-#line 2900 "seclang-parser.yy"
+  case 403: // act: "SkipAfter"
+#line 2904 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
       }
 #line 5381 "seclang-parser.cc"
     break;
 
-  case 405: // act: "Tag" run_time_string
-#line 2904 "seclang-parser.yy"
+  case 404: // act: "Status"
+#line 2908 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
       }
 #line 5389 "seclang-parser.cc"
     break;
 
-  case 406: // act: "Ver"
-#line 2908 "seclang-parser.yy"
+  case 405: // act: "Tag" run_time_string
+#line 2912 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5397 "seclang-parser.cc"
     break;
 
-  case 407: // act: "xmlns"
-#line 2912 "seclang-parser.yy"
+  case 406: // act: "Ver"
+#line 2916 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
       }
 #line 5405 "seclang-parser.cc"
     break;
 
-  case 408: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
-#line 2916 "seclang-parser.yy"
+  case 407: // act: "xmlns"
+#line 2920 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
       }
 #line 5413 "seclang-parser.cc"
     break;
 
-  case 409: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
-#line 2920 "seclang-parser.yy"
+  case 408: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
+#line 2924 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
       }
 #line 5421 "seclang-parser.cc"
     break;
 
-  case 410: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
-#line 2924 "seclang-parser.yy"
+  case 409: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
+#line 2928 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
       }
 #line 5429 "seclang-parser.cc"
     break;
 
-  case 411: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
-#line 2928 "seclang-parser.yy"
+  case 410: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
+#line 2932 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
       }
 #line 5437 "seclang-parser.cc"
     break;
 
-  case 412: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
-#line 2932 "seclang-parser.yy"
+  case 411: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
+#line 2936 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5445 "seclang-parser.cc"
     break;
 
-  case 413: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
-#line 2936 "seclang-parser.yy"
+  case 412: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
+#line 2940 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
       }
 #line 5453 "seclang-parser.cc"
     break;
 
-  case 414: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
-#line 2940 "seclang-parser.yy"
+  case 413: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
+#line 2944 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
       }
 #line 5461 "seclang-parser.cc"
     break;
 
-  case 415: // act: "ACTION_TRANSFORMATION_CMD_LINE"
-#line 2944 "seclang-parser.yy"
+  case 414: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
+#line 2948 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
       }
 #line 5469 "seclang-parser.cc"
     break;
 
-  case 416: // act: "ACTION_TRANSFORMATION_SHA1"
-#line 2948 "seclang-parser.yy"
+  case 415: // act: "ACTION_TRANSFORMATION_CMD_LINE"
+#line 2952 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
       }
 #line 5477 "seclang-parser.cc"
     break;
 
-  case 417: // act: "ACTION_TRANSFORMATION_MD5"
-#line 2952 "seclang-parser.yy"
+  case 416: // act: "ACTION_TRANSFORMATION_SHA1"
+#line 2956 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
       }
 #line 5485 "seclang-parser.cc"
     break;
 
-  case 418: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
-#line 2956 "seclang-parser.yy"
+  case 417: // act: "ACTION_TRANSFORMATION_MD5"
+#line 2960 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
       }
 #line 5493 "seclang-parser.cc"
     break;
 
-  case 419: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
-#line 2960 "seclang-parser.yy"
+  case 418: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
+#line 2964 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5501 "seclang-parser.cc"
     break;
 
-  case 420: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
-#line 2964 "seclang-parser.yy"
+  case 419: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
+#line 2968 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
       }
 #line 5509 "seclang-parser.cc"
     break;
 
-  case 421: // act: "ACTION_TRANSFORMATION_LOWERCASE"
-#line 2968 "seclang-parser.yy"
+  case 420: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
+#line 2972 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5517 "seclang-parser.cc"
     break;
 
-  case 422: // act: "ACTION_TRANSFORMATION_UPPERCASE"
-#line 2972 "seclang-parser.yy"
+  case 421: // act: "ACTION_TRANSFORMATION_LOWERCASE"
+#line 2976 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
       }
 #line 5525 "seclang-parser.cc"
     break;
 
-  case 423: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
-#line 2976 "seclang-parser.yy"
+  case 422: // act: "ACTION_TRANSFORMATION_UPPERCASE"
+#line 2980 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
       }
 #line 5533 "seclang-parser.cc"
     break;
 
-  case 424: // act: "ACTION_TRANSFORMATION_URL_DECODE"
-#line 2980 "seclang-parser.yy"
+  case 423: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
+#line 2984 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
       }
 #line 5541 "seclang-parser.cc"
     break;
 
-  case 425: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
-#line 2984 "seclang-parser.yy"
+  case 424: // act: "ACTION_TRANSFORMATION_URL_DECODE"
+#line 2988 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5549 "seclang-parser.cc"
     break;
 
-  case 426: // act: "ACTION_TRANSFORMATION_NONE"
-#line 2988 "seclang-parser.yy"
+  case 425: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
+#line 2992 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
       }
 #line 5557 "seclang-parser.cc"
     break;
 
-  case 427: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
-#line 2992 "seclang-parser.yy"
+  case 426: // act: "ACTION_TRANSFORMATION_NONE"
+#line 2996 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
       }
 #line 5565 "seclang-parser.cc"
     break;
 
-  case 428: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
-#line 2996 "seclang-parser.yy"
+  case 427: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
+#line 3000 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
       }
 #line 5573 "seclang-parser.cc"
     break;
 
-  case 429: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
-#line 3000 "seclang-parser.yy"
+  case 428: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
+#line 3004 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
       }
 #line 5581 "seclang-parser.cc"
     break;
 
-  case 430: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
-#line 3004 "seclang-parser.yy"
+  case 429: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
+#line 3008 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
       }
 #line 5589 "seclang-parser.cc"
     break;
 
-  case 431: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
-#line 3008 "seclang-parser.yy"
+  case 430: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
+#line 3012 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
       }
 #line 5597 "seclang-parser.cc"
     break;
 
-  case 432: // act: "ACTION_TRANSFORMATION_JS_DECODE"
-#line 3012 "seclang-parser.yy"
+  case 431: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
+#line 3016 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5605 "seclang-parser.cc"
     break;
 
-  case 433: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
-#line 3016 "seclang-parser.yy"
+  case 432: // act: "ACTION_TRANSFORMATION_JS_DECODE"
+#line 3020 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5613 "seclang-parser.cc"
     break;
 
-  case 434: // act: "ACTION_TRANSFORMATION_TRIM"
-#line 3020 "seclang-parser.yy"
+  case 433: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
+#line 3024 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
       }
 #line 5621 "seclang-parser.cc"
     break;
 
-  case 435: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
-#line 3024 "seclang-parser.yy"
+  case 434: // act: "ACTION_TRANSFORMATION_TRIM"
+#line 3028 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
       }
 #line 5629 "seclang-parser.cc"
     break;
 
-  case 436: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
-#line 3028 "seclang-parser.yy"
+  case 435: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
+#line 3032 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
       }
 #line 5637 "seclang-parser.cc"
     break;
 
-  case 437: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
-#line 3032 "seclang-parser.yy"
+  case 436: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
+#line 3036 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
       }
 #line 5645 "seclang-parser.cc"
     break;
 
-  case 438: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
-#line 3036 "seclang-parser.yy"
+  case 437: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
+#line 3040 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
       }
 #line 5653 "seclang-parser.cc"
     break;
 
-  case 439: // act: "ACTION_TRANSFORMATION_LENGTH"
-#line 3040 "seclang-parser.yy"
+  case 438: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
+#line 3044 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
       }
 #line 5661 "seclang-parser.cc"
     break;
 
-  case 440: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
-#line 3044 "seclang-parser.yy"
+  case 439: // act: "ACTION_TRANSFORMATION_LENGTH"
+#line 3048 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
       }
 #line 5669 "seclang-parser.cc"
     break;
 
-  case 441: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
-#line 3048 "seclang-parser.yy"
+  case 440: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
+#line 3052 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
       }
 #line 5677 "seclang-parser.cc"
     break;
 
-  case 442: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
-#line 3052 "seclang-parser.yy"
+  case 441: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
+#line 3056 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
       }
 #line 5685 "seclang-parser.cc"
     break;
 
-  case 443: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
-#line 3056 "seclang-parser.yy"
+  case 442: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
+#line 3060 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
       }
 #line 5693 "seclang-parser.cc"
     break;
 
-  case 444: // setvar_action: "NOT" var
-#line 3063 "seclang-parser.yy"
+  case 443: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
+#line 3064 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
       }
 #line 5701 "seclang-parser.cc"
     break;
 
-  case 445: // setvar_action: var
-#line 3067 "seclang-parser.yy"
+  case 444: // setvar_action: "NOT" var
+#line 3071 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
 #line 5709 "seclang-parser.cc"
     break;
 
-  case 446: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
-#line 3071 "seclang-parser.yy"
+  case 445: // setvar_action: var
+#line 3075 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
 #line 5717 "seclang-parser.cc"
     break;
 
-  case 447: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
-#line 3075 "seclang-parser.yy"
+  case 446: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
+#line 3079 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5725 "seclang-parser.cc"
     break;
 
-  case 448: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
-#line 3079 "seclang-parser.yy"
+  case 447: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
+#line 3083 "seclang-parser.yy"
       {
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
 #line 5733 "seclang-parser.cc"
     break;
 
+  case 448: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
+#line 3087 "seclang-parser.yy"
+      {
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
+      }
+#line 5741 "seclang-parser.cc"
+    break;
+
   case 449: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3086 "seclang-parser.yy"
+#line 3094 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5742 "seclang-parser.cc"
+#line 5750 "seclang-parser.cc"
     break;
 
   case 450: // run_time_string: run_time_string var
-#line 3091 "seclang-parser.yy"
+#line 3099 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5751 "seclang-parser.cc"
+#line 5759 "seclang-parser.cc"
     break;
 
   case 451: // run_time_string: "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3096 "seclang-parser.yy"
+#line 3104 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5761 "seclang-parser.cc"
+#line 5769 "seclang-parser.cc"
     break;
 
   case 452: // run_time_string: var
-#line 3102 "seclang-parser.yy"
+#line 3110 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5771 "seclang-parser.cc"
+#line 5779 "seclang-parser.cc"
     break;
 
 
-#line 5775 "seclang-parser.cc"
+#line 5783 "seclang-parser.cc"
 
             default:
               break;
@@ -7323,39 +7331,39 @@ namespace yy {
     1336,  1341,  1344,  1349,  1354,  1359,  1364,  1369,  1374,  1379,
     1382,  1387,  1392,  1397,  1402,  1405,  1410,  1415,  1420,  1433,
     1446,  1459,  1472,  1485,  1511,  1539,  1551,  1571,  1598,  1603,
-    1609,  1614,  1619,  1628,  1633,  1637,  1641,  1645,  1649,  1653,
-    1657,  1662,  1667,  1679,  1685,  1689,  1693,  1697,  1701,  1705,
-    1716,  1725,  1726,  1733,  1738,  1743,  1797,  1804,  1812,  1849,
-    1853,  1860,  1865,  1871,  1877,  1883,  1890,  1900,  1904,  1908,
-    1912,  1916,  1920,  1924,  1928,  1932,  1936,  1940,  1944,  1948,
-    1952,  1956,  1960,  1964,  1968,  1972,  1976,  1980,  1984,  1988,
-    1992,  1996,  2000,  2004,  2008,  2012,  2016,  2020,  2024,  2028,
-    2032,  2036,  2040,  2044,  2048,  2052,  2056,  2060,  2064,  2068,
-    2072,  2076,  2080,  2084,  2088,  2092,  2096,  2100,  2104,  2108,
-    2112,  2116,  2120,  2124,  2128,  2132,  2136,  2140,  2144,  2148,
-    2152,  2156,  2160,  2164,  2168,  2172,  2176,  2180,  2184,  2188,
-    2192,  2196,  2200,  2204,  2208,  2212,  2216,  2220,  2224,  2228,
-    2232,  2236,  2240,  2244,  2248,  2252,  2256,  2260,  2264,  2268,
-    2273,  2277,  2281,  2286,  2290,  2294,  2299,  2304,  2308,  2312,
-    2316,  2320,  2324,  2328,  2332,  2336,  2340,  2344,  2348,  2352,
-    2356,  2360,  2364,  2368,  2372,  2376,  2380,  2384,  2388,  2392,
-    2396,  2400,  2404,  2408,  2412,  2416,  2420,  2424,  2428,  2432,
-    2436,  2440,  2444,  2448,  2452,  2456,  2460,  2464,  2468,  2472,
-    2476,  2480,  2484,  2488,  2492,  2496,  2500,  2504,  2508,  2512,
-    2516,  2520,  2524,  2528,  2532,  2536,  2540,  2544,  2548,  2552,
-    2560,  2567,  2574,  2581,  2588,  2595,  2602,  2609,  2616,  2623,
-    2630,  2637,  2647,  2651,  2655,  2659,  2663,  2667,  2671,  2675,
-    2680,  2684,  2689,  2693,  2697,  2701,  2705,  2710,  2715,  2719,
-    2723,  2727,  2731,  2735,  2739,  2743,  2747,  2751,  2755,  2759,
-    2763,  2767,  2771,  2775,  2779,  2783,  2787,  2791,  2795,  2799,
-    2803,  2807,  2811,  2815,  2819,  2823,  2827,  2831,  2835,  2839,
-    2843,  2847,  2851,  2855,  2859,  2863,  2867,  2871,  2875,  2879,
-    2883,  2887,  2891,  2895,  2899,  2903,  2907,  2911,  2915,  2919,
-    2923,  2927,  2931,  2935,  2939,  2943,  2947,  2951,  2955,  2959,
-    2963,  2967,  2971,  2975,  2979,  2983,  2987,  2991,  2995,  2999,
-    3003,  3007,  3011,  3015,  3019,  3023,  3027,  3031,  3035,  3039,
-    3043,  3047,  3051,  3055,  3062,  3066,  3070,  3074,  3078,  3085,
-    3090,  3095,  3101
+    1609,  1618,  1627,  1636,  1641,  1645,  1649,  1653,  1657,  1661,
+    1665,  1670,  1675,  1687,  1693,  1697,  1701,  1705,  1709,  1713,
+    1724,  1733,  1734,  1741,  1746,  1751,  1805,  1812,  1820,  1857,
+    1861,  1868,  1873,  1879,  1885,  1891,  1898,  1908,  1912,  1916,
+    1920,  1924,  1928,  1932,  1936,  1940,  1944,  1948,  1952,  1956,
+    1960,  1964,  1968,  1972,  1976,  1980,  1984,  1988,  1992,  1996,
+    2000,  2004,  2008,  2012,  2016,  2020,  2024,  2028,  2032,  2036,
+    2040,  2044,  2048,  2052,  2056,  2060,  2064,  2068,  2072,  2076,
+    2080,  2084,  2088,  2092,  2096,  2100,  2104,  2108,  2112,  2116,
+    2120,  2124,  2128,  2132,  2136,  2140,  2144,  2148,  2152,  2156,
+    2160,  2164,  2168,  2172,  2176,  2180,  2184,  2188,  2192,  2196,
+    2200,  2204,  2208,  2212,  2216,  2220,  2224,  2228,  2232,  2236,
+    2240,  2244,  2248,  2252,  2256,  2260,  2264,  2268,  2272,  2276,
+    2281,  2285,  2289,  2294,  2298,  2302,  2307,  2312,  2316,  2320,
+    2324,  2328,  2332,  2336,  2340,  2344,  2348,  2352,  2356,  2360,
+    2364,  2368,  2372,  2376,  2380,  2384,  2388,  2392,  2396,  2400,
+    2404,  2408,  2412,  2416,  2420,  2424,  2428,  2432,  2436,  2440,
+    2444,  2448,  2452,  2456,  2460,  2464,  2468,  2472,  2476,  2480,
+    2484,  2488,  2492,  2496,  2500,  2504,  2508,  2512,  2516,  2520,
+    2524,  2528,  2532,  2536,  2540,  2544,  2548,  2552,  2556,  2560,
+    2568,  2575,  2582,  2589,  2596,  2603,  2610,  2617,  2624,  2631,
+    2638,  2645,  2655,  2659,  2663,  2667,  2671,  2675,  2679,  2683,
+    2688,  2692,  2697,  2701,  2705,  2709,  2713,  2718,  2723,  2727,
+    2731,  2735,  2739,  2743,  2747,  2751,  2755,  2759,  2763,  2767,
+    2771,  2775,  2779,  2783,  2787,  2791,  2795,  2799,  2803,  2807,
+    2811,  2815,  2819,  2823,  2827,  2831,  2835,  2839,  2843,  2847,
+    2851,  2855,  2859,  2863,  2867,  2871,  2875,  2879,  2883,  2887,
+    2891,  2895,  2899,  2903,  2907,  2911,  2915,  2919,  2923,  2927,
+    2931,  2935,  2939,  2943,  2947,  2951,  2955,  2959,  2963,  2967,
+    2971,  2975,  2979,  2983,  2987,  2991,  2995,  2999,  3003,  3007,
+    3011,  3015,  3019,  3023,  3027,  3031,  3035,  3039,  3043,  3047,
+    3051,  3055,  3059,  3063,  3070,  3074,  3078,  3082,  3086,  3093,
+    3098,  3103,  3109
   };
 
   void
@@ -7387,9 +7395,9 @@ namespace yy {
 
 
 } // yy
-#line 7391 "seclang-parser.cc"
+#line 7399 "seclang-parser.cc"
 
-#line 3108 "seclang-parser.yy"
+#line 3116 "seclang-parser.yy"
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -1609,12 +1609,20 @@ expression:
     | CONFIG_DIR_REQ_BODY_LIMIT
       {
         driver.m_requestBodyLimit.m_set = true;
-        driver.m_requestBodyLimit.m_value = atoi($1.c_str());
+        if (modsecurity::utils::string::parse_unsigned_int($1, &driver.m_requestBodyLimit.m_value) != 1) {
+          std::stringstream ss;
+          ss << "Failed to parse SecRequestBodyLimit value as an unsigned integer.";
+          driver.error(@0, ss.str());
+        }
       }
     | CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT
       {
         driver.m_requestBodyNoFilesLimit.m_set = true;
-        driver.m_requestBodyNoFilesLimit.m_value = atoi($1.c_str());
+        if (modsecurity::utils::string::parse_unsigned_int($1, &driver.m_requestBodyNoFilesLimit.m_value) != 1) {
+          std::stringstream ss;
+          ss << "Failed to parse SecRequestBodyNoFilesLimit value as an unsigned integer.";
+          driver.error(@0, ss.str());
+        }
       }
     | CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT
       {

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <iomanip>
 #include <time.h>
+#include <climits>
 
 #ifdef WIN32
 #include "src/compat/msvc.h"
@@ -276,6 +277,30 @@ inline std::string toupper(std::string str) { // cppcheck-suppress passedByValue
     return toCaseHelper(str, ::toupper);
 }
 
+inline int parse_unsigned_int(std::string a, unsigned int *res) {
+    char *endptr = NULL;
+    errno = 0;
+
+    unsigned long val = strtoul(a.c_str(), &endptr, 10);
+
+    if (a.c_str() == endptr) {
+        // no number
+        return 0;
+    }
+
+    if (*endptr != '\0') {
+        // broken conversion
+        return 0;
+    }
+
+    if (errno == ERANGE || val > UINT_MAX) {
+        // unsigned int overflow
+        return 0;
+    }
+
+    *res = static_cast<unsigned int>(val);
+    return 1;
+}
 
 }  // namespace modsecurity::utils::string
 

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -278,7 +278,7 @@ inline std::string toupper(std::string str) { // cppcheck-suppress passedByValue
 }
 
 inline int parse_unsigned_int(const std::string &a, unsigned int *res) {
-    char *endptr = NULL;
+    char *endptr = nullptr;
     errno = 0;
 
     unsigned long val = strtoul(a.c_str(), &endptr, 10);

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -277,7 +277,7 @@ inline std::string toupper(std::string str) { // cppcheck-suppress passedByValue
     return toCaseHelper(str, ::toupper);
 }
 
-inline int parse_unsigned_int(std::string a, unsigned int *res) {
+inline int parse_unsigned_int(const std::string &a, unsigned int *res) {
     char *endptr = NULL;
     errno = 0;
 


### PR DESCRIPTION
## what

This PR fixes the possible overflow of `SecRequestBodyLimit` and `SecRequestBodyNoFilesLimit` directives.

## why

There are two reported issues:
* #3356
* #3352 

There are a few problems in handling these config variables:
* the type of variables were `double` before this patch - this makes no sense, there is no 1234.6 bytes...
* the type of variables were signed - also makes sense, there is no negative value
* the parser converted the read value with `atoi()`, which gives an integer with different bitsize

Therefore if a user gave an extra high value, then the `atoi()` converted it into a negative value.

## references

Fixes #3356 and #3352

## side note

Now there is no hardcoded limit for these values. Beside of that if the admin gives `0` (zero) value then the engine allows unlimited bytes.

I want to stop this, which means if the value of these variables aren't set or set to 0, that means the value is `0` and engine will allow only `0` byte. Hopefully this will force the admin to set an explicit value.
