### PR TITLE
fix: rx operators better null checks

### DIFF
--- a/src/operators/rx.cc
+++ b/src/operators/rx.cc
@@ -68,18 +68,19 @@ bool Rx::evaluate(Transaction *transaction, RuleWithActions *rule,
 
     // FIXME: DRY regex error reporting. This logic is currently duplicated in other operators.
     if (regex_result != Utils::RegexResult::Ok) {
-        transaction->m_variableMscPcreError.set("1", transaction->m_variableOffset);
+        if (transaction) {
+            transaction->m_variableMscPcreError.set("1", transaction->m_variableOffset);
 
-        std::string regex_error_str = "OTHER";
-        if (regex_result == Utils::RegexResult::ErrorMatchLimit) {
-            regex_error_str = "MATCH_LIMIT";
-            transaction->m_variableMscPcreLimitsExceeded.set("1", transaction->m_variableOffset);
-            transaction->m_collections.m_tx_collection->storeOrUpdateFirst("MSC_PCRE_LIMITS_EXCEEDED", "1");
-            ms_dbg_a(transaction, 7, "Set TX.MSC_PCRE_LIMITS_EXCEEDED to 1");
+            std::string regex_error_str = "OTHER";
+            if (regex_result == Utils::RegexResult::ErrorMatchLimit) {
+                regex_error_str = "MATCH_LIMIT";
+                transaction->m_variableMscPcreLimitsExceeded.set("1", transaction->m_variableOffset);
+                transaction->m_collections.m_tx_collection->storeOrUpdateFirst("MSC_PCRE_LIMITS_EXCEEDED", "1");
+                ms_dbg_a(transaction, 7, "Set TX.MSC_PCRE_LIMITS_EXCEEDED to 1");
+            }
+
+            ms_dbg_a(transaction, 1, "rx: regex error '" + regex_error_str + "' for pattern '" + re->pattern + "'");
         }
-
-        ms_dbg_a(transaction, 1, "rx: regex error '" + regex_error_str + "' for pattern '" + re->pattern + "'");
-
 
         return false;
     }

--- a/src/operators/rx_global.cc
+++ b/src/operators/rx_global.cc
@@ -62,17 +62,19 @@ bool RxGlobal::evaluate(Transaction *transaction, RuleWithActions *rule,
 
     // FIXME: DRY regex error reporting. This logic is currently duplicated in other operators.
     if (regex_result != Utils::RegexResult::Ok) {
-        transaction->m_variableMscPcreError.set("1", transaction->m_variableOffset);
+        if (transaction) {
+            transaction->m_variableMscPcreError.set("1", transaction->m_variableOffset);
 
-        std::string regex_error_str = "OTHER";
-        if (regex_result == Utils::RegexResult::ErrorMatchLimit) {
-            regex_error_str = "MATCH_LIMIT";
-            transaction->m_variableMscPcreLimitsExceeded.set("1", transaction->m_variableOffset);
-            transaction->m_collections.m_tx_collection->storeOrUpdateFirst("MSC_PCRE_LIMITS_EXCEEDED", "1");
-            ms_dbg_a(transaction, 7, "Set TX.MSC_PCRE_LIMITS_EXCEEDED to 1");
+            std::string regex_error_str = "OTHER";
+            if (regex_result == Utils::RegexResult::ErrorMatchLimit) {
+                regex_error_str = "MATCH_LIMIT";
+                transaction->m_variableMscPcreLimitsExceeded.set("1", transaction->m_variableOffset);
+                transaction->m_collections.m_tx_collection->storeOrUpdateFirst("MSC_PCRE_LIMITS_EXCEEDED", "1");
+                ms_dbg_a(transaction, 7, "Set TX.MSC_PCRE_LIMITS_EXCEEDED to 1");
+            }
+
+            ms_dbg_a(transaction, 1, "rxGlobal: regex error '" + regex_error_str + "' for pattern '" + re->pattern + "'");
         }
-
-        ms_dbg_a(transaction, 1, "rxGlobal: regex error '" + regex_error_str + "' for pattern '" + re->pattern + "'");
 
         return false;
     }


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

Add nullptr check in one more place

## why

I think it can cause null derefence, because before we check for null:
https://github.com/owasp-modsecurity/ModSecurity/blob/1ff9f2a943529301a35e188ced84c3f977f3cd96/src/operators/rx.cc#L62

But after forget about this check and do dereference:
https://github.com/owasp-modsecurity/ModSecurity/blob/1ff9f2a943529301a35e188ced84c3f977f3cd96/src/operators/rx.cc#L71

I cannot create PoC, maybe I'm wrong and using  regex without limit will never cause `!= Utils::RegexResult::Ok`, but looks legit


