### PR TITLE
Refactoring the cleaning of MATCHED_VAR* variables

### DIFF
--- a/headers/modsecurity/rule_with_operator.h
+++ b/headers/modsecurity/rule_with_operator.h
@@ -59,7 +59,6 @@ class RuleWithOperator : public RuleWithActions {
 
     static void updateMatchedVars(Transaction *trasn, const std::string &key,
         const std::string &value);
-    static void cleanMatchedVars(Transaction *trasn);
 
 
     const std::string& getOperatorName() const;

--- a/headers/modsecurity/rules_set.h
+++ b/headers/modsecurity/rules_set.h
@@ -80,6 +80,8 @@ class RulesSet : public RulesSetProperties {
     void debug(int level, const std::string &id, const std::string &uri,
         const std::string &msg);
 
+    static void cleanMatchedVars(Transaction *trans);
+
     RulesSetPhases m_rulesSetPhases;
  private:
 #ifndef NO_LOGS

--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -90,17 +90,6 @@ void RuleWithOperator::updateMatchedVars(Transaction *trans, const std::string &
 }
 
 
-void RuleWithOperator::cleanMatchedVars(Transaction *trans) {
-    ms_dbg_a(trans, 9, "Matched vars cleaned.");
-    // cppcheck-suppress ctunullpointer
-    trans->m_variableMatchedVar.unset();
-    trans->m_variableMatchedVars.unset();
-    trans->m_variableMatchedVarName.unset();
-    trans->m_variableMatchedVarsNames.unset();
-}
-
-
-
 bool RuleWithOperator::executeOperatorAt(Transaction *trans, const std::string &key,
     const std::string &value, RuleMessage &ruleMessage) {
 #if MSC_EXEC_CLOCK_ENABLED
@@ -324,7 +313,6 @@ bool RuleWithOperator::evaluate(Transaction *trans,
 
     if (globalRet == false) {
         ms_dbg_a(trans, 4, "Rule returned 0.");
-        cleanMatchedVars(trans);
         goto end_clean;
     }
     ms_dbg_a(trans, 4, "Rule returned 1.");

--- a/src/rules_set.cc
+++ b/src/rules_set.cc
@@ -105,6 +105,14 @@ std::string RulesSet::getParserError() {
     return this->m_parserError.str();
 }
 
+void RulesSet::cleanMatchedVars(Transaction *trans) {
+    ms_dbg_a(trans, 9, "Matched vars cleaned.");
+    // cppcheck-suppress ctunullpointer
+    trans->m_variableMatchedVar.unset();
+    trans->m_variableMatchedVars.unset();
+    trans->m_variableMatchedVarName.unset();
+    trans->m_variableMatchedVarsNames.unset();
+}
 
 int RulesSet::evaluate(int phase, Transaction *t) {
     if (phase >= modsecurity::Phases::NUMBER_OF_PHASES) {
@@ -208,6 +216,7 @@ int RulesSet::evaluate(int phase, Transaction *t) {
             }
 
             rule->evaluate(t);
+            cleanMatchedVars(t);
             if (t->m_it.disruptive > 0) {
 
                 ms_dbg_a(t, 8, "Skipping this phase as this " \

--- a/test/test-cases/regression/variable-MATCHED_VAR.json
+++ b/test/test-cases/regression/variable-MATCHED_VAR.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR (1/2)",
+    "title":"Testing Variables :: MATCHED_VAR (1/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -42,7 +42,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR (2/2)",
+    "title":"Testing Variables :: MATCHED_VAR (2/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -81,6 +81,128 @@
       "SecRule MATCHED_VAR \"@contains other_value\" \"id:29,pass\"",
       "SecRule MATCHED_VAR \"@contains other_value\" \"id:30,pass\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR (3/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR \"@eq 1\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR (4/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR \"@eq 2\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR (5/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VAR \"@eq 2\""
+    ]
   }
 ]
-

--- a/test/test-cases/regression/variable-MATCHED_VARS.json
+++ b/test/test-cases/regression/variable-MATCHED_VARS.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS (1/2)",
+    "title":"Testing Variables :: MATCHED_VARS (1/6)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -43,7 +43,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS (2/2)",
+    "title":"Testing Variables :: MATCHED_VARS (2/6)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -81,6 +81,169 @@
       "SecRule MATCHED_VARS \"@contains asdf\" \"\"",
       "SecRule MATCHED_VARS \"@contains value\" \"id:29\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (3/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS \"@contains 1\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (4/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS \"@contains 2\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (5/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS \"@within 1 2\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS (6/6)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VARS \"@eq 2\""
+    ]
   }
 ]
-

--- a/test/test-cases/regression/variable-MATCHED_VARS_NAMES.json
+++ b/test/test-cases/regression/variable-MATCHED_VARS_NAMES.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS_NAMES (1/2)",
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (1/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -43,7 +43,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VARS_NAMES (2/2)",
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (2/5)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -81,6 +81,128 @@
       "SecRule MATCHED_VARS_NAMES \"@contains asdf\" \"\"",
       "SecRule MATCHED_VARS_NAMES \"@contains value\" \"id:29\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (3/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VARS_NAMES \"@within ARGS:foo ARGS:bar ARGS:baz\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (4/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VARS_NAMES \"@strEq ARGS:foo\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VARS_NAMES (5/5)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VARS_NAMES \"@within ARGS:bar ARGS:baz\""
+    ]
   }
 ]
