### PR TITLE
fix: integer type limits

### DIFF
--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -614,8 +614,8 @@ class RulesSetProperties {
     ConfigXMLParseXmlIntoArgs m_secXMLParseXmlIntoArgs;
     ConfigBoolean m_tmpSaveUploadedFiles;
     ConfigBoolean m_uploadKeepFiles;
-    ConfigDouble m_argumentsLimit;
-    ConfigDouble m_requestBodyJsonDepthLimit;
+    ConfigUnsignedInt m_argumentsLimit;
+    ConfigUnsignedInt m_requestBodyJsonDepthLimit;
     ConfigUnsignedLong m_requestBodyLimit;
     ConfigUnsignedLong m_requestBodyNoFilesLimit;
     ConfigUnsignedLong m_responseBodyLimit;

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -13,6 +13,14 @@
  *
  */
 
+#ifdef WIN32
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+#endif
 
 #ifdef __cplusplus
 #include <ctime>

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -111,17 +111,18 @@ public:
         }
         catch (const std::invalid_argument&) {
             // probably can't occur, but we handle it anyway
-            if (errmsg) *errmsg = "Invalid number format (not numeric)";
+            set_error(errmsg, "Invalid number format (not numeric)");
             return false;
         }
         catch (const std::out_of_range&) {
-            if (errmsg) *errmsg = "Number out of range";
+            // the value is out of range, we can not handle it
+            set_error(errmsg, "Number out of range");
             return false;
         }
         catch (...) {
             // we don't need to handle all exceptions, the engine's BISON parser
             // does not allow other symbols than numbers
-            if (errmsg) *errmsg = "An unknown error occurred while parsed the value.";
+            set_error(errmsg, "An unknown error occurred while parsed the value.");
             return false;
         }
 
@@ -135,7 +136,7 @@ public:
             (val > static_cast<unsigned long long>(maxValue()))
 
         ) {
-            if (errmsg) *errmsg = "Value is too big.";
+            set_error(errmsg, "Value is too big.");
             return false;
         }
 
@@ -149,7 +150,7 @@ public:
                 ||
                 (val < static_cast<unsigned long long>(minValue()))
             ) {
-                if (errmsg) *errmsg = "Value is too small.";
+                set_error(errmsg, "Value is too small.");
                 return false;
             }
         }
@@ -161,7 +162,7 @@ public:
                 ||
                 (val < static_cast<long long>(minValue()))
             ) {
-                if (errmsg) *errmsg = "Value is too small.";
+                set_error(errmsg, "Value is too small.");
                 return false;
             }
         }
@@ -178,6 +179,11 @@ protected:
     virtual T maxValue() const = 0;
     // minValue is optional
     virtual T minValue() const { return 0; }
+
+private:
+    static inline void set_error(std::string* err, const char* msg) {
+        if (err) *err = msg;
+    }
 };
 
 /** @ingroup ModSecurity_CPP_API */

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -119,7 +119,7 @@ public:
             set_error(errmsg, "Number out of range");
             return false;
         }
