### PR TITLE
fix: memory leak at msc_tree

### DIFF
--- a/src/utils/msc_tree.cc
+++ b/src/utils/msc_tree.cc
@@ -407,8 +407,10 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
                 CPTData *prefix_data = CPTCreateCPTData(netmask);
                 CPTAppendToCPTDataList(prefix_data, &prefix->prefix_data);
 
-                if(CheckBitmask(netmask, ip_bitmask))
+                if(CheckBitmask(netmask, ip_bitmask)) {
+                    free(prefix);
                     return node;
+                }
 
                 parent = node->parent;
                 while (parent != NULL && netmask < (parent->bit + 1)) {
@@ -423,6 +425,7 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
 
                 if ((node->count -1) == 0) {
                     node->netmasks[0] = netmask;
+                    free(prefix);
                     return new_node;
                 }
 
@@ -449,8 +452,10 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
 
     new_node = CPTCreateNode();
 
-    if(new_node == NULL)
+    if(new_node == NULL) {
+        free(prefix);
         return NULL;
+    }
 
     new_node->prefix = prefix;
     new_node->bit = prefix->bitlen;


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

Prefix memory can be leaked at place there I suggest patch.
After prefix can be freed by node->prefix, it's okay