### PR TITLE
fix: confusing indentation at acmp.cc

### DIFF
--- a/src/utils/acmp.cc
+++ b/src/utils/acmp.cc
@@ -226,7 +226,7 @@ static void acmp_build_binary_tree(ACMP *parser, acmp_node_t *node) {
 
     /* We have array with all children of the node and number of those children
      */
-    for (i = 0; i < count - 1; i++)
+    for (i = 0; i < count - 1; i++) {
         for (j = i + 1; j < count; j++) {
             acmp_node_t *tmp;
 
@@ -236,6 +236,7 @@ static void acmp_build_binary_tree(ACMP *parser, acmp_node_t *node) {
             nodes[i] = nodes[j];
             nodes[j] = tmp;
         }
+    }       
     if (node->btree != NULL) {
         free(node->btree);
         node->btree = NULL;

--- a/src/utils/acmp.cc
+++ b/src/utils/acmp.cc
@@ -236,10 +236,10 @@ static void acmp_build_binary_tree(ACMP *parser, acmp_node_t *node) {
             nodes[i] = nodes[j];
             nodes[j] = tmp;
         }
-        if (node->btree != NULL) {
-            free(node->btree);
-            node->btree = NULL;
-        }
+    if (node->btree != NULL) {
+        free(node->btree);
+        node->btree = NULL;
+    }
     node->btree = reinterpret_cast<acmp_btree_node_t *>(calloc(1, sizeof(acmp_btree_node_t)));
 
     /* ENH: Check alloc succeded */


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

Change indentation, which can confuse users

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

On first sight on code it can be seems that this block in for cycle, but it's not true

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