-        catch (...) {
+        catch (...) { // NOSONAR
             // we don't need to handle all exceptions, the engine's BISON parser
             // does not allow other symbols than numbers
             set_error(errmsg, "An unknown error occurred while parsed the value.");

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -22,6 +22,7 @@
 #include <list>
 #include <set>
 #include <cstring>
+#include <limits>
 #endif
 
 
@@ -68,29 +69,130 @@ class Driver;
 using modsecurity::debug_log::DebugLog;
 using modsecurity::audit_log::AuditLog;
 
-/** @ingroup ModSecurity_CPP_API */
-class ConfigInt {
- public:
-    ConfigInt() : m_set(false), m_value(0) { }
-    bool m_set;
-    int m_value;
+// template for different numeric int types
+template <typename T>
+class ConfigValue {
+public:
+    bool m_set = false;
+    T m_value = 0;
 
-    void merge(const ConfigInt *from) {
-        if (m_set == true || from->m_set == false) {
-            return;
-        }
+    ConfigValue() = default;
+
+    void merge(const ConfigValue<T>* from) {
+        if (m_set || !from->m_set) return;
         m_set = true;
         m_value = from->m_value;
-        return;
+    }
+
+    // default parser
+    bool parse(const std::string& a, std::string* errmsg = nullptr) {
+
+        // use an alias type because the template can convert both signed and unsigned int
+        using LimitSigned = std::conditional_t<std::is_signed<T>::value, long long, unsigned long long>;
+        LimitSigned val;
+
+        // clear errno variable, wee need that later
+        errno = 0;
+
+        try {
+            if constexpr (std::is_signed<T>::value) {
+                val = std::stoll(a);
+            } else {
+                val = std::stoull(a);
+            }
+        } catch (...) {
+            // we don't need to handle all exceptions, the engine's BISON parser
+            // does not allow other symbols than numbers
+            if (errmsg) *errmsg = "An unknown error occurred while parsed the value.";
+            return false;
+        }
+
+        if (
+            // first condition will be true if the value is bigger than ull max value
+            // the second condition checks if the value is fit as ull, but not fit for
+            // designed type, eg. unsigned int; in that case the errno will be 0, but
+            // we must check the value is not bigger than the given maxValue at the type class
+            (errno == ERANGE && val == static_cast<unsigned long long>(maxValue()))
+            ||
+            (val > static_cast<unsigned long long>(maxValue()))
+
+        ) {
+            if (errmsg) *errmsg = "Value is too big.";
+            return false;
+        }
+
+        if constexpr (std::is_unsigned_v<T>) {
+            // we should split the check of minValue
+            // because if the type is signed, then the casted value
+            // will be a problem
+            if (
+                // same as above
+                (errno == ERANGE && val == static_cast<unsigned long long>(minValue()))
+                ||
+                (val < static_cast<unsigned long long>(minValue()))
+            ) {
+                if (errmsg) *errmsg = "Value is too small.";
+                return false;
+            }
+        }
+        else {
+            if (
+                // same as above
+                // but cast to not unsigned
+                (errno == ERANGE && val == static_cast<long long>(minValue()))
+                ||
+                (val < static_cast<long long>(minValue()))
+            ) {
+                if (errmsg) *errmsg = "Value is too small.";
+                return false;
+            }
+        }
+
+
+        m_value = static_cast<T>(val);
+        m_set = true;
+        return true;
+
+    }
+
+protected:
+    // derived classes must implement the maxValue
+    virtual T maxValue() const = 0;
+    // minValue is optional
+    virtual T minValue() const { return 0; }
+};
+
+/** @ingroup ModSecurity_CPP_API */
+
+class ConfigInt : public ConfigValue<signed int> {
+protected:
+    signed int minValue() const override {
+        return std::numeric_limits<signed int>::min();
+    }
+    signed int maxValue() const override {
+        return std::numeric_limits<signed int>::max();
     }
 };
 
+class ConfigUnsignedInt : public ConfigValue<unsigned int> {
+protected:
+    unsigned int maxValue() const override {
+        return std::numeric_limits<unsigned int>::max();
+    }
+};
+
+class ConfigUnsignedLong : public ConfigValue<unsigned long> {
+protected:
+    unsigned long maxValue() const override {
+        return std::numeric_limits<unsigned long>::max();
+    }
+};
 
 class ConfigDouble {
  public:
-    ConfigDouble() : m_set(false), m_value(0) { }
-    bool m_set;
-    double m_value;
+    bool m_set = false;
+    double m_value = 0.0;
+    ConfigDouble() = default;
 
     void merge(const ConfigDouble *from) {
         if (m_set == true || from->m_set == false) {
@@ -105,9 +207,9 @@ class ConfigDouble {
 
 class ConfigString {
  public:
-    ConfigString() : m_set(false), m_value("") { }
-    bool m_set;
-    std::string m_value;
+    bool m_set = false;
+    std::string m_value = "";
+    ConfigString() = default;
 
     void merge(const ConfigString *from) {
         if (m_set == true || from->m_set == false) {
@@ -122,10 +224,10 @@ class ConfigString {
 
 class ConfigSet {
  public:
-    ConfigSet() : m_set(false), m_clear(false) { }
-    bool m_set;
-    bool m_clear;
+    bool m_set = false;
+    bool m_clear = false;
     std::set<std::string> m_value;
+    ConfigSet() = default;
 };
 
 
@@ -506,12 +608,12 @@ class RulesSetProperties {
     ConfigBoolean m_uploadKeepFiles;
     ConfigDouble m_argumentsLimit;
     ConfigDouble m_requestBodyJsonDepthLimit;
-    ConfigDouble m_requestBodyLimit;
-    ConfigDouble m_requestBodyNoFilesLimit;
-    ConfigDouble m_responseBodyLimit;
-    ConfigInt m_pcreMatchLimit;
-    ConfigInt m_uploadFileLimit;
-    ConfigInt m_uploadFileMode;
+    ConfigUnsignedLong m_requestBodyLimit;
+    ConfigUnsignedLong m_requestBodyNoFilesLimit;
+    ConfigUnsignedLong m_responseBodyLimit;
+    ConfigUnsignedInt m_pcreMatchLimit;
+    ConfigUnsignedInt m_uploadFileLimit;
+    ConfigUnsignedInt m_uploadFileMode;
     DebugLog *m_debugLog;
     OnFailedRemoteRulesAction m_remoteRulesActionOnFailed;
     RuleEngine m_secRuleEngine;

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -96,19 +96,29 @@ public:
     bool parse(const std::string& a, std::string* errmsg = nullptr) {
 
         // use an alias type because the template can convert both signed and unsigned int
-        using LimitSigned = std::conditional_t<std::is_signed<T>::value, long long, unsigned long long>;
+        using LimitSigned = std::conditional_t<std::is_signed_v<T>, long long, unsigned long long>;
         LimitSigned val;
 
         // clear errno variable, wee need that later
         errno = 0;
 
         try {
-            if constexpr (std::is_signed<T>::value) {
+            if constexpr (std::is_signed_v<T>) {
                 val = std::stoll(a);
             } else {
                 val = std::stoull(a);
             }
-        } catch (...) {
+        }
+        catch (const std::invalid_argument&) {
+            // probably can't occur, but we handle it anyway
+            if (errmsg) *errmsg = "Invalid number format (not numeric)";
+            return false;
+        }
+        catch (const std::out_of_range&) {
+            if (errmsg) *errmsg = "Number out of range";
+            return false;
+        }
+        catch (...) {
             // we don't need to handle all exceptions, the engine's BISON parser
             // does not allow other symbols than numbers
             if (errmsg) *errmsg = "An unknown error occurred while parsed the value.";

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -1867,85 +1867,91 @@ namespace yy {
   case 24: // audit_log: "CONFIG_UPLOAD_FILE_LIMIT"
 #line 833 "seclang-parser.yy"
       {
-        driver.m_uploadFileLimit.m_set = true;
-        driver.m_uploadFileLimit.m_value = strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 10);
+        std::string errmsg = "";
+        if (driver.m_uploadFileLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
+          driver.error(yystack_[1].location, "Failed to parse SecUploadFileLimit: " + errmsg);
+          YYERROR;
+        }
       }
-#line 1874 "seclang-parser.cc"
+#line 1877 "seclang-parser.cc"
     break;
 
   case 25: // audit_log: "CONFIG_UPLOAD_FILE_MODE"
-#line 838 "seclang-parser.yy"
+#line 841 "seclang-parser.yy"
       {
-        driver.m_uploadFileMode.m_set = true;
-        driver.m_uploadFileMode.m_value = strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 8);
+        std::string errmsg = "";
+        if (driver.m_uploadFileMode.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
+          driver.error(yystack_[1].location, "Failed to parse SecUploadFileMode: " + errmsg);
+          YYERROR;
+        }
       }
-#line 1883 "seclang-parser.cc"
+#line 1889 "seclang-parser.cc"
     break;
 
   case 26: // audit_log: "CONFIG_UPLOAD_DIR"
-#line 843 "seclang-parser.yy"
+#line 849 "seclang-parser.yy"
       {
         driver.m_uploadDirectory.m_set = true;
         driver.m_uploadDirectory.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 1892 "seclang-parser.cc"
+#line 1898 "seclang-parser.cc"
     break;
 
   case 27: // audit_log: "CONFIG_UPDLOAD_SAVE_TMP_FILES" "CONFIG_VALUE_ON"
-#line 848 "seclang-parser.yy"
+#line 854 "seclang-parser.yy"
       {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 1900 "seclang-parser.cc"
+#line 1906 "seclang-parser.cc"
     break;
 
   case 28: // audit_log: "CONFIG_UPDLOAD_SAVE_TMP_FILES" "CONFIG_VALUE_OFF"
-#line 852 "seclang-parser.yy"
+#line 858 "seclang-parser.yy"
       {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 1908 "seclang-parser.cc"
+#line 1914 "seclang-parser.cc"
     break;
 
   case 29: // actions: "QUOTATION_MARK" actions_may_quoted "QUOTATION_MARK"
-#line 859 "seclang-parser.yy"
+#line 865 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1916 "seclang-parser.cc"
+#line 1922 "seclang-parser.cc"
     break;
 
   case 30: // actions: actions_may_quoted
-#line 863 "seclang-parser.yy"
+#line 869 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1924 "seclang-parser.cc"
+#line 1930 "seclang-parser.cc"
     break;
 
   case 31: // actions_may_quoted: actions_may_quoted "," act
-#line 870 "seclang-parser.yy"
+#line 876 "seclang-parser.yy"
       {
         ACTION_INIT(yystack_[0].value.as < std::unique_ptr<actions::Action> > (), yystack_[3].location)
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1934 "seclang-parser.cc"
+#line 1940 "seclang-parser.cc"
     break;
 
   case 32: // actions_may_quoted: act
-#line 876 "seclang-parser.yy"
+#line 882 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<actions::Action>>> b(new std::vector<std::unique_ptr<actions::Action>>());
         ACTION_INIT(yystack_[0].value.as < std::unique_ptr<actions::Action> > (), yystack_[1].location)
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(b);
       }
-#line 1945 "seclang-parser.cc"
+#line 1951 "seclang-parser.cc"
     break;
 
   case 33: // op: op_before_init
-#line 886 "seclang-parser.yy"
+#line 892 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as < std::unique_ptr<Operator> > ());
         std::string error;
@@ -1954,11 +1960,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1958 "seclang-parser.cc"
+#line 1964 "seclang-parser.cc"
     break;
 
   case 34: // op: "NOT" op_before_init
-#line 895 "seclang-parser.yy"
+#line 901 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as < std::unique_ptr<Operator> > ());
         yylhs.value.as < std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1968,11 +1974,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1972 "seclang-parser.cc"
+#line 1978 "seclang-parser.cc"
     break;
 
   case 35: // op: run_time_string
-#line 905 "seclang-parser.yy"
+#line 911 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
         std::string error;
@@ -1981,11 +1987,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1985 "seclang-parser.cc"
+#line 1991 "seclang-parser.cc"
     break;
 
   case 36: // op: "NOT" run_time_string
-#line 914 "seclang-parser.yy"
+#line 920 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
         yylhs.value.as < std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1995,302 +2001,302 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1999 "seclang-parser.cc"
+#line 2005 "seclang-parser.cc"
     break;
 
   case 37: // op_before_init: "OPERATOR_UNCONDITIONAL_MATCH"
-#line 927 "seclang-parser.yy"
+#line 933 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::UnconditionalMatch());
       }
-#line 2007 "seclang-parser.cc"
+#line 2013 "seclang-parser.cc"
     break;
 
   case 38: // op_before_init: "OPERATOR_DETECT_SQLI"
-#line 931 "seclang-parser.yy"
+#line 937 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::DetectSQLi());
       }
-#line 2015 "seclang-parser.cc"
+#line 2021 "seclang-parser.cc"
     break;
 
   case 39: // op_before_init: "OPERATOR_DETECT_XSS"
-#line 935 "seclang-parser.yy"
+#line 941 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::DetectXSS());
       }
-#line 2023 "seclang-parser.cc"
+#line 2029 "seclang-parser.cc"
     break;
 
   case 40: // op_before_init: "OPERATOR_VALIDATE_URL_ENCODING"
-#line 939 "seclang-parser.yy"
+#line 945 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateUrlEncoding());
       }
-#line 2031 "seclang-parser.cc"
+#line 2037 "seclang-parser.cc"
     break;
 
   case 41: // op_before_init: "OPERATOR_VALIDATE_UTF8_ENCODING"
-#line 943 "seclang-parser.yy"
+#line 949 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateUtf8Encoding());
       }
-#line 2039 "seclang-parser.cc"
+#line 2045 "seclang-parser.cc"
     break;
 
   case 42: // op_before_init: "OPERATOR_INSPECT_FILE" run_time_string
-#line 947 "seclang-parser.yy"
+#line 953 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::InspectFile(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2047 "seclang-parser.cc"
+#line 2053 "seclang-parser.cc"
     break;
 
   case 43: // op_before_init: "OPERATOR_FUZZY_HASH" run_time_string
-#line 951 "seclang-parser.yy"
+#line 957 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::FuzzyHash(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2055 "seclang-parser.cc"
+#line 2061 "seclang-parser.cc"
     break;
 
   case 44: // op_before_init: "OPERATOR_VALIDATE_BYTE_RANGE" run_time_string
-#line 955 "seclang-parser.yy"
+#line 961 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateByteRange(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2063 "seclang-parser.cc"
+#line 2069 "seclang-parser.cc"
     break;
 
   case 45: // op_before_init: "OPERATOR_VALIDATE_DTD" run_time_string
-#line 959 "seclang-parser.yy"
+#line 965 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateDTD(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2071 "seclang-parser.cc"
+#line 2077 "seclang-parser.cc"
     break;
 
   case 46: // op_before_init: "OPERATOR_VALIDATE_HASH" run_time_string
-#line 963 "seclang-parser.yy"
+#line 969 "seclang-parser.yy"
       {
         /* $$ = new operators::ValidateHash($1); */
         OPERATOR_NOT_SUPPORTED("ValidateHash", yystack_[2].location);
       }
-#line 2080 "seclang-parser.cc"
+#line 2086 "seclang-parser.cc"
     break;
 
   case 47: // op_before_init: "OPERATOR_VALIDATE_SCHEMA" run_time_string
-#line 968 "seclang-parser.yy"
+#line 974 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateSchema(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2088 "seclang-parser.cc"
+#line 2094 "seclang-parser.cc"
     break;
 
   case 48: // op_before_init: "OPERATOR_VERIFY_CC" run_time_string
-#line 972 "seclang-parser.yy"
+#line 978 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifyCC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2096 "seclang-parser.cc"
+#line 2102 "seclang-parser.cc"
     break;
 
   case 49: // op_before_init: "OPERATOR_VERIFY_CPF" run_time_string
-#line 976 "seclang-parser.yy"
+#line 982 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifyCPF(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2104 "seclang-parser.cc"
+#line 2110 "seclang-parser.cc"
     break;
 
   case 50: // op_before_init: "OPERATOR_VERIFY_SSN" run_time_string
-#line 980 "seclang-parser.yy"
+#line 986 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifySSN(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2112 "seclang-parser.cc"
+#line 2118 "seclang-parser.cc"
     break;
 
   case 51: // op_before_init: "OPERATOR_VERIFY_SVNR" run_time_string
-#line 984 "seclang-parser.yy"
+#line 990 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifySVNR(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2120 "seclang-parser.cc"
+#line 2126 "seclang-parser.cc"
     break;
 
   case 52: // op_before_init: "OPERATOR_GSB_LOOKUP" run_time_string
-#line 988 "seclang-parser.yy"
+#line 994 "seclang-parser.yy"
       {
         /* $$ = new operators::GsbLookup($1); */
         OPERATOR_NOT_SUPPORTED("GsbLookup", yystack_[2].location);
       }
-#line 2129 "seclang-parser.cc"
+#line 2135 "seclang-parser.cc"
     break;
 
   case 53: // op_before_init: "OPERATOR_RSUB" run_time_string
-#line 993 "seclang-parser.yy"
+#line 999 "seclang-parser.yy"
       {
         /* $$ = new operators::Rsub($1); */
         OPERATOR_NOT_SUPPORTED("Rsub", yystack_[2].location);
       }
-#line 2138 "seclang-parser.cc"
+#line 2144 "seclang-parser.cc"
     break;
 
   case 54: // op_before_init: "OPERATOR_WITHIN" run_time_string
-#line 998 "seclang-parser.yy"
+#line 1004 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Within(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2146 "seclang-parser.cc"
+#line 2152 "seclang-parser.cc"
     break;
 
   case 55: // op_before_init: "OPERATOR_CONTAINS_WORD" run_time_string
-#line 1002 "seclang-parser.yy"
+#line 1008 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ContainsWord(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2154 "seclang-parser.cc"
+#line 2160 "seclang-parser.cc"
     break;
 
   case 56: // op_before_init: "OPERATOR_CONTAINS" run_time_string
-#line 1006 "seclang-parser.yy"
+#line 1012 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Contains(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2162 "seclang-parser.cc"
+#line 2168 "seclang-parser.cc"
     break;
 
   case 57: // op_before_init: "OPERATOR_ENDS_WITH" run_time_string
-#line 1010 "seclang-parser.yy"
+#line 1016 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::EndsWith(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2170 "seclang-parser.cc"
+#line 2176 "seclang-parser.cc"
     break;
 
   case 58: // op_before_init: "OPERATOR_EQ" run_time_string
-#line 1014 "seclang-parser.yy"
+#line 1020 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Eq(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2178 "seclang-parser.cc"
+#line 2184 "seclang-parser.cc"
     break;
 
   case 59: // op_before_init: "OPERATOR_GE" run_time_string
-#line 1018 "seclang-parser.yy"
+#line 1024 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Ge(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2186 "seclang-parser.cc"
+#line 2192 "seclang-parser.cc"
     break;
 
   case 60: // op_before_init: "OPERATOR_GT" run_time_string
-#line 1022 "seclang-parser.yy"
+#line 1028 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Gt(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2194 "seclang-parser.cc"
+#line 2200 "seclang-parser.cc"
     break;
 
   case 61: // op_before_init: "OPERATOR_IP_MATCH_FROM_FILE" run_time_string
-#line 1026 "seclang-parser.yy"
+#line 1032 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::IpMatchF(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2202 "seclang-parser.cc"
+#line 2208 "seclang-parser.cc"
     break;
 
   case 62: // op_before_init: "OPERATOR_IP_MATCH" run_time_string
-#line 1030 "seclang-parser.yy"
+#line 1036 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::IpMatch(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2210 "seclang-parser.cc"
+#line 2216 "seclang-parser.cc"
     break;
 
   case 63: // op_before_init: "OPERATOR_LE" run_time_string
-#line 1034 "seclang-parser.yy"
+#line 1040 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Le(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2218 "seclang-parser.cc"
+#line 2224 "seclang-parser.cc"
     break;
 
   case 64: // op_before_init: "OPERATOR_LT" run_time_string
-#line 1038 "seclang-parser.yy"
+#line 1044 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Lt(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2226 "seclang-parser.cc"
+#line 2232 "seclang-parser.cc"
     break;
 
   case 65: // op_before_init: "OPERATOR_PM_FROM_FILE" run_time_string
-#line 1042 "seclang-parser.yy"
+#line 1048 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::PmFromFile(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2234 "seclang-parser.cc"
+#line 2240 "seclang-parser.cc"
     break;
 
   case 66: // op_before_init: "OPERATOR_PM" run_time_string
-#line 1046 "seclang-parser.yy"
+#line 1052 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Pm(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2242 "seclang-parser.cc"
+#line 2248 "seclang-parser.cc"
     break;
 
   case 67: // op_before_init: "OPERATOR_RBL" run_time_string
-#line 1050 "seclang-parser.yy"
+#line 1056 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rbl(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2250 "seclang-parser.cc"
+#line 2256 "seclang-parser.cc"
     break;
 
   case 68: // op_before_init: "OPERATOR_RX" run_time_string
-#line 1054 "seclang-parser.yy"
+#line 1060 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2258 "seclang-parser.cc"
+#line 2264 "seclang-parser.cc"
     break;
 
   case 69: // op_before_init: "OPERATOR_RX_GLOBAL" run_time_string
-#line 1058 "seclang-parser.yy"
+#line 1064 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::RxGlobal(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2266 "seclang-parser.cc"
+#line 2272 "seclang-parser.cc"
     break;
 
   case 70: // op_before_init: "OPERATOR_STR_EQ" run_time_string
-#line 1062 "seclang-parser.yy"
+#line 1068 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::StrEq(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2274 "seclang-parser.cc"
+#line 2280 "seclang-parser.cc"
     break;
 
   case 71: // op_before_init: "OPERATOR_STR_MATCH" run_time_string
-#line 1066 "seclang-parser.yy"
+#line 1072 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::StrMatch(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2282 "seclang-parser.cc"
+#line 2288 "seclang-parser.cc"
     break;
 
   case 72: // op_before_init: "OPERATOR_BEGINS_WITH" run_time_string
-#line 1070 "seclang-parser.yy"
+#line 1076 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::BeginsWith(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2290 "seclang-parser.cc"
+#line 2296 "seclang-parser.cc"
     break;
 
   case 73: // op_before_init: "OPERATOR_GEOLOOKUP"
-#line 1074 "seclang-parser.yy"
+#line 1080 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::GeoLookup());
@@ -2301,11 +2307,11 @@ namespace yy {
             YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 2305 "seclang-parser.cc"
+#line 2311 "seclang-parser.cc"
     break;
 
   case 75: // expression: "DIRECTIVE" variables op actions
-#line 1089 "seclang-parser.yy"
+#line 1095 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
@@ -2336,11 +2342,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2340 "seclang-parser.cc"
+#line 2346 "seclang-parser.cc"
     break;
 
   case 76: // expression: "DIRECTIVE" variables op
-#line 1120 "seclang-parser.yy"
+#line 1126 "seclang-parser.yy"
       {
         variables::Variables *v = new variables::Variables();
         for (auto &i : *yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ().get()) {
@@ -2359,11 +2365,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2363 "seclang-parser.cc"
+#line 2369 "seclang-parser.cc"
     break;
 
   case 77: // expression: "CONFIG_DIR_SEC_ACTION" actions
-#line 1139 "seclang-parser.yy"
+#line 1145 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
@@ -2383,11 +2389,11 @@ namespace yy {
             ));
         driver.addSecAction(std::move(rule));
       }
-#line 2387 "seclang-parser.cc"
+#line 2393 "seclang-parser.cc"
     break;
 
   case 78: // expression: "DIRECTIVE_SECRULESCRIPT" actions
-#line 1159 "seclang-parser.yy"
+#line 1165 "seclang-parser.yy"
       {
         std::string err;
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
@@ -2416,11 +2422,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2420 "seclang-parser.cc"
+#line 2426 "seclang-parser.cc"
     break;
 
   case 79: // expression: "CONFIG_DIR_SEC_DEFAULT_ACTION" actions
-#line 1188 "seclang-parser.yy"
+#line 1194 "seclang-parser.yy"
       {
         bool hasDisruptive = false;
         std::vector<actions::Action *> *actions = new std::vector<actions::Action *>();
@@ -2477,78 +2483,78 @@ namespace yy {
 
         delete actions;
       }
-#line 2481 "seclang-parser.cc"
+#line 2487 "seclang-parser.cc"
     break;
 
   case 80: // expression: "CONFIG_DIR_SEC_MARKER"
-#line 1245 "seclang-parser.yy"
+#line 1251 "seclang-parser.yy"
       {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as < std::string > ()),
             /* file name */ std::string(*yystack_[0].location.end.filename),
             /* line number */ yystack_[0].location.end.line
         );
       }
-#line 2492 "seclang-parser.cc"
+#line 2498 "seclang-parser.cc"
     break;
 
   case 81: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_OFF"
-#line 1252 "seclang-parser.yy"
+#line 1258 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DisabledRuleEngine;
       }
-#line 2500 "seclang-parser.cc"
+#line 2506 "seclang-parser.cc"
     break;
 
   case 82: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_ON"
-#line 1256 "seclang-parser.yy"
+#line 1262 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::EnabledRuleEngine;
       }
-#line 2508 "seclang-parser.cc"
+#line 2514 "seclang-parser.cc"
     break;
 
   case 83: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_DETC"
-#line 1260 "seclang-parser.yy"
+#line 1266 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DetectionOnlyRuleEngine;
       }
-#line 2516 "seclang-parser.cc"
+#line 2522 "seclang-parser.cc"
     break;
 
   case 84: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_ON"
-#line 1264 "seclang-parser.yy"
+#line 1270 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2524 "seclang-parser.cc"
+#line 2530 "seclang-parser.cc"
     break;
 
   case 85: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_OFF"
-#line 1268 "seclang-parser.yy"
+#line 1274 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2532 "seclang-parser.cc"
+#line 2538 "seclang-parser.cc"
     break;
 
   case 86: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_ON"
-#line 1272 "seclang-parser.yy"
+#line 1278 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2540 "seclang-parser.cc"
+#line 2546 "seclang-parser.cc"
     break;
 
   case 87: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_OFF"
-#line 1276 "seclang-parser.yy"
+#line 1282 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2548 "seclang-parser.cc"
+#line 2554 "seclang-parser.cc"
     break;
 
   case 88: // expression: "CONFIG_SEC_ARGUMENT_SEPARATOR"
-#line 1280 "seclang-parser.yy"
+#line 1286 "seclang-parser.yy"
       {
         if (yystack_[0].value.as < std::string > ().length() != 1) {
           driver.error(yystack_[1].location, "Argument separator should be set to a single character.");
@@ -2557,259 +2563,259 @@ namespace yy {
         driver.m_secArgumentSeparator.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secArgumentSeparator.m_set = true;
       }
-#line 2561 "seclang-parser.cc"
+#line 2567 "seclang-parser.cc"
     break;
 
   case 89: // expression: "CONFIG_COMPONENT_SIG"
-#line 1289 "seclang-parser.yy"
+#line 1295 "seclang-parser.yy"
       {
         driver.m_components.push_back(yystack_[0].value.as < std::string > ());
       }
-#line 2569 "seclang-parser.cc"
+#line 2575 "seclang-parser.cc"
     break;
 
   case 90: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_ON"
-#line 1293 "seclang-parser.yy"
+#line 1299 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecConnEngine is not yet supported.");
         YYERROR;
       }
-#line 2578 "seclang-parser.cc"
+#line 2584 "seclang-parser.cc"
     break;
 
   case 91: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_OFF"
-#line 1298 "seclang-parser.yy"
+#line 1304 "seclang-parser.yy"
       {
       }
-#line 2585 "seclang-parser.cc"
+#line 2591 "seclang-parser.cc"
     break;
 
   case 92: // expression: "CONFIG_SEC_WEB_APP_ID"
-#line 1301 "seclang-parser.yy"
+#line 1307 "seclang-parser.yy"
       {
         driver.m_secWebAppId.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secWebAppId.m_set = true;
       }
-#line 2594 "seclang-parser.cc"
+#line 2600 "seclang-parser.cc"
     break;
 
   case 93: // expression: "CONFIG_SEC_SERVER_SIG"
-#line 1306 "seclang-parser.yy"
+#line 1312 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecServerSignature is not supported.");
         YYERROR;
       }
-#line 2603 "seclang-parser.cc"
+#line 2609 "seclang-parser.cc"
     break;
 
   case 94: // expression: "CONFIG_SEC_CACHE_TRANSFORMATIONS"
-#line 1311 "seclang-parser.yy"
+#line 1317 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCacheTransformations is not supported.");
         YYERROR;
       }
-#line 2612 "seclang-parser.cc"
+#line 2618 "seclang-parser.cc"
     break;
 
   case 95: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_ON"
-#line 1316 "seclang-parser.yy"
+#line 1322 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecDisableBackendCompression is not supported.");
         YYERROR;
       }
-#line 2621 "seclang-parser.cc"
+#line 2627 "seclang-parser.cc"
     break;
 
   case 96: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_OFF"
-#line 1321 "seclang-parser.yy"
+#line 1327 "seclang-parser.yy"
       {
       }
-#line 2628 "seclang-parser.cc"
+#line 2634 "seclang-parser.cc"
     break;
 
   case 97: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_ON"
-#line 1324 "seclang-parser.yy"
+#line 1330 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecContentInjection is not yet supported.");
         YYERROR;
       }
-#line 2637 "seclang-parser.cc"
+#line 2643 "seclang-parser.cc"
     break;
 
   case 98: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_OFF"
-#line 1329 "seclang-parser.yy"
+#line 1335 "seclang-parser.yy"
       {
       }
-#line 2644 "seclang-parser.cc"
+#line 2650 "seclang-parser.cc"
     break;
 
   case 99: // expression: "CONFIG_SEC_CHROOT_DIR"
-#line 1332 "seclang-parser.yy"
+#line 1338 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecChrootDir is not supported.");
         YYERROR;
       }
-#line 2653 "seclang-parser.cc"
+#line 2659 "seclang-parser.cc"
     break;
 
   case 100: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_ON"
-#line 1337 "seclang-parser.yy"
+#line 1343 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecHashEngine is not yet supported.");
         YYERROR;
       }
-#line 2662 "seclang-parser.cc"
+#line 2668 "seclang-parser.cc"
     break;
 
   case 101: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_OFF"
-#line 1342 "seclang-parser.yy"
+#line 1348 "seclang-parser.yy"
       {
       }
-#line 2669 "seclang-parser.cc"
+#line 2675 "seclang-parser.cc"
     break;
 
   case 102: // expression: "CONFIG_SEC_HASH_KEY"
-#line 1345 "seclang-parser.yy"
+#line 1351 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashKey is not yet supported.");
         YYERROR;
       }
-#line 2678 "seclang-parser.cc"
+#line 2684 "seclang-parser.cc"
     break;
 
   case 103: // expression: "CONFIG_SEC_HASH_PARAM"
-#line 1350 "seclang-parser.yy"
+#line 1356 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashParam is not yet supported.");
         YYERROR;
       }
-#line 2687 "seclang-parser.cc"
+#line 2693 "seclang-parser.cc"
     break;
 
   case 104: // expression: "CONFIG_SEC_HASH_METHOD_RX"
-#line 1355 "seclang-parser.yy"
+#line 1361 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodRx is not yet supported.");
         YYERROR;
       }
-#line 2696 "seclang-parser.cc"
+#line 2702 "seclang-parser.cc"
     break;
 
   case 105: // expression: "CONFIG_SEC_HASH_METHOD_PM"
-#line 1360 "seclang-parser.yy"
+#line 1366 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodPm is not yet supported.");
         YYERROR;
       }
-#line 2705 "seclang-parser.cc"
+#line 2711 "seclang-parser.cc"
     break;
 
   case 106: // expression: "CONFIG_DIR_GSB_DB"
-#line 1365 "seclang-parser.yy"
+#line 1371 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGsbLookupDb is not supported.");
         YYERROR;
       }
-#line 2714 "seclang-parser.cc"
+#line 2720 "seclang-parser.cc"
     break;
 
   case 107: // expression: "CONFIG_SEC_GUARDIAN_LOG"
-#line 1370 "seclang-parser.yy"
+#line 1376 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGuardianLog is not supported.");
         YYERROR;
       }
