### PR TITLE
fix: malloc checks at msc_tree

### DIFF
--- a/src/utils/msc_tree.cc
+++ b/src/utils/msc_tree.cc
@@ -419,6 +419,9 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
                 node->count++;
                 new_node = node;
                 node->netmasks = reinterpret_cast<unsigned char *>(malloc(node->count *  sizeof(unsigned char)));
+                if (node->netmasks == NULL) {
+                    return node;
+                }
                 memset(node->netmasks, 0, (node->count *  sizeof(unsigned char)));
 
                 if ((node->count -1) == 0) {
@@ -491,14 +494,14 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
             }
 
             i_node->netmasks = reinterpret_cast<unsigned char *>(malloc((node->count - i) * sizeof(unsigned char)));
-            memset(i_node->netmasks, 0, ((node->count - i) * sizeof(unsigned char)));
-
             if(i_node->netmasks == NULL) {
                 free(new_node->prefix);
                 free(new_node);
                 free(i_node);
                 return NULL;
             }
+
+            memset(i_node->netmasks, 0, ((node->count - i) * sizeof(unsigned char)));
 
             j = 0;
             while (j < (node->count - i))   {


### PR DESCRIPTION
## what

1. Check for malloc success
2. Avoid check for NULL after dereference (at memset)

## why

Avoid NPD

## references

Some more info: #2890

P.S. Maybe at 419 we should return something another?