-

--- a/test/test-cases/regression/variable-MATCHED_VAR_NAME.json
+++ b/test/test-cases/regression/variable-MATCHED_VAR_NAME.json
@@ -2,7 +2,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR_NAME (1/3)",
+    "title":"Testing Variables :: MATCHED_VAR_NAME (1/7)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -43,7 +43,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR_NAME (2/3)",
+    "title":"Testing Variables :: MATCHED_VAR_NAME (2/7)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -85,7 +85,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing Variables :: MATCHED_VAR_NAME (3/3)",
+    "title":"Testing Variables :: MATCHED_VAR_NAME (3/7)",
     "client":{
       "ip":"200.249.12.31",
       "port":123
@@ -121,6 +121,169 @@
       "SecRule ARGS_NAMES \"@contains ey1\" \"chain,id:30,pass\"",
       "SecRule MATCHED_VAR_NAME \"@contains key1\" \"id:31\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (4/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:foo\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (5/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:bar\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (6/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 200
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,pass\"",
+      "SecRule MATCHED_VAR_NAME \"@strEq ARGS:baz\" \"id:3,phase:1,deny,status:403\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing Variables :: MATCHED_VAR_NAME (7/7)",
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*"
+      },
+      "uri":"/?foo=1&bar=2&baz=2",
+      "method":"GET"
+    },
+    "response":{
+      "headers":{
+        "Date":"Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified":"Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type":"text/html"
+      },
+      "body":[
+        "no need."
+      ]
+    },
+    "expected":{
+      "http_code": 403
+    },
+    "rules":[
+      "SecRuleEngine On",
+      "SecRule ARGS \"@rx 1\" \"id:1,phase:1,pass\"",
+      "SecRule ARGS \"@rx 2\" \"id:2,phase:1,deny,status:403,chain\"",
+      "SecRule MATCHED_VAR_NAME \"@within ARGS:baz ARGS:bar\""
+    ]
   }
 ]
-


### PR DESCRIPTION
## what

This PR changes the code behavior: now the engine cleans the `MATCHED_VAR*` variables after chained and non-chained rules too.

With current behavior if a rule is not chained then `MATCHED_VAR*` variables kept their values.

**Changes**:
* moved `cleanMatchedVars()` method from `RuleWithOperator` class to `RuleSet`
  * the reason is: `RuleWithOperator` represents a `SecRule` object, which can be a chained or non-chained rule; it's important that `SecRule` (in this context) has a variable and an operator at least (`SecAction` does not have these)
  * `RuleSet` is a container which holds `SecRule` and `SecAction` objects
  * when the `evaluate()` method is called from the transaction's phase, then `RuleSet` evaluates all rules and actions in a loop
  * because the `cleanMatchedVars()` was a part of `RuleWithOperator` (which is a `SecRule`), then it was possible to call that only from that class
  * it was difficult to decide when a rule ended (see [discussion](https://github.com/owasp-modsecurity/ModSecurity/pull/3418#discussion_r2227380953))
  * otherwise, I think this method is better suited here, because we must clean these variables after each rule, whether it's chained or non-chained - but in case of chained rule, only after the last part of it
* the location of this method call has also been moved after the point where `RulesSet` object evaluates the rules of phases, now we can call it after all `evaluate()` call - and the condition fits that it cleans the `MATCHED_VAR*` variables after all single rule and after all last part of chained rule
* I also added the new test cases from previous PR

## why

The issue #3382 describes the problem: if a non-chained rule evaluated, and the rule filled the `MATCHED_VAR*` variables, then those values remained after the ending of evaluation. Then if a next rule used any of `MATCHED_VAR*`, it found those values and led a false match.

## other notes

There was a try before this, see #3418. There - as I wrote above - wasn't clean how the solution solves the issue exactly and was a [suggestion](https://github.com/owasp-modsecurity/ModSecurity/pull/3418#discussion_r2229452774) we should clean these variables before the rule's evaluation. It was not possible, because the `cleanMatchedVars()` was a part of the one rule's method.

## references

Closes #3382.