-#line 2723 "seclang-parser.cc"
+#line 2729 "seclang-parser.cc"
     break;
 
   case 108: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_ON"
-#line 1375 "seclang-parser.yy"
+#line 1381 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecInterceptOnError is not yet supported.");
         YYERROR;
       }
-#line 2732 "seclang-parser.cc"
+#line 2738 "seclang-parser.cc"
     break;
 
   case 109: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_OFF"
-#line 1380 "seclang-parser.yy"
+#line 1386 "seclang-parser.yy"
       {
       }
-#line 2739 "seclang-parser.cc"
+#line 2745 "seclang-parser.cc"
     break;
 
   case 110: // expression: "CONFIG_SEC_CONN_R_STATE_LIMIT"
-#line 1383 "seclang-parser.yy"
+#line 1389 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnReadStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2748 "seclang-parser.cc"
+#line 2754 "seclang-parser.cc"
     break;
 
   case 111: // expression: "CONFIG_SEC_CONN_W_STATE_LIMIT"
-#line 1388 "seclang-parser.yy"
+#line 1394 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnWriteStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2757 "seclang-parser.cc"
+#line 2763 "seclang-parser.cc"
     break;
 
   case 112: // expression: "CONFIG_SEC_SENSOR_ID"
-#line 1393 "seclang-parser.yy"
+#line 1399 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecSensorId is not yet supported.");
         YYERROR;
       }
-#line 2766 "seclang-parser.cc"
+#line 2772 "seclang-parser.cc"
     break;
 
   case 113: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_ON"
-#line 1398 "seclang-parser.yy"
+#line 1404 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecRuleInheritance is not yet supported.");
         YYERROR;
       }
-#line 2775 "seclang-parser.cc"
+#line 2781 "seclang-parser.cc"
     break;
 
   case 114: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_OFF"
-#line 1403 "seclang-parser.yy"
+#line 1409 "seclang-parser.yy"
       {
       }
-#line 2782 "seclang-parser.cc"
+#line 2788 "seclang-parser.cc"
     break;
 
   case 115: // expression: "CONFIG_SEC_RULE_PERF_TIME"
-#line 1406 "seclang-parser.yy"
+#line 1412 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecRulePerfTime is not yet supported.");
         YYERROR;
       }
-#line 2791 "seclang-parser.cc"
+#line 2797 "seclang-parser.cc"
     break;
 
   case 116: // expression: "CONFIG_SEC_STREAM_IN_BODY_INSPECTION"
-#line 1411 "seclang-parser.yy"
+#line 1417 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamInBodyInspection is not supported.");
         YYERROR;
       }
-#line 2800 "seclang-parser.cc"
+#line 2806 "seclang-parser.cc"
     break;
 
   case 117: // expression: "CONFIG_SEC_STREAM_OUT_BODY_INSPECTION"
-#line 1416 "seclang-parser.yy"
+#line 1422 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamOutBodyInspection is not supported.");
         YYERROR;
       }
-#line 2809 "seclang-parser.cc"
+#line 2815 "seclang-parser.cc"
     break;
 
   case 118: // expression: "CONFIG_SEC_RULE_REMOVE_BY_ID"
-#line 1421 "seclang-parser.yy"
+#line 1427 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.load(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2822,11 +2828,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2826 "seclang-parser.cc"
+#line 2832 "seclang-parser.cc"
     break;
 
   case 119: // expression: "CONFIG_SEC_RULE_REMOVE_BY_TAG"
-#line 1434 "seclang-parser.yy"
+#line 1440 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByTag(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2839,11 +2845,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2843 "seclang-parser.cc"
+#line 2849 "seclang-parser.cc"
     break;
 
   case 120: // expression: "CONFIG_SEC_RULE_REMOVE_BY_MSG"
-#line 1447 "seclang-parser.yy"
+#line 1453 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByMsg(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2856,11 +2862,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2860 "seclang-parser.cc"
+#line 2866 "seclang-parser.cc"
     break;
 
   case 121: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_TAG" variables_pre_process
-#line 1460 "seclang-parser.yy"
+#line 1466 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByTag(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2873,11 +2879,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2877 "seclang-parser.cc"
+#line 2883 "seclang-parser.cc"
     break;
 
   case 122: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_MSG" variables_pre_process
-#line 1473 "seclang-parser.yy"
+#line 1479 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByMsg(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2890,11 +2896,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2894 "seclang-parser.cc"
+#line 2900 "seclang-parser.cc"
     break;
 
   case 123: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID" variables_pre_process
-#line 1486 "seclang-parser.yy"
+#line 1492 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2920,11 +2926,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2924 "seclang-parser.cc"
+#line 2930 "seclang-parser.cc"
     break;
 
   case 124: // expression: "CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID" actions
-#line 1512 "seclang-parser.yy"
+#line 1518 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2951,11 +2957,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2955 "seclang-parser.cc"
+#line 2961 "seclang-parser.cc"
     break;
 
   case 125: // expression: "CONFIG_DIR_DEBUG_LVL"
-#line 1540 "seclang-parser.yy"
+#line 1546 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as < std::string > ().c_str()));
@@ -2967,11 +2973,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2971 "seclang-parser.cc"
+#line 2977 "seclang-parser.cc"
     break;
 
   case 126: // expression: "CONFIG_DIR_DEBUG_LOG"
-#line 1552 "seclang-parser.yy"
+#line 1558 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -2990,11 +2996,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2994 "seclang-parser.cc"
+#line 3000 "seclang-parser.cc"
     break;
 
   case 127: // expression: "CONFIG_DIR_GEO_DB"
-#line 1572 "seclang-parser.yy"
+#line 1578 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
@@ -3021,47 +3027,53 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 3025 "seclang-parser.cc"
+#line 3031 "seclang-parser.cc"
     break;
 
   case 128: // expression: "CONFIG_DIR_ARGS_LIMIT"
-#line 1599 "seclang-parser.yy"
+#line 1605 "seclang-parser.yy"
       {
         driver.m_argumentsLimit.m_set = true;
         driver.m_argumentsLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3034 "seclang-parser.cc"
+#line 3040 "seclang-parser.cc"
     break;
 
   case 129: // expression: "CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT"
-#line 1604 "seclang-parser.yy"
+#line 1610 "seclang-parser.yy"
       {
         driver.m_requestBodyJsonDepthLimit.m_set = true;
         driver.m_requestBodyJsonDepthLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3043 "seclang-parser.cc"
+#line 3049 "seclang-parser.cc"
     break;
 
   case 130: // expression: "CONFIG_DIR_REQ_BODY_LIMIT"
-#line 1610 "seclang-parser.yy"
+#line 1616 "seclang-parser.yy"
       {
-        driver.m_requestBodyLimit.m_set = true;
-        driver.m_requestBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
-      }
-#line 3052 "seclang-parser.cc"
-    break;
-
-  case 131: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
-#line 1615 "seclang-parser.yy"
-      {
-        driver.m_requestBodyNoFilesLimit.m_set = true;
-        driver.m_requestBodyNoFilesLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
+        std::string errmsg = "";
+        if (driver.m_requestBodyLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
+          driver.error(yystack_[1].location, "Failed to parse SecRequestBodyLimit: " + errmsg);
+          YYERROR;
+        }
       }
 #line 3061 "seclang-parser.cc"
     break;
 
+  case 131: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
+#line 1624 "seclang-parser.yy"
+      {
+        std::string errmsg = "";
+        if (driver.m_requestBodyNoFilesLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
+          driver.error(yystack_[1].location, "Failed to parse SecRequestsBodyNoFilesLimit: " + errmsg);
+          YYERROR;
+        }
+      }
+#line 3073 "seclang-parser.cc"
+    break;
+
   case 132: // expression: "CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT"
-#line 1620 "seclang-parser.yy"
+#line 1632 "seclang-parser.yy"
       {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -3070,77 +3082,83 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 3074 "seclang-parser.cc"
+#line 3086 "seclang-parser.cc"
     break;
 
   case 133: // expression: "CONFIG_DIR_RES_BODY_LIMIT"
-#line 1629 "seclang-parser.yy"
+#line 1641 "seclang-parser.yy"
       {
-        driver.m_responseBodyLimit.m_set = true;
-        driver.m_responseBodyLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
+        std::string errmsg = "";
+        if (driver.m_responseBodyLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
+          driver.error(yystack_[1].location, "Failed to parse SecResponseBodyLimit: " + errmsg);
+          YYERROR;
+        }
       }
-#line 3083 "seclang-parser.cc"
+#line 3098 "seclang-parser.cc"
     break;
 
   case 134: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1634 "seclang-parser.yy"
+#line 1649 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3091 "seclang-parser.cc"
+#line 3106 "seclang-parser.cc"
     break;
 
   case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1638 "seclang-parser.yy"
+#line 1653 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3099 "seclang-parser.cc"
+#line 3114 "seclang-parser.cc"
     break;
 
   case 136: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1642 "seclang-parser.yy"
+#line 1657 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3107 "seclang-parser.cc"
+#line 3122 "seclang-parser.cc"
     break;
 
   case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1646 "seclang-parser.yy"
+#line 1661 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3115 "seclang-parser.cc"
+#line 3130 "seclang-parser.cc"
     break;
 
   case 138: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
-#line 1650 "seclang-parser.yy"
+#line 1665 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 3123 "seclang-parser.cc"
+#line 3138 "seclang-parser.cc"
     break;
 
   case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
-#line 1654 "seclang-parser.yy"
+#line 1669 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 3131 "seclang-parser.cc"
+#line 3146 "seclang-parser.cc"
     break;
 
   case 141: // expression: "CONFIG_DIR_PCRE_MATCH_LIMIT"
-#line 1663 "seclang-parser.yy"
+#line 1678 "seclang-parser.yy"
       {
-        driver.m_pcreMatchLimit.m_set = true;
-        driver.m_pcreMatchLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
+        std::string errmsg = "";
+        if (driver.m_pcreMatchLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
+          driver.error(yystack_[1].location, "Failed to parse SecPcreMatchLimit: " + errmsg);
+          YYERROR;
+        }
       }
-#line 3140 "seclang-parser.cc"
+#line 3158 "seclang-parser.cc"
     break;
 
   case 142: // expression: "CONGIG_DIR_RESPONSE_BODY_MP"
-#line 1668 "seclang-parser.yy"
+#line 1686 "seclang-parser.yy"
       {
         std::istringstream buf(yystack_[0].value.as < std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -3152,61 +3170,61 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 3156 "seclang-parser.cc"
+#line 3174 "seclang-parser.cc"
     break;
 
   case 143: // expression: "CONGIG_DIR_RESPONSE_BODY_MP_CLEAR"
-#line 1680 "seclang-parser.yy"
+#line 1698 "seclang-parser.yy"
       {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 3166 "seclang-parser.cc"
+#line 3184 "seclang-parser.cc"
     break;
 
   case 144: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
-#line 1686 "seclang-parser.yy"
+#line 1704 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 3174 "seclang-parser.cc"
+#line 3192 "seclang-parser.cc"
     break;
 
   case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
-#line 1690 "seclang-parser.yy"
+#line 1708 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 3182 "seclang-parser.cc"
+#line 3200 "seclang-parser.cc"
     break;
 
   case 146: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
-#line 1694 "seclang-parser.yy"
+#line 1712 "seclang-parser.yy"
       {
         driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::OnlyArgsConfigXMLParseXmlIntoArgs;
       }
-#line 3190 "seclang-parser.cc"
+#line 3208 "seclang-parser.cc"
     break;
 
   case 147: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
-#line 1698 "seclang-parser.yy"
+#line 1716 "seclang-parser.yy"
       {
         driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::FalseConfigXMLParseXmlIntoArgs;
       }
-#line 3198 "seclang-parser.cc"
+#line 3216 "seclang-parser.cc"
     break;
 
   case 148: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
-#line 1702 "seclang-parser.yy"
+#line 1720 "seclang-parser.yy"
       {
         driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::TrueConfigXMLParseXmlIntoArgs;
       }
-#line 3206 "seclang-parser.cc"
+#line 3224 "seclang-parser.cc"
     break;
 
   case 149: // expression: "CONGIG_DIR_SEC_TMP_DIR"
-#line 1706 "seclang-parser.yy"
+#line 1724 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
         std::stringstream ss;
@@ -3217,31 +3235,31 @@ namespace yy {
         YYERROR;
 */
       }
-#line 3221 "seclang-parser.cc"
+#line 3239 "seclang-parser.cc"
     break;
 
   case 152: // expression: "CONGIG_DIR_SEC_COOKIE_FORMAT"
-#line 1727 "seclang-parser.yy"
+#line 1745 "seclang-parser.yy"
       {
         if (atoi(yystack_[0].value.as < std::string > ().c_str()) == 1) {
           driver.error(yystack_[1].location, "SecCookieFormat 1 is not yet supported.");
           YYERROR;
         }
       }
-#line 3232 "seclang-parser.cc"
+#line 3250 "seclang-parser.cc"
     break;
 
   case 153: // expression: "CONFIG_SEC_COOKIEV0_SEPARATOR"
-#line 1734 "seclang-parser.yy"
+#line 1752 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCookieV0Separator is not yet supported.");
         YYERROR;
       }
-#line 3241 "seclang-parser.cc"
+#line 3259 "seclang-parser.cc"
     break;
 
   case 155: // expression: "CONFIG_DIR_UNICODE_MAP_FILE"
-#line 1744 "seclang-parser.yy"
+#line 1762 "seclang-parser.yy"
       {
         std::string error;
         std::vector<std::string> param;
@@ -3295,31 +3313,31 @@ namespace yy {
         }
 
       }
-#line 3299 "seclang-parser.cc"
+#line 3317 "seclang-parser.cc"
     break;
 
   case 156: // expression: "CONFIG_SEC_COLLECTION_TIMEOUT"
-#line 1798 "seclang-parser.yy"
+#line 1816 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default CRS installations with crs-setup.conf-recommended
         driver.error(@0, "SecCollectionTimeout is not yet supported.");
         YYERROR;
 */
       }
-#line 3310 "seclang-parser.cc"
+#line 3328 "seclang-parser.cc"
     break;
 
   case 157: // expression: "CONFIG_SEC_HTTP_BLKEY"
-#line 1805 "seclang-parser.yy"
+#line 1823 "seclang-parser.yy"
       {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 3319 "seclang-parser.cc"
+#line 3337 "seclang-parser.cc"
     break;
 
   case 158: // variables: variables_pre_process
-#line 1813 "seclang-parser.yy"
+#line 1831 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable> > > originalList = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> newList(new std::vector<std::unique_ptr<Variable>>());
@@ -3353,2425 +3371,2425 @@ namespace yy {
         }
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(newNewList);
       }
-#line 3357 "seclang-parser.cc"
+#line 3375 "seclang-parser.cc"
     break;
 
   case 159: // variables_pre_process: variables_may_be_quoted
-#line 1850 "seclang-parser.yy"
+#line 1868 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3365 "seclang-parser.cc"
+#line 3383 "seclang-parser.cc"
     break;
 
   case 160: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
-#line 1854 "seclang-parser.yy"
+#line 1872 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3373 "seclang-parser.cc"
+#line 3391 "seclang-parser.cc"
     break;
 
   case 161: // variables_may_be_quoted: variables_may_be_quoted PIPE var
-#line 1861 "seclang-parser.yy"
+#line 1879 "seclang-parser.yy"
       {
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3382 "seclang-parser.cc"
+#line 3400 "seclang-parser.cc"
     break;
 
   case 162: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_EXCLUSION var
-#line 1866 "seclang-parser.yy"
+#line 1884 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3392 "seclang-parser.cc"
+#line 3410 "seclang-parser.cc"
     break;
 
   case 163: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_COUNT var
-#line 1872 "seclang-parser.yy"
+#line 1890 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3402 "seclang-parser.cc"
+#line 3420 "seclang-parser.cc"
     break;
 
   case 164: // variables_may_be_quoted: var
-#line 1878 "seclang-parser.yy"
+#line 1896 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3412 "seclang-parser.cc"
+#line 3430 "seclang-parser.cc"
     break;
 
   case 165: // variables_may_be_quoted: VAR_EXCLUSION var
-#line 1884 "seclang-parser.yy"
+#line 1902 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3423 "seclang-parser.cc"
+#line 3441 "seclang-parser.cc"
     break;
 
   case 166: // variables_may_be_quoted: VAR_COUNT var
-#line 1891 "seclang-parser.yy"
+#line 1909 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3434 "seclang-parser.cc"
+#line 3452 "seclang-parser.cc"
     break;
 
   case 167: // var: VARIABLE_ARGS "Dictionary element"
-#line 1901 "seclang-parser.yy"
+#line 1919 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3442 "seclang-parser.cc"
+#line 3460 "seclang-parser.cc"
     break;
 
   case 168: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
-#line 1905 "seclang-parser.yy"
+#line 1923 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3450 "seclang-parser.cc"
+#line 3468 "seclang-parser.cc"
     break;
 
   case 169: // var: VARIABLE_ARGS
-#line 1909 "seclang-parser.yy"
+#line 1927 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
       }
-#line 3458 "seclang-parser.cc"
+#line 3476 "seclang-parser.cc"
     break;
 
   case 170: // var: VARIABLE_ARGS_POST "Dictionary element"
-#line 1913 "seclang-parser.yy"
+#line 1931 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3466 "seclang-parser.cc"
+#line 3484 "seclang-parser.cc"
     break;
 
   case 171: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
-#line 1917 "seclang-parser.yy"
+#line 1935 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3474 "seclang-parser.cc"
+#line 3492 "seclang-parser.cc"
     break;
 
   case 172: // var: VARIABLE_ARGS_POST
-#line 1921 "seclang-parser.yy"
+#line 1939 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
       }
-#line 3482 "seclang-parser.cc"
+#line 3500 "seclang-parser.cc"
     break;
 
   case 173: // var: VARIABLE_ARGS_GET "Dictionary element"
-#line 1925 "seclang-parser.yy"
+#line 1943 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3490 "seclang-parser.cc"
+#line 3508 "seclang-parser.cc"
     break;
 
   case 174: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
-#line 1929 "seclang-parser.yy"
+#line 1947 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3498 "seclang-parser.cc"
+#line 3516 "seclang-parser.cc"
     break;
 
   case 175: // var: VARIABLE_ARGS_GET
-#line 1933 "seclang-parser.yy"
+#line 1951 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
       }
-#line 3506 "seclang-parser.cc"
+#line 3524 "seclang-parser.cc"
     break;
 
   case 176: // var: VARIABLE_FILES_SIZES "Dictionary element"
-#line 1937 "seclang-parser.yy"
+#line 1955 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3514 "seclang-parser.cc"
+#line 3532 "seclang-parser.cc"
     break;
 
   case 177: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
-#line 1941 "seclang-parser.yy"
+#line 1959 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3522 "seclang-parser.cc"
+#line 3540 "seclang-parser.cc"
     break;
 
   case 178: // var: VARIABLE_FILES_SIZES
-#line 1945 "seclang-parser.yy"
+#line 1963 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
       }
-#line 3530 "seclang-parser.cc"
+#line 3548 "seclang-parser.cc"
     break;
 
   case 179: // var: VARIABLE_FILES_NAMES "Dictionary element"
-#line 1949 "seclang-parser.yy"
+#line 1967 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3538 "seclang-parser.cc"
+#line 3556 "seclang-parser.cc"
     break;
 
   case 180: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
-#line 1953 "seclang-parser.yy"
+#line 1971 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3546 "seclang-parser.cc"
+#line 3564 "seclang-parser.cc"
     break;
 
   case 181: // var: VARIABLE_FILES_NAMES
-#line 1957 "seclang-parser.yy"
+#line 1975 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
       }
-#line 3554 "seclang-parser.cc"
+#line 3572 "seclang-parser.cc"
     break;
 
   case 182: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
-#line 1961 "seclang-parser.yy"
+#line 1979 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3562 "seclang-parser.cc"
+#line 3580 "seclang-parser.cc"
     break;
 
   case 183: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
-#line 1965 "seclang-parser.yy"
+#line 1983 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3570 "seclang-parser.cc"
+#line 3588 "seclang-parser.cc"
     break;
 
   case 184: // var: VARIABLE_FILES_TMP_CONTENT
-#line 1969 "seclang-parser.yy"
+#line 1987 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
       }
-#line 3578 "seclang-parser.cc"
+#line 3596 "seclang-parser.cc"
     break;
 
   case 185: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
-#line 1973 "seclang-parser.yy"
+#line 1991 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3586 "seclang-parser.cc"
+#line 3604 "seclang-parser.cc"
     break;
 
   case 186: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
-#line 1977 "seclang-parser.yy"
+#line 1995 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3594 "seclang-parser.cc"
+#line 3612 "seclang-parser.cc"
     break;
 
   case 187: // var: VARIABLE_MULTIPART_FILENAME
-#line 1981 "seclang-parser.yy"
+#line 1999 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
       }
-#line 3602 "seclang-parser.cc"
+#line 3620 "seclang-parser.cc"
     break;
 
   case 188: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
-#line 1985 "seclang-parser.yy"
+#line 2003 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3610 "seclang-parser.cc"
+#line 3628 "seclang-parser.cc"
     break;
 
   case 189: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
-#line 1989 "seclang-parser.yy"
+#line 2007 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3618 "seclang-parser.cc"
+#line 3636 "seclang-parser.cc"
     break;
 
   case 190: // var: VARIABLE_MULTIPART_NAME
-#line 1993 "seclang-parser.yy"
+#line 2011 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
       }
-#line 3626 "seclang-parser.cc"
+#line 3644 "seclang-parser.cc"
     break;
 
   case 191: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
-#line 1997 "seclang-parser.yy"
+#line 2015 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3634 "seclang-parser.cc"
+#line 3652 "seclang-parser.cc"
     break;
 
   case 192: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
-#line 2001 "seclang-parser.yy"
+#line 2019 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3642 "seclang-parser.cc"
+#line 3660 "seclang-parser.cc"
     break;
 
   case 193: // var: VARIABLE_MATCHED_VARS_NAMES
-#line 2005 "seclang-parser.yy"
+#line 2023 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
       }
-#line 3650 "seclang-parser.cc"
+#line 3668 "seclang-parser.cc"
     break;
 
   case 194: // var: VARIABLE_MATCHED_VARS "Dictionary element"
-#line 2009 "seclang-parser.yy"
+#line 2027 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3658 "seclang-parser.cc"
+#line 3676 "seclang-parser.cc"
     break;
 
   case 195: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
-#line 2013 "seclang-parser.yy"
+#line 2031 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3666 "seclang-parser.cc"
+#line 3684 "seclang-parser.cc"
     break;
 
   case 196: // var: VARIABLE_MATCHED_VARS
-#line 2017 "seclang-parser.yy"
+#line 2035 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
       }
-#line 3674 "seclang-parser.cc"
+#line 3692 "seclang-parser.cc"
     break;
 
   case 197: // var: VARIABLE_FILES "Dictionary element"
-#line 2021 "seclang-parser.yy"
+#line 2039 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3682 "seclang-parser.cc"
+#line 3700 "seclang-parser.cc"
     break;
 
   case 198: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
-#line 2025 "seclang-parser.yy"
+#line 2043 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3690 "seclang-parser.cc"
+#line 3708 "seclang-parser.cc"
     break;
 
   case 199: // var: VARIABLE_FILES
-#line 2029 "seclang-parser.yy"
+#line 2047 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
       }
-#line 3698 "seclang-parser.cc"
+#line 3716 "seclang-parser.cc"
     break;
 
   case 200: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
-#line 2033 "seclang-parser.yy"
+#line 2051 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3706 "seclang-parser.cc"
+#line 3724 "seclang-parser.cc"
     break;
 
   case 201: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
-#line 2037 "seclang-parser.yy"
+#line 2055 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3714 "seclang-parser.cc"
+#line 3732 "seclang-parser.cc"
     break;
 
   case 202: // var: VARIABLE_REQUEST_COOKIES
-#line 2041 "seclang-parser.yy"
+#line 2059 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
       }
-#line 3722 "seclang-parser.cc"
+#line 3740 "seclang-parser.cc"
     break;
 
   case 203: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
-#line 2045 "seclang-parser.yy"
+#line 2063 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3730 "seclang-parser.cc"
+#line 3748 "seclang-parser.cc"
     break;
 
   case 204: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
-#line 2049 "seclang-parser.yy"
+#line 2067 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3738 "seclang-parser.cc"
+#line 3756 "seclang-parser.cc"
     break;
 
   case 205: // var: VARIABLE_REQUEST_HEADERS
-#line 2053 "seclang-parser.yy"
+#line 2071 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
       }
-#line 3746 "seclang-parser.cc"
+#line 3764 "seclang-parser.cc"
     break;
 
   case 206: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
-#line 2057 "seclang-parser.yy"
+#line 2075 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3754 "seclang-parser.cc"
+#line 3772 "seclang-parser.cc"
     break;
 
   case 207: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
-#line 2061 "seclang-parser.yy"
+#line 2079 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3762 "seclang-parser.cc"
+#line 3780 "seclang-parser.cc"
     break;
 
   case 208: // var: VARIABLE_RESPONSE_HEADERS
-#line 2065 "seclang-parser.yy"
+#line 2083 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
       }
-#line 3770 "seclang-parser.cc"
+#line 3788 "seclang-parser.cc"
     break;
 
   case 209: // var: VARIABLE_GEO "Dictionary element"
-#line 2069 "seclang-parser.yy"
+#line 2087 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3778 "seclang-parser.cc"
+#line 3796 "seclang-parser.cc"
     break;
 
   case 210: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
-#line 2073 "seclang-parser.yy"
+#line 2091 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3786 "seclang-parser.cc"
+#line 3804 "seclang-parser.cc"
     break;
 
   case 211: // var: VARIABLE_GEO
-#line 2077 "seclang-parser.yy"
+#line 2095 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
       }
-#line 3794 "seclang-parser.cc"
+#line 3812 "seclang-parser.cc"
     break;
 
   case 212: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
-#line 2081 "seclang-parser.yy"
+#line 2099 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3802 "seclang-parser.cc"
+#line 3820 "seclang-parser.cc"
     break;
 
   case 213: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
-#line 2085 "seclang-parser.yy"
+#line 2103 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3810 "seclang-parser.cc"
+#line 3828 "seclang-parser.cc"
     break;
 
   case 214: // var: VARIABLE_REQUEST_COOKIES_NAMES
-#line 2089 "seclang-parser.yy"
+#line 2107 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
       }
-#line 3818 "seclang-parser.cc"
+#line 3836 "seclang-parser.cc"
     break;
 
   case 215: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element"
-#line 2093 "seclang-parser.yy"
+#line 2111 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3826 "seclang-parser.cc"
+#line 3844 "seclang-parser.cc"
     break;
 
   case 216: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element, selected by regexp"
-#line 2097 "seclang-parser.yy"
+#line 2115 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3834 "seclang-parser.cc"
+#line 3852 "seclang-parser.cc"
     break;
 
   case 217: // var: VARIABLE_MULTIPART_PART_HEADERS
-#line 2101 "seclang-parser.yy"
+#line 2119 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_NoDictElement());
       }
-#line 3842 "seclang-parser.cc"
+#line 3860 "seclang-parser.cc"
     break;
 
   case 218: // var: VARIABLE_RULE "Dictionary element"
-#line 2105 "seclang-parser.yy"
+#line 2123 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3850 "seclang-parser.cc"
+#line 3868 "seclang-parser.cc"
     break;
 
   case 219: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
-#line 2109 "seclang-parser.yy"
+#line 2127 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3858 "seclang-parser.cc"
+#line 3876 "seclang-parser.cc"
     break;
 
   case 220: // var: VARIABLE_RULE
-#line 2113 "seclang-parser.yy"
+#line 2131 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
       }
-#line 3866 "seclang-parser.cc"
+#line 3884 "seclang-parser.cc"
     break;
 
   case 221: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
-#line 2117 "seclang-parser.yy"
+#line 2135 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3874 "seclang-parser.cc"
+#line 3892 "seclang-parser.cc"
     break;
 
   case 222: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
-#line 2121 "seclang-parser.yy"
+#line 2139 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3882 "seclang-parser.cc"
+#line 3900 "seclang-parser.cc"
     break;
 
   case 223: // var: "RUN_TIME_VAR_ENV"
-#line 2125 "seclang-parser.yy"
+#line 2143 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
       }
-#line 3890 "seclang-parser.cc"
+#line 3908 "seclang-parser.cc"
     break;
 
   case 224: // var: "RUN_TIME_VAR_XML" "Dictionary element"
-#line 2129 "seclang-parser.yy"
+#line 2147 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3898 "seclang-parser.cc"
+#line 3916 "seclang-parser.cc"
     break;
 
   case 225: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
-#line 2133 "seclang-parser.yy"
+#line 2151 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3906 "seclang-parser.cc"
+#line 3924 "seclang-parser.cc"
     break;
 
   case 226: // var: "RUN_TIME_VAR_XML"
-#line 2137 "seclang-parser.yy"
+#line 2155 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
       }
-#line 3914 "seclang-parser.cc"
+#line 3932 "seclang-parser.cc"
     break;
 
   case 227: // var: "FILES_TMPNAMES" "Dictionary element"
-#line 2141 "seclang-parser.yy"
+#line 2159 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3922 "seclang-parser.cc"
+#line 3940 "seclang-parser.cc"
     break;
 
   case 228: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
-#line 2145 "seclang-parser.yy"
+#line 2163 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3930 "seclang-parser.cc"
+#line 3948 "seclang-parser.cc"
     break;
 
   case 229: // var: "FILES_TMPNAMES"
-#line 2149 "seclang-parser.yy"
+#line 2167 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
       }
-#line 3938 "seclang-parser.cc"
+#line 3956 "seclang-parser.cc"
     break;
 
   case 230: // var: "RESOURCE" run_time_string
-#line 2153 "seclang-parser.yy"
+#line 2171 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3946 "seclang-parser.cc"
+#line 3964 "seclang-parser.cc"
     break;
 
   case 231: // var: "RESOURCE" "Dictionary element"
-#line 2157 "seclang-parser.yy"
+#line 2175 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3954 "seclang-parser.cc"
+#line 3972 "seclang-parser.cc"
     break;
 
   case 232: // var: "RESOURCE" "Dictionary element, selected by regexp"
-#line 2161 "seclang-parser.yy"
+#line 2179 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3962 "seclang-parser.cc"
+#line 3980 "seclang-parser.cc"
     break;
 
   case 233: // var: "RESOURCE"
-#line 2165 "seclang-parser.yy"
+#line 2183 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
       }
-#line 3970 "seclang-parser.cc"
+#line 3988 "seclang-parser.cc"
     break;
 
   case 234: // var: "VARIABLE_IP" run_time_string
-#line 2169 "seclang-parser.yy"
+#line 2187 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3978 "seclang-parser.cc"
+#line 3996 "seclang-parser.cc"
     break;
 
   case 235: // var: "VARIABLE_IP" "Dictionary element"
-#line 2173 "seclang-parser.yy"
+#line 2191 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3986 "seclang-parser.cc"
+#line 4004 "seclang-parser.cc"
     break;
 
   case 236: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
-#line 2177 "seclang-parser.yy"
+#line 2195 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3994 "seclang-parser.cc"
+#line 4012 "seclang-parser.cc"
     break;
 
   case 237: // var: "VARIABLE_IP"
-#line 2181 "seclang-parser.yy"
+#line 2199 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
       }
-#line 4002 "seclang-parser.cc"
+#line 4020 "seclang-parser.cc"
     break;
 
   case 238: // var: "VARIABLE_GLOBAL" run_time_string
-#line 2185 "seclang-parser.yy"
+#line 2203 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4010 "seclang-parser.cc"
+#line 4028 "seclang-parser.cc"
     break;
 
   case 239: // var: "VARIABLE_GLOBAL" "Dictionary element"
-#line 2189 "seclang-parser.yy"
+#line 2207 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4018 "seclang-parser.cc"
+#line 4036 "seclang-parser.cc"
     break;
 
   case 240: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
-#line 2193 "seclang-parser.yy"
+#line 2211 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4026 "seclang-parser.cc"
+#line 4044 "seclang-parser.cc"
     break;
 
   case 241: // var: "VARIABLE_GLOBAL"
-#line 2197 "seclang-parser.yy"
+#line 2215 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
       }
-#line 4034 "seclang-parser.cc"
+#line 4052 "seclang-parser.cc"
     break;
 
   case 242: // var: "VARIABLE_USER" run_time_string
-#line 2201 "seclang-parser.yy"
+#line 2219 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4042 "seclang-parser.cc"
+#line 4060 "seclang-parser.cc"
     break;
 
   case 243: // var: "VARIABLE_USER" "Dictionary element"
-#line 2205 "seclang-parser.yy"
+#line 2223 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4050 "seclang-parser.cc"
+#line 4068 "seclang-parser.cc"
     break;
 
   case 244: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
-#line 2209 "seclang-parser.yy"
+#line 2227 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4058 "seclang-parser.cc"
+#line 4076 "seclang-parser.cc"
     break;
 
   case 245: // var: "VARIABLE_USER"
-#line 2213 "seclang-parser.yy"
+#line 2231 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
       }
-#line 4066 "seclang-parser.cc"
+#line 4084 "seclang-parser.cc"
     break;
 
   case 246: // var: "VARIABLE_TX" run_time_string
-#line 2217 "seclang-parser.yy"
+#line 2235 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4074 "seclang-parser.cc"
+#line 4092 "seclang-parser.cc"
     break;
 
   case 247: // var: "VARIABLE_TX" "Dictionary element"
-#line 2221 "seclang-parser.yy"
+#line 2239 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4082 "seclang-parser.cc"
+#line 4100 "seclang-parser.cc"
     break;
 
   case 248: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
-#line 2225 "seclang-parser.yy"
+#line 2243 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4090 "seclang-parser.cc"
+#line 4108 "seclang-parser.cc"
     break;
 
   case 249: // var: "VARIABLE_TX"
-#line 2229 "seclang-parser.yy"
+#line 2247 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
       }
-#line 4098 "seclang-parser.cc"
+#line 4116 "seclang-parser.cc"
     break;
 
   case 250: // var: "VARIABLE_SESSION" run_time_string
-#line 2233 "seclang-parser.yy"
+#line 2251 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4106 "seclang-parser.cc"
+#line 4124 "seclang-parser.cc"
     break;
 
   case 251: // var: "VARIABLE_SESSION" "Dictionary element"
-#line 2237 "seclang-parser.yy"
+#line 2255 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4114 "seclang-parser.cc"
+#line 4132 "seclang-parser.cc"
     break;
 
   case 252: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
-#line 2241 "seclang-parser.yy"
+#line 2259 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4122 "seclang-parser.cc"
+#line 4140 "seclang-parser.cc"
     break;
 
   case 253: // var: "VARIABLE_SESSION"
-#line 2245 "seclang-parser.yy"
+#line 2263 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
       }
-#line 4130 "seclang-parser.cc"
+#line 4148 "seclang-parser.cc"
     break;
 
   case 254: // var: "Variable ARGS_NAMES" "Dictionary element"
-#line 2249 "seclang-parser.yy"
+#line 2267 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4138 "seclang-parser.cc"
+#line 4156 "seclang-parser.cc"
     break;
 
   case 255: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
-#line 2253 "seclang-parser.yy"
+#line 2271 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4146 "seclang-parser.cc"
+#line 4164 "seclang-parser.cc"
     break;
 
   case 256: // var: "Variable ARGS_NAMES"
-#line 2257 "seclang-parser.yy"
+#line 2275 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
       }
-#line 4154 "seclang-parser.cc"
+#line 4172 "seclang-parser.cc"
     break;
 
   case 257: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
-#line 2261 "seclang-parser.yy"
+#line 2279 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4162 "seclang-parser.cc"
+#line 4180 "seclang-parser.cc"
     break;
 
   case 258: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
-#line 2265 "seclang-parser.yy"
+#line 2283 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4170 "seclang-parser.cc"
+#line 4188 "seclang-parser.cc"
     break;
 
   case 259: // var: VARIABLE_ARGS_GET_NAMES
-#line 2269 "seclang-parser.yy"
+#line 2287 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
       }
-#line 4178 "seclang-parser.cc"
+#line 4196 "seclang-parser.cc"
     break;
 
   case 260: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
-#line 2274 "seclang-parser.yy"
+#line 2292 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4186 "seclang-parser.cc"
+#line 4204 "seclang-parser.cc"
     break;
 
   case 261: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
-#line 2278 "seclang-parser.yy"
+#line 2296 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4194 "seclang-parser.cc"
+#line 4212 "seclang-parser.cc"
     break;
 
   case 262: // var: VARIABLE_ARGS_POST_NAMES
-#line 2282 "seclang-parser.yy"
+#line 2300 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
       }
-#line 4202 "seclang-parser.cc"
+#line 4220 "seclang-parser.cc"
     break;
 
   case 263: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
-#line 2287 "seclang-parser.yy"
+#line 2305 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4210 "seclang-parser.cc"
+#line 4228 "seclang-parser.cc"
     break;
 
   case 264: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2291 "seclang-parser.yy"
+#line 2309 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4218 "seclang-parser.cc"
+#line 4236 "seclang-parser.cc"
     break;
 
   case 265: // var: VARIABLE_REQUEST_HEADERS_NAMES
-#line 2295 "seclang-parser.yy"
+#line 2313 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
       }
-#line 4226 "seclang-parser.cc"
+#line 4244 "seclang-parser.cc"
     break;
 
   case 266: // var: VARIABLE_RESPONSE_CONTENT_TYPE
-#line 2300 "seclang-parser.yy"
+#line 2318 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
       }
-#line 4234 "seclang-parser.cc"
+#line 4252 "seclang-parser.cc"
     break;
 
   case 267: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
-#line 2305 "seclang-parser.yy"
+#line 2323 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4242 "seclang-parser.cc"
+#line 4260 "seclang-parser.cc"
     break;
 
   case 268: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2309 "seclang-parser.yy"
+#line 2327 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4250 "seclang-parser.cc"
+#line 4268 "seclang-parser.cc"
     break;
 
   case 269: // var: VARIABLE_RESPONSE_HEADERS_NAMES
-#line 2313 "seclang-parser.yy"
+#line 2331 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
       }
-#line 4258 "seclang-parser.cc"
+#line 4276 "seclang-parser.cc"
     break;
 
   case 270: // var: VARIABLE_ARGS_COMBINED_SIZE
-#line 2317 "seclang-parser.yy"
+#line 2335 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
       }
-#line 4266 "seclang-parser.cc"
+#line 4284 "seclang-parser.cc"
     break;
 
   case 271: // var: "AUTH_TYPE"
-#line 2321 "seclang-parser.yy"
+#line 2339 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
       }
-#line 4274 "seclang-parser.cc"
+#line 4292 "seclang-parser.cc"
     break;
 
   case 272: // var: "FILES_COMBINED_SIZE"
-#line 2325 "seclang-parser.yy"
+#line 2343 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
       }
-#line 4282 "seclang-parser.cc"
+#line 4300 "seclang-parser.cc"
     break;
 
   case 273: // var: "FULL_REQUEST"
-#line 2329 "seclang-parser.yy"
+#line 2347 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
       }
-#line 4290 "seclang-parser.cc"
+#line 4308 "seclang-parser.cc"
     break;
 
   case 274: // var: "FULL_REQUEST_LENGTH"
-#line 2333 "seclang-parser.yy"
+#line 2351 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
       }
-#line 4298 "seclang-parser.cc"
+#line 4316 "seclang-parser.cc"
     break;
 
   case 275: // var: "INBOUND_DATA_ERROR"
-#line 2337 "seclang-parser.yy"
+#line 2355 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
       }
-#line 4306 "seclang-parser.cc"
+#line 4324 "seclang-parser.cc"
     break;
 
   case 276: // var: "MATCHED_VAR"
-#line 2341 "seclang-parser.yy"
+#line 2359 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
       }
-#line 4314 "seclang-parser.cc"
+#line 4332 "seclang-parser.cc"
     break;
 
   case 277: // var: "MATCHED_VAR_NAME"
-#line 2345 "seclang-parser.yy"
+#line 2363 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
       }
-#line 4322 "seclang-parser.cc"
+#line 4340 "seclang-parser.cc"
     break;
 
   case 278: // var: "MSC_PCRE_ERROR"
-#line 2349 "seclang-parser.yy"
+#line 2367 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreError());
       }
-#line 4330 "seclang-parser.cc"
+#line 4348 "seclang-parser.cc"
     break;
 
   case 279: // var: "MSC_PCRE_LIMITS_EXCEEDED"
-#line 2353 "seclang-parser.yy"
+#line 2371 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreLimitsExceeded());
       }
-#line 4338 "seclang-parser.cc"
+#line 4356 "seclang-parser.cc"
     break;
 
   case 280: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
-#line 2357 "seclang-parser.yy"
+#line 2375 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
       }
-#line 4346 "seclang-parser.cc"
+#line 4364 "seclang-parser.cc"
     break;
 
   case 281: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
-#line 2361 "seclang-parser.yy"
+#line 2379 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
       }
-#line 4354 "seclang-parser.cc"
+#line 4372 "seclang-parser.cc"
     break;
 
   case 282: // var: "MULTIPART_CRLF_LF_LINES"
-#line 2365 "seclang-parser.yy"
+#line 2383 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
       }
-#line 4362 "seclang-parser.cc"
+#line 4380 "seclang-parser.cc"
     break;
 
   case 283: // var: "MULTIPART_DATA_AFTER"
-#line 2369 "seclang-parser.yy"
+#line 2387 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
       }
-#line 4370 "seclang-parser.cc"
+#line 4388 "seclang-parser.cc"
     break;
 
   case 284: // var: VARIABLE_MULTIPART_DATA_BEFORE
-#line 2373 "seclang-parser.yy"
+#line 2391 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
       }
-#line 4378 "seclang-parser.cc"
+#line 4396 "seclang-parser.cc"
     break;
 
   case 285: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
-#line 2377 "seclang-parser.yy"
+#line 2395 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
       }
-#line 4386 "seclang-parser.cc"
+#line 4404 "seclang-parser.cc"
     break;
 
   case 286: // var: "MULTIPART_HEADER_FOLDING"
-#line 2381 "seclang-parser.yy"
+#line 2399 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
       }
-#line 4394 "seclang-parser.cc"
+#line 4412 "seclang-parser.cc"
     break;
 
   case 287: // var: "MULTIPART_INVALID_HEADER_FOLDING"
-#line 2385 "seclang-parser.yy"
+#line 2403 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
       }
-#line 4402 "seclang-parser.cc"
+#line 4420 "seclang-parser.cc"
     break;
 
   case 288: // var: VARIABLE_MULTIPART_INVALID_PART
-#line 2389 "seclang-parser.yy"
+#line 2407 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
       }
-#line 4410 "seclang-parser.cc"
+#line 4428 "seclang-parser.cc"
     break;
 
   case 289: // var: "MULTIPART_INVALID_QUOTING"
-#line 2393 "seclang-parser.yy"
+#line 2411 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
       }
-#line 4418 "seclang-parser.cc"
+#line 4436 "seclang-parser.cc"
     break;
 
   case 290: // var: VARIABLE_MULTIPART_LF_LINE
-#line 2397 "seclang-parser.yy"
+#line 2415 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
       }
-#line 4426 "seclang-parser.cc"
+#line 4444 "seclang-parser.cc"
     break;
 
   case 291: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
-#line 2401 "seclang-parser.yy"
+#line 2419 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4434 "seclang-parser.cc"
+#line 4452 "seclang-parser.cc"
     break;
 
   case 292: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
-#line 2405 "seclang-parser.yy"
+#line 2423 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4442 "seclang-parser.cc"
+#line 4460 "seclang-parser.cc"
     break;
 
   case 293: // var: "MULTIPART_STRICT_ERROR"
-#line 2409 "seclang-parser.yy"
+#line 2427 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
       }
-#line 4450 "seclang-parser.cc"
+#line 4468 "seclang-parser.cc"
     break;
 
   case 294: // var: "MULTIPART_UNMATCHED_BOUNDARY"
-#line 2413 "seclang-parser.yy"
+#line 2431 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
       }
-#line 4458 "seclang-parser.cc"
+#line 4476 "seclang-parser.cc"
     break;
 
   case 295: // var: "OUTBOUND_DATA_ERROR"
-#line 2417 "seclang-parser.yy"
+#line 2435 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
       }
-#line 4466 "seclang-parser.cc"
+#line 4484 "seclang-parser.cc"
     break;
 
   case 296: // var: "PATH_INFO"
-#line 2421 "seclang-parser.yy"
+#line 2439 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
       }
-#line 4474 "seclang-parser.cc"
+#line 4492 "seclang-parser.cc"
     break;
 
   case 297: // var: "QUERY_STRING"
-#line 2425 "seclang-parser.yy"
+#line 2443 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
       }
-#line 4482 "seclang-parser.cc"
+#line 4500 "seclang-parser.cc"
     break;
 
   case 298: // var: "REMOTE_ADDR"
-#line 2429 "seclang-parser.yy"
+#line 2447 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
       }
-#line 4490 "seclang-parser.cc"
+#line 4508 "seclang-parser.cc"
     break;
 
   case 299: // var: "REMOTE_HOST"
-#line 2433 "seclang-parser.yy"
+#line 2451 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
       }
-#line 4498 "seclang-parser.cc"
+#line 4516 "seclang-parser.cc"
     break;
 
   case 300: // var: "REMOTE_PORT"
-#line 2437 "seclang-parser.yy"
+#line 2455 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
       }
-#line 4506 "seclang-parser.cc"
+#line 4524 "seclang-parser.cc"
     break;
 
   case 301: // var: "REQBODY_ERROR"
-#line 2441 "seclang-parser.yy"
+#line 2459 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
       }
-#line 4514 "seclang-parser.cc"
+#line 4532 "seclang-parser.cc"
     break;
 
   case 302: // var: "REQBODY_ERROR_MSG"
-#line 2445 "seclang-parser.yy"
+#line 2463 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
       }
-#line 4522 "seclang-parser.cc"
+#line 4540 "seclang-parser.cc"
     break;
 
   case 303: // var: "REQBODY_PROCESSOR"
-#line 2449 "seclang-parser.yy"
+#line 2467 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
       }
-#line 4530 "seclang-parser.cc"
+#line 4548 "seclang-parser.cc"
     break;
 
   case 304: // var: "REQBODY_PROCESSOR_ERROR"
-#line 2453 "seclang-parser.yy"
+#line 2471 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
       }
-#line 4538 "seclang-parser.cc"
+#line 4556 "seclang-parser.cc"
     break;
 
   case 305: // var: "REQBODY_PROCESSOR_ERROR_MSG"
-#line 2457 "seclang-parser.yy"
+#line 2475 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
       }
-#line 4546 "seclang-parser.cc"
+#line 4564 "seclang-parser.cc"
     break;
 
   case 306: // var: "REQUEST_BASENAME"
-#line 2461 "seclang-parser.yy"
+#line 2479 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
       }
-#line 4554 "seclang-parser.cc"
+#line 4572 "seclang-parser.cc"
     break;
 
   case 307: // var: "REQUEST_BODY"
-#line 2465 "seclang-parser.yy"
+#line 2483 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
       }
-#line 4562 "seclang-parser.cc"
+#line 4580 "seclang-parser.cc"
     break;
 
   case 308: // var: "REQUEST_BODY_LENGTH"
-#line 2469 "seclang-parser.yy"
+#line 2487 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
       }
-#line 4570 "seclang-parser.cc"
+#line 4588 "seclang-parser.cc"
     break;
 
   case 309: // var: "REQUEST_FILENAME"
-#line 2473 "seclang-parser.yy"
+#line 2491 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
       }
-#line 4578 "seclang-parser.cc"
+#line 4596 "seclang-parser.cc"
     break;
 
   case 310: // var: "REQUEST_LINE"
-#line 2477 "seclang-parser.yy"
+#line 2495 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
       }
-#line 4586 "seclang-parser.cc"
+#line 4604 "seclang-parser.cc"
     break;
 
   case 311: // var: "REQUEST_METHOD"
-#line 2481 "seclang-parser.yy"
+#line 2499 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
       }
-#line 4594 "seclang-parser.cc"
+#line 4612 "seclang-parser.cc"
     break;
 
   case 312: // var: "REQUEST_PROTOCOL"
-#line 2485 "seclang-parser.yy"
+#line 2503 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
       }
-#line 4602 "seclang-parser.cc"
+#line 4620 "seclang-parser.cc"
     break;
 
   case 313: // var: "REQUEST_URI"
-#line 2489 "seclang-parser.yy"
+#line 2507 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
       }
-#line 4610 "seclang-parser.cc"
+#line 4628 "seclang-parser.cc"
     break;
 
   case 314: // var: "REQUEST_URI_RAW"
-#line 2493 "seclang-parser.yy"
+#line 2511 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
       }
-#line 4618 "seclang-parser.cc"
+#line 4636 "seclang-parser.cc"
     break;
 
   case 315: // var: "RESPONSE_BODY"
-#line 2497 "seclang-parser.yy"
+#line 2515 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
       }
-#line 4626 "seclang-parser.cc"
+#line 4644 "seclang-parser.cc"
     break;
 
   case 316: // var: "RESPONSE_CONTENT_LENGTH"
-#line 2501 "seclang-parser.yy"
+#line 2519 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
       }
-#line 4634 "seclang-parser.cc"
+#line 4652 "seclang-parser.cc"
     break;
 
   case 317: // var: "RESPONSE_PROTOCOL"
-#line 2505 "seclang-parser.yy"
+#line 2523 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
       }
-#line 4642 "seclang-parser.cc"
+#line 4660 "seclang-parser.cc"
     break;
 
   case 318: // var: "RESPONSE_STATUS"
-#line 2509 "seclang-parser.yy"
+#line 2527 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
       }
-#line 4650 "seclang-parser.cc"
+#line 4668 "seclang-parser.cc"
     break;
 
   case 319: // var: "SERVER_ADDR"
-#line 2513 "seclang-parser.yy"
+#line 2531 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
       }
-#line 4658 "seclang-parser.cc"
+#line 4676 "seclang-parser.cc"
     break;
 
   case 320: // var: "SERVER_NAME"
-#line 2517 "seclang-parser.yy"
+#line 2535 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
       }
-#line 4666 "seclang-parser.cc"
+#line 4684 "seclang-parser.cc"
     break;
 
   case 321: // var: "SERVER_PORT"
-#line 2521 "seclang-parser.yy"
+#line 2539 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
       }
-#line 4674 "seclang-parser.cc"
+#line 4692 "seclang-parser.cc"
     break;
 
   case 322: // var: "SESSIONID"
-#line 2525 "seclang-parser.yy"
+#line 2543 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
       }
-#line 4682 "seclang-parser.cc"
+#line 4700 "seclang-parser.cc"
     break;
 
   case 323: // var: "UNIQUE_ID"
-#line 2529 "seclang-parser.yy"
+#line 2547 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
       }
-#line 4690 "seclang-parser.cc"
+#line 4708 "seclang-parser.cc"
     break;
 
   case 324: // var: "URLENCODED_ERROR"
-#line 2533 "seclang-parser.yy"
+#line 2551 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
       }
-#line 4698 "seclang-parser.cc"
+#line 4716 "seclang-parser.cc"
     break;
 
   case 325: // var: "USERID"
-#line 2537 "seclang-parser.yy"
+#line 2555 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
       }
-#line 4706 "seclang-parser.cc"
+#line 4724 "seclang-parser.cc"
     break;
 
   case 326: // var: "VARIABLE_STATUS"
-#line 2541 "seclang-parser.yy"
+#line 2559 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4714 "seclang-parser.cc"
+#line 4732 "seclang-parser.cc"
     break;
 
   case 327: // var: "VARIABLE_STATUS_LINE"
-#line 2545 "seclang-parser.yy"
+#line 2563 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4722 "seclang-parser.cc"
+#line 4740 "seclang-parser.cc"
     break;
 
   case 328: // var: "WEBAPPID"
-#line 2549 "seclang-parser.yy"
+#line 2567 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
       }
-#line 4730 "seclang-parser.cc"
+#line 4748 "seclang-parser.cc"
     break;
 
   case 329: // var: "RUN_TIME_VAR_DUR"
-#line 2553 "seclang-parser.yy"
+#line 2571 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4741 "seclang-parser.cc"
+#line 4759 "seclang-parser.cc"
     break;
 
   case 330: // var: "RUN_TIME_VAR_BLD"
-#line 2561 "seclang-parser.yy"
+#line 2579 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4752 "seclang-parser.cc"
+#line 4770 "seclang-parser.cc"
     break;
 
   case 331: // var: "RUN_TIME_VAR_HSV"
-#line 2568 "seclang-parser.yy"
+#line 2586 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4763 "seclang-parser.cc"
+#line 4781 "seclang-parser.cc"
     break;
 
   case 332: // var: "RUN_TIME_VAR_REMOTE_USER"
-#line 2575 "seclang-parser.yy"
+#line 2593 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4774 "seclang-parser.cc"
+#line 4792 "seclang-parser.cc"
     break;
 
   case 333: // var: "RUN_TIME_VAR_TIME"
-#line 2582 "seclang-parser.yy"
+#line 2600 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4785 "seclang-parser.cc"
+#line 4803 "seclang-parser.cc"
     break;
 
   case 334: // var: "RUN_TIME_VAR_TIME_DAY"
-#line 2589 "seclang-parser.yy"
+#line 2607 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4796 "seclang-parser.cc"
+#line 4814 "seclang-parser.cc"
     break;
 
   case 335: // var: "RUN_TIME_VAR_TIME_EPOCH"
-#line 2596 "seclang-parser.yy"
+#line 2614 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4807 "seclang-parser.cc"
+#line 4825 "seclang-parser.cc"
     break;
 
   case 336: // var: "RUN_TIME_VAR_TIME_HOUR"
-#line 2603 "seclang-parser.yy"
+#line 2621 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4818 "seclang-parser.cc"
+#line 4836 "seclang-parser.cc"
     break;
 
   case 337: // var: "RUN_TIME_VAR_TIME_MIN"
-#line 2610 "seclang-parser.yy"
+#line 2628 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4829 "seclang-parser.cc"
+#line 4847 "seclang-parser.cc"
     break;
 
   case 338: // var: "RUN_TIME_VAR_TIME_MON"
-#line 2617 "seclang-parser.yy"
+#line 2635 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4840 "seclang-parser.cc"
+#line 4858 "seclang-parser.cc"
     break;
 
   case 339: // var: "RUN_TIME_VAR_TIME_SEC"
-#line 2624 "seclang-parser.yy"
+#line 2642 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4851 "seclang-parser.cc"
+#line 4869 "seclang-parser.cc"
     break;
 
   case 340: // var: "RUN_TIME_VAR_TIME_WDAY"
-#line 2631 "seclang-parser.yy"
+#line 2649 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4862 "seclang-parser.cc"
+#line 4880 "seclang-parser.cc"
     break;
 
   case 341: // var: "RUN_TIME_VAR_TIME_YEAR"
-#line 2638 "seclang-parser.yy"
+#line 2656 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4873 "seclang-parser.cc"
+#line 4891 "seclang-parser.cc"
     break;
 
   case 342: // act: "Accuracy"
-#line 2648 "seclang-parser.yy"
+#line 2666 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
       }
-#line 4881 "seclang-parser.cc"
+#line 4899 "seclang-parser.cc"
     break;
 
   case 343: // act: "Allow"
-#line 2652 "seclang-parser.yy"
+#line 2670 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
       }
-#line 4889 "seclang-parser.cc"
+#line 4907 "seclang-parser.cc"
     break;
 
   case 344: // act: "Append"
-#line 2656 "seclang-parser.yy"
+#line 2674 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 4897 "seclang-parser.cc"
+#line 4915 "seclang-parser.cc"
     break;
 
   case 345: // act: "AuditLog"
-#line 2660 "seclang-parser.yy"
+#line 2678 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 4905 "seclang-parser.cc"
+#line 4923 "seclang-parser.cc"
     break;
 
   case 346: // act: "Block"
-#line 2664 "seclang-parser.yy"
+#line 2682 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
       }
-#line 4913 "seclang-parser.cc"
+#line 4931 "seclang-parser.cc"
     break;
 
   case 347: // act: "Capture"
-#line 2668 "seclang-parser.yy"
+#line 2686 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
       }
-#line 4921 "seclang-parser.cc"
+#line 4939 "seclang-parser.cc"
     break;
 
   case 348: // act: "Chain"
-#line 2672 "seclang-parser.yy"
+#line 2690 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
       }
-#line 4929 "seclang-parser.cc"
+#line 4947 "seclang-parser.cc"
     break;
 
   case 349: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_ON"
-#line 2676 "seclang-parser.yy"
+#line 2694 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=on"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4938 "seclang-parser.cc"
+#line 4956 "seclang-parser.cc"
     break;
 
   case 350: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
-#line 2681 "seclang-parser.yy"
+#line 2699 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
       }
-#line 4946 "seclang-parser.cc"
+#line 4964 "seclang-parser.cc"
     break;
 
   case 351: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 2685 "seclang-parser.yy"
+#line 2703 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=relevantonly"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4955 "seclang-parser.cc"
+#line 4973 "seclang-parser.cc"
     break;
 
   case 352: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
-#line 2690 "seclang-parser.yy"
+#line 2708 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
       }
-#line 4963 "seclang-parser.cc"
+#line 4981 "seclang-parser.cc"
     break;
 
   case 353: // act: "ACTION_CTL_BDY_JSON"
-#line 2694 "seclang-parser.yy"
+#line 2712 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
       }
-#line 4971 "seclang-parser.cc"
+#line 4989 "seclang-parser.cc"
     break;
 
   case 354: // act: "ACTION_CTL_BDY_XML"
-#line 2698 "seclang-parser.yy"
+#line 2716 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
       }
-#line 4979 "seclang-parser.cc"
+#line 4997 "seclang-parser.cc"
     break;
 
   case 355: // act: "ACTION_CTL_BDY_URLENCODED"
-#line 2702 "seclang-parser.yy"
+#line 2720 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
-      }
-#line 4987 "seclang-parser.cc"
-    break;
-
-  case 356: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
-#line 2706 "seclang-parser.yy"
-      {
-        //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
-      }
-#line 4996 "seclang-parser.cc"
-    break;
-
-  case 357: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
-#line 2711 "seclang-parser.yy"
-      {
-        //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
-        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
 #line 5005 "seclang-parser.cc"
     break;
 
+  case 356: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
+#line 2724 "seclang-parser.yy"
+      {
+        //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
+      }
+#line 5014 "seclang-parser.cc"
+    break;
+
+  case 357: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
+#line 2729 "seclang-parser.yy"
+      {
+        //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
+        ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
+      }
+#line 5023 "seclang-parser.cc"
+    break;
+
   case 358: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
-#line 2716 "seclang-parser.yy"
+#line 2734 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=on"));
       }
-#line 5013 "seclang-parser.cc"
+#line 5031 "seclang-parser.cc"
     break;
 
   case 359: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
-#line 2720 "seclang-parser.yy"
+#line 2738 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=off"));
       }
-#line 5021 "seclang-parser.cc"
+#line 5039 "seclang-parser.cc"
     break;
 
   case 360: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
-#line 2724 "seclang-parser.yy"
+#line 2742 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=onlyargs"));
       }
-#line 5029 "seclang-parser.cc"
+#line 5047 "seclang-parser.cc"
     break;
 
   case 361: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
-#line 2728 "seclang-parser.yy"
+#line 2746 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
       }
-#line 5037 "seclang-parser.cc"
+#line 5055 "seclang-parser.cc"
     break;
 
   case 362: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
-#line 2732 "seclang-parser.yy"
+#line 2750 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
       }
-#line 5045 "seclang-parser.cc"
+#line 5063 "seclang-parser.cc"
     break;
 
   case 363: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
-#line 2736 "seclang-parser.yy"
+#line 2754 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 5053 "seclang-parser.cc"
+#line 5071 "seclang-parser.cc"
     break;
 
   case 364: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
-#line 2740 "seclang-parser.yy"
+#line 2758 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 5061 "seclang-parser.cc"
+#line 5079 "seclang-parser.cc"
     break;
 
   case 365: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
-#line 2744 "seclang-parser.yy"
+#line 2762 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 5069 "seclang-parser.cc"
+#line 5087 "seclang-parser.cc"
     break;
 
   case 366: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
-#line 2748 "seclang-parser.yy"
+#line 2766 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
       }
-#line 5077 "seclang-parser.cc"
+#line 5095 "seclang-parser.cc"
     break;
 
   case 367: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
-#line 2752 "seclang-parser.yy"
+#line 2770 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5085 "seclang-parser.cc"
+#line 5103 "seclang-parser.cc"
     break;
 
   case 368: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
-#line 2756 "seclang-parser.yy"
+#line 2774 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
       }
-#line 5093 "seclang-parser.cc"
+#line 5111 "seclang-parser.cc"
     break;
 
   case 369: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
-#line 2760 "seclang-parser.yy"
+#line 2778 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5101 "seclang-parser.cc"
+#line 5119 "seclang-parser.cc"
     break;
 
   case 370: // act: "Deny"
-#line 2764 "seclang-parser.yy"
+#line 2782 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
       }
-#line 5109 "seclang-parser.cc"
+#line 5127 "seclang-parser.cc"
     break;
 
   case 371: // act: "DeprecateVar"
-#line 2768 "seclang-parser.yy"
+#line 2786 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 5117 "seclang-parser.cc"
+#line 5135 "seclang-parser.cc"
     break;
 
   case 372: // act: "Drop"
-#line 2772 "seclang-parser.yy"
+#line 2790 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
       }
-#line 5125 "seclang-parser.cc"
+#line 5143 "seclang-parser.cc"
     break;
 
   case 373: // act: "Exec"
-#line 2776 "seclang-parser.yy"
+#line 2794 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
       }
-#line 5133 "seclang-parser.cc"
+#line 5151 "seclang-parser.cc"
     break;
 
   case 374: // act: "ExpireVar" run_time_string
-#line 2780 "seclang-parser.yy"
+#line 2798 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ExpireVar(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5141 "seclang-parser.cc"
+#line 5159 "seclang-parser.cc"
     break;
 
   case 375: // act: "Id"
-#line 2784 "seclang-parser.yy"
+#line 2802 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
       }
-#line 5149 "seclang-parser.cc"
+#line 5167 "seclang-parser.cc"
     break;
 
   case 376: // act: "InitCol" run_time_string
-#line 2788 "seclang-parser.yy"
+#line 2806 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5157 "seclang-parser.cc"
+#line 5175 "seclang-parser.cc"
     break;
 
   case 377: // act: "LogData" run_time_string
-#line 2792 "seclang-parser.yy"
+#line 2810 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5165 "seclang-parser.cc"
+#line 5183 "seclang-parser.cc"
     break;
 
   case 378: // act: "Log"
-#line 2796 "seclang-parser.yy"
+#line 2814 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
       }
-#line 5173 "seclang-parser.cc"
+#line 5191 "seclang-parser.cc"
     break;
 
   case 379: // act: "Maturity"
-#line 2800 "seclang-parser.yy"
+#line 2818 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
       }
-#line 5181 "seclang-parser.cc"
+#line 5199 "seclang-parser.cc"
     break;
 
   case 380: // act: "Msg" run_time_string
-#line 2804 "seclang-parser.yy"
+#line 2822 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5189 "seclang-parser.cc"
+#line 5207 "seclang-parser.cc"
     break;
 
   case 381: // act: "MultiMatch"
-#line 2808 "seclang-parser.yy"
+#line 2826 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
       }
-#line 5197 "seclang-parser.cc"
+#line 5215 "seclang-parser.cc"
     break;
 
   case 382: // act: "NoAuditLog"
-#line 2812 "seclang-parser.yy"
+#line 2830 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5205 "seclang-parser.cc"
+#line 5223 "seclang-parser.cc"
     break;
 
   case 383: // act: "NoLog"
-#line 2816 "seclang-parser.yy"
+#line 2834 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5213 "seclang-parser.cc"
+#line 5231 "seclang-parser.cc"
     break;
 
   case 384: // act: "Pass"
-#line 2820 "seclang-parser.yy"
+#line 2838 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
       }
-#line 5221 "seclang-parser.cc"
+#line 5239 "seclang-parser.cc"
     break;
 
   case 385: // act: "Pause"
-#line 2824 "seclang-parser.yy"
+#line 2842 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 5229 "seclang-parser.cc"
+#line 5247 "seclang-parser.cc"
     break;
 
   case 386: // act: "Phase"
-#line 2828 "seclang-parser.yy"
+#line 2846 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
       }
-#line 5237 "seclang-parser.cc"
+#line 5255 "seclang-parser.cc"
     break;
 
   case 387: // act: "Prepend"
-#line 2832 "seclang-parser.yy"
+#line 2850 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 5245 "seclang-parser.cc"
+#line 5263 "seclang-parser.cc"
     break;
 
   case 388: // act: "Proxy"
-#line 2836 "seclang-parser.yy"
+#line 2854 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 5253 "seclang-parser.cc"
+#line 5271 "seclang-parser.cc"
     break;
 
   case 389: // act: "Redirect" run_time_string
-#line 2840 "seclang-parser.yy"
+#line 2858 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5261 "seclang-parser.cc"
+#line 5279 "seclang-parser.cc"
     break;
 
   case 390: // act: "Rev"
-#line 2844 "seclang-parser.yy"
+#line 2862 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
       }
-#line 5269 "seclang-parser.cc"
+#line 5287 "seclang-parser.cc"
     break;
 
   case 391: // act: "SanitiseArg"
-#line 2848 "seclang-parser.yy"
+#line 2866 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
       }
-#line 5277 "seclang-parser.cc"
+#line 5295 "seclang-parser.cc"
     break;
 
   case 392: // act: "SanitiseMatched"
-#line 2852 "seclang-parser.yy"
+#line 2870 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
       }
-#line 5285 "seclang-parser.cc"
+#line 5303 "seclang-parser.cc"
     break;
 
   case 393: // act: "SanitiseMatchedBytes"
-#line 2856 "seclang-parser.yy"
+#line 2874 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
       }
-#line 5293 "seclang-parser.cc"
+#line 5311 "seclang-parser.cc"
     break;
 
   case 394: // act: "SanitiseRequestHeader"
-#line 2860 "seclang-parser.yy"
+#line 2878 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
       }
-#line 5301 "seclang-parser.cc"
+#line 5319 "seclang-parser.cc"
     break;
 
   case 395: // act: "SanitiseResponseHeader"
-#line 2864 "seclang-parser.yy"
+#line 2882 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
       }
-#line 5309 "seclang-parser.cc"
+#line 5327 "seclang-parser.cc"
     break;
 
   case 396: // act: "SetEnv" run_time_string
-#line 2868 "seclang-parser.yy"
+#line 2886 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5317 "seclang-parser.cc"
+#line 5335 "seclang-parser.cc"
     break;
 
   case 397: // act: "SetRsc" run_time_string
-#line 2872 "seclang-parser.yy"
+#line 2890 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5325 "seclang-parser.cc"
+#line 5343 "seclang-parser.cc"
     break;
 
   case 398: // act: "SetSid" run_time_string
-#line 2876 "seclang-parser.yy"
+#line 2894 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5333 "seclang-parser.cc"
+#line 5351 "seclang-parser.cc"
     break;
 
   case 399: // act: "SetUID" run_time_string
-#line 2880 "seclang-parser.yy"
+#line 2898 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5341 "seclang-parser.cc"
+#line 5359 "seclang-parser.cc"
     break;
 
   case 400: // act: "SetVar" setvar_action
-#line 2884 "seclang-parser.yy"
+#line 2902 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
       }
-#line 5349 "seclang-parser.cc"
+#line 5367 "seclang-parser.cc"
     break;
 
   case 401: // act: "Severity"
-#line 2888 "seclang-parser.yy"
+#line 2906 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
       }
-#line 5357 "seclang-parser.cc"
+#line 5375 "seclang-parser.cc"
     break;
 
   case 402: // act: "Skip"
-#line 2892 "seclang-parser.yy"
+#line 2910 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
       }
-#line 5365 "seclang-parser.cc"
+#line 5383 "seclang-parser.cc"
     break;
 
   case 403: // act: "SkipAfter"
-#line 2896 "seclang-parser.yy"
+#line 2914 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
       }
-#line 5373 "seclang-parser.cc"
+#line 5391 "seclang-parser.cc"
     break;
 
   case 404: // act: "Status"
-#line 2900 "seclang-parser.yy"
+#line 2918 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
       }
-#line 5381 "seclang-parser.cc"
+#line 5399 "seclang-parser.cc"
     break;
 
   case 405: // act: "Tag" run_time_string
-#line 2904 "seclang-parser.yy"
+#line 2922 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5389 "seclang-parser.cc"
+#line 5407 "seclang-parser.cc"
     break;
 
   case 406: // act: "Ver"
-#line 2908 "seclang-parser.yy"
+#line 2926 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
       }
-#line 5397 "seclang-parser.cc"
+#line 5415 "seclang-parser.cc"
     break;
 
   case 407: // act: "xmlns"
-#line 2912 "seclang-parser.yy"
+#line 2930 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
       }
-#line 5405 "seclang-parser.cc"
+#line 5423 "seclang-parser.cc"
     break;
 
   case 408: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
-#line 2916 "seclang-parser.yy"
+#line 2934 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5413 "seclang-parser.cc"
+#line 5431 "seclang-parser.cc"
     break;
 
   case 409: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
-#line 2920 "seclang-parser.yy"
+#line 2938 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5421 "seclang-parser.cc"
+#line 5439 "seclang-parser.cc"
     break;
 
   case 410: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
-#line 2924 "seclang-parser.yy"
+#line 2942 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5429 "seclang-parser.cc"
+#line 5447 "seclang-parser.cc"
     break;
 
   case 411: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
-#line 2928 "seclang-parser.yy"
+#line 2946 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5437 "seclang-parser.cc"
+#line 5455 "seclang-parser.cc"
     break;
 
   case 412: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
-#line 2932 "seclang-parser.yy"
+#line 2950 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
       }
-#line 5445 "seclang-parser.cc"
+#line 5463 "seclang-parser.cc"
     break;
 
   case 413: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
-#line 2936 "seclang-parser.yy"
+#line 2954 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
       }
-#line 5453 "seclang-parser.cc"
+#line 5471 "seclang-parser.cc"
     break;
 
   case 414: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
-#line 2940 "seclang-parser.yy"
+#line 2958 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
       }
-#line 5461 "seclang-parser.cc"
+#line 5479 "seclang-parser.cc"
     break;
 
   case 415: // act: "ACTION_TRANSFORMATION_CMD_LINE"
-#line 2944 "seclang-parser.yy"
+#line 2962 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
       }
-#line 5469 "seclang-parser.cc"
+#line 5487 "seclang-parser.cc"
     break;
 
   case 416: // act: "ACTION_TRANSFORMATION_SHA1"
-#line 2948 "seclang-parser.yy"
+#line 2966 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
       }
-#line 5477 "seclang-parser.cc"
+#line 5495 "seclang-parser.cc"
     break;
 
   case 417: // act: "ACTION_TRANSFORMATION_MD5"
-#line 2952 "seclang-parser.yy"
+#line 2970 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
       }
-#line 5485 "seclang-parser.cc"
+#line 5503 "seclang-parser.cc"
     break;
 
   case 418: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
-#line 2956 "seclang-parser.yy"
+#line 2974 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5493 "seclang-parser.cc"
+#line 5511 "seclang-parser.cc"
     break;
 
   case 419: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
-#line 2960 "seclang-parser.yy"
+#line 2978 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5501 "seclang-parser.cc"
+#line 5519 "seclang-parser.cc"
     break;
 
   case 420: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
-#line 2964 "seclang-parser.yy"
+#line 2982 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5509 "seclang-parser.cc"
+#line 5527 "seclang-parser.cc"
     break;
 
   case 421: // act: "ACTION_TRANSFORMATION_LOWERCASE"
-#line 2968 "seclang-parser.yy"
+#line 2986 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5517 "seclang-parser.cc"
+#line 5535 "seclang-parser.cc"
     break;
 
   case 422: // act: "ACTION_TRANSFORMATION_UPPERCASE"
-#line 2972 "seclang-parser.yy"
+#line 2990 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5525 "seclang-parser.cc"
+#line 5543 "seclang-parser.cc"
     break;
 
   case 423: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
-#line 2976 "seclang-parser.yy"
+#line 2994 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
       }
-#line 5533 "seclang-parser.cc"
+#line 5551 "seclang-parser.cc"
     break;
 
   case 424: // act: "ACTION_TRANSFORMATION_URL_DECODE"
-#line 2980 "seclang-parser.yy"
+#line 2998 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5541 "seclang-parser.cc"
+#line 5559 "seclang-parser.cc"
     break;
 
   case 425: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
-#line 2984 "seclang-parser.yy"
+#line 3002 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5549 "seclang-parser.cc"
+#line 5567 "seclang-parser.cc"
     break;
 
   case 426: // act: "ACTION_TRANSFORMATION_NONE"
-#line 2988 "seclang-parser.yy"
+#line 3006 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
       }
-#line 5557 "seclang-parser.cc"
+#line 5575 "seclang-parser.cc"
     break;
 
   case 427: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
-#line 2992 "seclang-parser.yy"
+#line 3010 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5565 "seclang-parser.cc"
+#line 5583 "seclang-parser.cc"
     break;
 
   case 428: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
-#line 2996 "seclang-parser.yy"
+#line 3014 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5573 "seclang-parser.cc"
+#line 5591 "seclang-parser.cc"
     break;
 
   case 429: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
-#line 3000 "seclang-parser.yy"
+#line 3018 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5581 "seclang-parser.cc"
+#line 5599 "seclang-parser.cc"
     break;
 
   case 430: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
-#line 3004 "seclang-parser.yy"
+#line 3022 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5589 "seclang-parser.cc"
+#line 5607 "seclang-parser.cc"
     break;
 
   case 431: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
-#line 3008 "seclang-parser.yy"
+#line 3026 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5597 "seclang-parser.cc"
+#line 5615 "seclang-parser.cc"
     break;
 
   case 432: // act: "ACTION_TRANSFORMATION_JS_DECODE"
-#line 3012 "seclang-parser.yy"
+#line 3030 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5605 "seclang-parser.cc"
+#line 5623 "seclang-parser.cc"
     break;
 
   case 433: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
-#line 3016 "seclang-parser.yy"
+#line 3034 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5613 "seclang-parser.cc"
+#line 5631 "seclang-parser.cc"
     break;
 
   case 434: // act: "ACTION_TRANSFORMATION_TRIM"
-#line 3020 "seclang-parser.yy"
+#line 3038 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
       }
-#line 5621 "seclang-parser.cc"
+#line 5639 "seclang-parser.cc"
     break;
 
   case 435: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
-#line 3024 "seclang-parser.yy"
+#line 3042 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
       }
-#line 5629 "seclang-parser.cc"
+#line 5647 "seclang-parser.cc"
     break;
 
   case 436: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
-#line 3028 "seclang-parser.yy"
+#line 3046 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
       }
-#line 5637 "seclang-parser.cc"
+#line 5655 "seclang-parser.cc"
     break;
 
   case 437: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
-#line 3032 "seclang-parser.yy"
+#line 3050 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
       }
-#line 5645 "seclang-parser.cc"
+#line 5663 "seclang-parser.cc"
     break;
 
   case 438: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
-#line 3036 "seclang-parser.yy"
+#line 3054 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
       }
-#line 5653 "seclang-parser.cc"
+#line 5671 "seclang-parser.cc"
     break;
 
   case 439: // act: "ACTION_TRANSFORMATION_LENGTH"
-#line 3040 "seclang-parser.yy"
+#line 3058 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
       }
-#line 5661 "seclang-parser.cc"
+#line 5679 "seclang-parser.cc"
     break;
 
   case 440: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
-#line 3044 "seclang-parser.yy"
+#line 3062 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
       }
-#line 5669 "seclang-parser.cc"
+#line 5687 "seclang-parser.cc"
     break;
 
   case 441: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
-#line 3048 "seclang-parser.yy"
+#line 3066 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
       }
-#line 5677 "seclang-parser.cc"
+#line 5695 "seclang-parser.cc"
     break;
 
   case 442: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
-#line 3052 "seclang-parser.yy"
+#line 3070 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5685 "seclang-parser.cc"
+#line 5703 "seclang-parser.cc"
     break;
 
   case 443: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
-#line 3056 "seclang-parser.yy"
+#line 3074 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5693 "seclang-parser.cc"
+#line 5711 "seclang-parser.cc"
     break;
 
   case 444: // setvar_action: "NOT" var
-#line 3063 "seclang-parser.yy"
+#line 3081 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5701 "seclang-parser.cc"
+#line 5719 "seclang-parser.cc"
     break;
 
   case 445: // setvar_action: var
-#line 3067 "seclang-parser.yy"
+#line 3085 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5709 "seclang-parser.cc"
+#line 5727 "seclang-parser.cc"
     break;
 
   case 446: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
-#line 3071 "seclang-parser.yy"
+#line 3089 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5717 "seclang-parser.cc"
+#line 5735 "seclang-parser.cc"
     break;
 
   case 447: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
-#line 3075 "seclang-parser.yy"
+#line 3093 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5725 "seclang-parser.cc"
+#line 5743 "seclang-parser.cc"
     break;
 
   case 448: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
-#line 3079 "seclang-parser.yy"
+#line 3097 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
-      }
-#line 5733 "seclang-parser.cc"
-    break;
-
-  case 449: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3086 "seclang-parser.yy"
-      {
-        yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
-        yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
-      }
-#line 5742 "seclang-parser.cc"
-    break;
-
-  case 450: // run_time_string: run_time_string var
-#line 3091 "seclang-parser.yy"
-      {
-        yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
-        yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
 #line 5751 "seclang-parser.cc"
     break;
 
+  case 449: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
+#line 3104 "seclang-parser.yy"
+      {
+        yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
+        yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
+      }
+#line 5760 "seclang-parser.cc"
+    break;
+
+  case 450: // run_time_string: run_time_string var
+#line 3109 "seclang-parser.yy"
+      {
+        yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
+        yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
+      }
+#line 5769 "seclang-parser.cc"
+    break;
+
   case 451: // run_time_string: "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3096 "seclang-parser.yy"
+#line 3114 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5761 "seclang-parser.cc"
+#line 5779 "seclang-parser.cc"
     break;
 
   case 452: // run_time_string: var
-#line 3102 "seclang-parser.yy"
+#line 3120 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5771 "seclang-parser.cc"
+#line 5789 "seclang-parser.cc"
     break;
 
 
-#line 5775 "seclang-parser.cc"
+#line 5793 "seclang-parser.cc"
 
             default:
               break;
@@ -7312,50 +7330,50 @@ namespace yy {
   {
        0,   725,   725,   729,   730,   733,   738,   744,   750,   754,
      758,   764,   770,   776,   782,   787,   792,   798,   805,   809,
-     813,   819,   823,   827,   832,   837,   842,   847,   851,   858,
-     862,   869,   875,   885,   894,   904,   913,   926,   930,   934,
-     938,   942,   946,   950,   954,   958,   962,   967,   971,   975,
-     979,   983,   987,   992,   997,  1001,  1005,  1009,  1013,  1017,
-    1021,  1025,  1029,  1033,  1037,  1041,  1045,  1049,  1053,  1057,
-    1061,  1065,  1069,  1073,  1087,  1088,  1119,  1138,  1158,  1187,
-    1244,  1251,  1255,  1259,  1263,  1267,  1271,  1275,  1279,  1288,
-    1292,  1297,  1300,  1305,  1310,  1315,  1320,  1323,  1328,  1331,
-    1336,  1341,  1344,  1349,  1354,  1359,  1364,  1369,  1374,  1379,
-    1382,  1387,  1392,  1397,  1402,  1405,  1410,  1415,  1420,  1433,
-    1446,  1459,  1472,  1485,  1511,  1539,  1551,  1571,  1598,  1603,
-    1609,  1614,  1619,  1628,  1633,  1637,  1641,  1645,  1649,  1653,
-    1657,  1662,  1667,  1679,  1685,  1689,  1693,  1697,  1701,  1705,
-    1716,  1725,  1726,  1733,  1738,  1743,  1797,  1804,  1812,  1849,
-    1853,  1860,  1865,  1871,  1877,  1883,  1890,  1900,  1904,  1908,
-    1912,  1916,  1920,  1924,  1928,  1932,  1936,  1940,  1944,  1948,
-    1952,  1956,  1960,  1964,  1968,  1972,  1976,  1980,  1984,  1988,
-    1992,  1996,  2000,  2004,  2008,  2012,  2016,  2020,  2024,  2028,
-    2032,  2036,  2040,  2044,  2048,  2052,  2056,  2060,  2064,  2068,
-    2072,  2076,  2080,  2084,  2088,  2092,  2096,  2100,  2104,  2108,
-    2112,  2116,  2120,  2124,  2128,  2132,  2136,  2140,  2144,  2148,
-    2152,  2156,  2160,  2164,  2168,  2172,  2176,  2180,  2184,  2188,
-    2192,  2196,  2200,  2204,  2208,  2212,  2216,  2220,  2224,  2228,
-    2232,  2236,  2240,  2244,  2248,  2252,  2256,  2260,  2264,  2268,
-    2273,  2277,  2281,  2286,  2290,  2294,  2299,  2304,  2308,  2312,
-    2316,  2320,  2324,  2328,  2332,  2336,  2340,  2344,  2348,  2352,
-    2356,  2360,  2364,  2368,  2372,  2376,  2380,  2384,  2388,  2392,
-    2396,  2400,  2404,  2408,  2412,  2416,  2420,  2424,  2428,  2432,
-    2436,  2440,  2444,  2448,  2452,  2456,  2460,  2464,  2468,  2472,
-    2476,  2480,  2484,  2488,  2492,  2496,  2500,  2504,  2508,  2512,
-    2516,  2520,  2524,  2528,  2532,  2536,  2540,  2544,  2548,  2552,
-    2560,  2567,  2574,  2581,  2588,  2595,  2602,  2609,  2616,  2623,
-    2630,  2637,  2647,  2651,  2655,  2659,  2663,  2667,  2671,  2675,
-    2680,  2684,  2689,  2693,  2697,  2701,  2705,  2710,  2715,  2719,
-    2723,  2727,  2731,  2735,  2739,  2743,  2747,  2751,  2755,  2759,
-    2763,  2767,  2771,  2775,  2779,  2783,  2787,  2791,  2795,  2799,
-    2803,  2807,  2811,  2815,  2819,  2823,  2827,  2831,  2835,  2839,
-    2843,  2847,  2851,  2855,  2859,  2863,  2867,  2871,  2875,  2879,
-    2883,  2887,  2891,  2895,  2899,  2903,  2907,  2911,  2915,  2919,
-    2923,  2927,  2931,  2935,  2939,  2943,  2947,  2951,  2955,  2959,
-    2963,  2967,  2971,  2975,  2979,  2983,  2987,  2991,  2995,  2999,
-    3003,  3007,  3011,  3015,  3019,  3023,  3027,  3031,  3035,  3039,
-    3043,  3047,  3051,  3055,  3062,  3066,  3070,  3074,  3078,  3085,
-    3090,  3095,  3101
+     813,   819,   823,   827,   832,   840,   848,   853,   857,   864,
+     868,   875,   881,   891,   900,   910,   919,   932,   936,   940,
+     944,   948,   952,   956,   960,   964,   968,   973,   977,   981,
+     985,   989,   993,   998,  1003,  1007,  1011,  1015,  1019,  1023,
+    1027,  1031,  1035,  1039,  1043,  1047,  1051,  1055,  1059,  1063,
+    1067,  1071,  1075,  1079,  1093,  1094,  1125,  1144,  1164,  1193,
+    1250,  1257,  1261,  1265,  1269,  1273,  1277,  1281,  1285,  1294,
+    1298,  1303,  1306,  1311,  1316,  1321,  1326,  1329,  1334,  1337,
+    1342,  1347,  1350,  1355,  1360,  1365,  1370,  1375,  1380,  1385,
+    1388,  1393,  1398,  1403,  1408,  1411,  1416,  1421,  1426,  1439,
+    1452,  1465,  1478,  1491,  1517,  1545,  1557,  1577,  1604,  1609,
+    1615,  1623,  1631,  1640,  1648,  1652,  1656,  1660,  1664,  1668,
+    1672,  1677,  1685,  1697,  1703,  1707,  1711,  1715,  1719,  1723,
+    1734,  1743,  1744,  1751,  1756,  1761,  1815,  1822,  1830,  1867,
+    1871,  1878,  1883,  1889,  1895,  1901,  1908,  1918,  1922,  1926,
+    1930,  1934,  1938,  1942,  1946,  1950,  1954,  1958,  1962,  1966,
+    1970,  1974,  1978,  1982,  1986,  1990,  1994,  1998,  2002,  2006,
+    2010,  2014,  2018,  2022,  2026,  2030,  2034,  2038,  2042,  2046,
+    2050,  2054,  2058,  2062,  2066,  2070,  2074,  2078,  2082,  2086,
+    2090,  2094,  2098,  2102,  2106,  2110,  2114,  2118,  2122,  2126,
+    2130,  2134,  2138,  2142,  2146,  2150,  2154,  2158,  2162,  2166,
+    2170,  2174,  2178,  2182,  2186,  2190,  2194,  2198,  2202,  2206,
+    2210,  2214,  2218,  2222,  2226,  2230,  2234,  2238,  2242,  2246,
+    2250,  2254,  2258,  2262,  2266,  2270,  2274,  2278,  2282,  2286,
+    2291,  2295,  2299,  2304,  2308,  2312,  2317,  2322,  2326,  2330,
+    2334,  2338,  2342,  2346,  2350,  2354,  2358,  2362,  2366,  2370,
+    2374,  2378,  2382,  2386,  2390,  2394,  2398,  2402,  2406,  2410,
+    2414,  2418,  2422,  2426,  2430,  2434,  2438,  2442,  2446,  2450,
+    2454,  2458,  2462,  2466,  2470,  2474,  2478,  2482,  2486,  2490,
+    2494,  2498,  2502,  2506,  2510,  2514,  2518,  2522,  2526,  2530,
+    2534,  2538,  2542,  2546,  2550,  2554,  2558,  2562,  2566,  2570,
+    2578,  2585,  2592,  2599,  2606,  2613,  2620,  2627,  2634,  2641,
+    2648,  2655,  2665,  2669,  2673,  2677,  2681,  2685,  2689,  2693,
+    2698,  2702,  2707,  2711,  2715,  2719,  2723,  2728,  2733,  2737,
+    2741,  2745,  2749,  2753,  2757,  2761,  2765,  2769,  2773,  2777,
+    2781,  2785,  2789,  2793,  2797,  2801,  2805,  2809,  2813,  2817,
+    2821,  2825,  2829,  2833,  2837,  2841,  2845,  2849,  2853,  2857,
+    2861,  2865,  2869,  2873,  2877,  2881,  2885,  2889,  2893,  2897,
+    2901,  2905,  2909,  2913,  2917,  2921,  2925,  2929,  2933,  2937,
+    2941,  2945,  2949,  2953,  2957,  2961,  2965,  2969,  2973,  2977,
+    2981,  2985,  2989,  2993,  2997,  3001,  3005,  3009,  3013,  3017,
+    3021,  3025,  3029,  3033,  3037,  3041,  3045,  3049,  3053,  3057,
+    3061,  3065,  3069,  3073,  3080,  3084,  3088,  3092,  3096,  3103,
+    3108,  3113,  3119
   };
 
   void
@@ -7387,9 +7405,9 @@ namespace yy {
 
 
 } // yy
-#line 7391 "seclang-parser.cc"
+#line 7409 "seclang-parser.cc"
 
-#line 3108 "seclang-parser.yy"
+#line 3126 "seclang-parser.yy"
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -831,13 +831,19 @@ audit_log:
       }
     | CONFIG_UPLOAD_FILE_LIMIT
       {
-        driver.m_uploadFileLimit.m_set = true;
-        driver.m_uploadFileLimit.m_value = strtol($1.c_str(), NULL, 10);
+        std::string errmsg = "";
+        if (driver.m_uploadFileLimit.parse(std::string($1), &errmsg) != true) {
+          driver.error(@0, "Failed to parse SecUploadFileLimit: " + errmsg);
+          YYERROR;
+        }
       }
     | CONFIG_UPLOAD_FILE_MODE
       {
-        driver.m_uploadFileMode.m_set = true;
-        driver.m_uploadFileMode.m_value = strtol($1.c_str(), NULL, 8);
+        std::string errmsg = "";
+        if (driver.m_uploadFileMode.parse(std::string($1), &errmsg) != true) {
+          driver.error(@0, "Failed to parse SecUploadFileMode: " + errmsg);
+          YYERROR;
+        }
       }
     | CONFIG_UPLOAD_DIR
       {
@@ -1608,13 +1614,19 @@ expression:
     /* Body limits */
     | CONFIG_DIR_REQ_BODY_LIMIT
       {
-        driver.m_requestBodyLimit.m_set = true;
-        driver.m_requestBodyLimit.m_value = atoi($1.c_str());
+        std::string errmsg = "";
+        if (driver.m_requestBodyLimit.parse(std::string($1), &errmsg) != true) {
+          driver.error(@0, "Failed to parse SecRequestBodyLimit: " + errmsg);
+          YYERROR;
+        }
       }
     | CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT
       {
-        driver.m_requestBodyNoFilesLimit.m_set = true;
-        driver.m_requestBodyNoFilesLimit.m_value = atoi($1.c_str());
+        std::string errmsg = "";
+        if (driver.m_requestBodyNoFilesLimit.parse(std::string($1), &errmsg) != true) {
+          driver.error(@0, "Failed to parse SecRequestsBodyNoFilesLimit: " + errmsg);
+          YYERROR;
+        }
       }
     | CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT
       {
@@ -1627,8 +1639,11 @@ expression:
       }
     | CONFIG_DIR_RES_BODY_LIMIT
       {
-        driver.m_responseBodyLimit.m_set = true;
-        driver.m_responseBodyLimit.m_value = atoi($1.c_str());
+        std::string errmsg = "";
+        if (driver.m_responseBodyLimit.parse(std::string($1), &errmsg) != true) {
+          driver.error(@0, "Failed to parse SecResponseBodyLimit: " + errmsg);
+          YYERROR;
+        }
       }
     | CONFIG_DIR_REQ_BODY_LIMIT_ACTION CONFIG_VALUE_PROCESS_PARTIAL
       {
@@ -1661,8 +1676,11 @@ expression:
 */
     | CONFIG_DIR_PCRE_MATCH_LIMIT
       {
-        driver.m_pcreMatchLimit.m_set = true;
-        driver.m_pcreMatchLimit.m_value = atoi($1.c_str());
+        std::string errmsg = "";
+        if (driver.m_pcreMatchLimit.parse(std::string($1), &errmsg) != true) {
+          driver.error(@0, "Failed to parse SecPcreMatchLimit: " + errmsg);
+          YYERROR;
+        }
       }
     | CONGIG_DIR_RESPONSE_BODY_MP
       {

--- a/src/utils/shared_files.h
+++ b/src/utils/shared_files.h
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 #ifdef WIN32
-#define NOMINMAX
 #include <Windows.h>
 #endif
 

--- a/src/utils/shared_files.h
+++ b/src/utils/shared_files.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #ifdef WIN32
+#define NOMINMAX
 #include <Windows.h>
 #endif
 


### PR DESCRIPTION
## what

This PR fixes the handling of integer type limits, eg. `SecRequestBodyNoFilesLimit`.

**Changes**:
* in `headers/modsecurity/rules_set_properties.h` I implemented a new template with name `ConfigValue`
* this implements the `parse()` method which reads safely the integer value from a string, which parsed by engine's SecLang parser (Bison)
* the template also sets the default `min` and `max` value to `0`
* this method checks the type limits, eg. if the type (for eg. `ConfigInt`) implements signed integer, then the min and max limits will be -32767 and +32767 (`INT_MIN` and `INT_MAX`)
* out-of-bounds values will trigger an error at startup with a message in error.log
* with help of this template I implemented three types: `ConfigInt`, `ConfigUnsignedInt` and `ConfigUnsignedLong`
* it's enough to set the min and max values in all new types (eg. if we want to add new integer types) - see existing new types; I used `std::numeric_limits<T>::min()` and `std::numeric_limits<T>::max()`
* I changed the type of variables: `m_argumentsLimit`, `m_requestBodyJsonDepthLimit`, `m_requestBodyLimit`, `m_requestBodyNoFilesLimit`, `m_responseBodyLimit`, `m_pcreMatchLimit`, `m_uploadFileLimit` and `m_uploadFileMode`;  the current types are [here](https://github.com/owasp-modsecurity/ModSecurity/blob/cf24aeaeadefd758d0220e485bd8e312945f06df/headers/modsecurity/rules_set_properties.h#L507-L514); now there is no more `ConfigDouble` type variable
* in `src/parser/seclang-parser.yy` I changed the type in grammar parser; there you can see the error handling (detailed error messages are in template's `parse()` method)
* I also regenerated `src/parser/seclang-parser.cc` (it's a generated file by Bison, don't need to check it)

**Other changes**:
* I fixed some SonarCloud issues in case of `ConfigDouble`, `ConfigString` and `ConfigSet` implementations (also in `headers/modsecurity/rules_set_properties.h`)
* in top of `headers/modsecurity/rules_set_properties.h` I had to add undefining macro directives if the target is `WIN32`, because the CI workflow was unsuccessful on Windows, because - probably - `min` and `max` are Windows C++ macros

## why

The problem with current solution is that the type of these variables are `ConfigDouble`, see the [variable declarations](https://github.com/owasp-modsecurity/ModSecurity/blob/cf24aeaeadefd758d0220e485bd8e312945f06df/headers/modsecurity/rules_set_properties.h#L507-L511) and their [type implementation](https://github.com/owasp-modsecurity/ModSecurity/blob/cf24aeaeadefd758d0220e485bd8e312945f06df/headers/modsecurity/rules_set_properties.h#L93).

A quick review of current implementation:
* the type of variables were double before this patch - this makes no sense, there is no 1234.6 bytes...
* the type of variables were signed - also makes sense, there is no negative value
* the parser converted the read value with `atoi()`, which gives an integer with different bitsize

Therefore if a user gave an extra high value, then the `atoi()` converted it into a negative value.

Previously I sent another PR (#3419), but I realized that solution wasn't complete. In this PR I reworked the whole storage implementation.

## references

Fixes #3352 and #3356.