### PR TITLE
chore: fix cppcheck warning

### DIFF
--- a/src/operators/fuzzy_hash.cc
+++ b/src/operators/fuzzy_hash.cc
@@ -27,7 +27,7 @@ bool FuzzyHash::init(const std::string &param2, std::string *error) {
 #ifdef WITH_SSDEEP
     std::string digit;
     std::string file;
-    std::istream *iss;
+    std::ifstream *iss;
     std::shared_ptr<fuzzy_hash_chunk> chunk, t;
     std::string err;
 
@@ -48,7 +48,7 @@ bool FuzzyHash::init(const std::string &param2, std::string *error) {
     std::string resource = utils::find_resource(file, param2, &err);
     iss = new std::ifstream(resource, std::ios::in);
 
-    if (((std::ifstream *)iss)->is_open() == false) {
+    if ((iss)->is_open() == false) {
         error->assign("Failed to open file: " + m_param + ". " + err);
         delete iss;
         return false;

--- a/src/operators/fuzzy_hash.cc
+++ b/src/operators/fuzzy_hash.cc
@@ -48,7 +48,7 @@ bool FuzzyHash::init(const std::string &param2, std::string *error) {
     std::string resource = utils::find_resource(file, param2, &err);
     iss = new std::ifstream(resource, std::ios::in);
 
-    if ((iss)->is_open() == false) {
+    if (iss->is_open() == false) {
         error->assign("Failed to open file: " + m_param + ". " + err);
         delete iss;
         return false;

--- a/src/operators/inspect_file.cc
+++ b/src/operators/inspect_file.cc
@@ -31,14 +31,14 @@ namespace modsecurity {
 namespace operators {
 
 bool InspectFile::init(const std::string &param2, std::string *error) {
-    std::istream *iss;
+    std::ifstream *iss;
     std::string err;
     std::string err_lua;
 
     m_file = utils::find_resource(m_param, param2, &err);
     iss = new std::ifstream(m_file, std::ios::in);
 
-    if (((std::ifstream *)iss)->is_open() == false) {
+    if ((iss)->is_open() == false) {
         error->assign("Failed to open file: " + m_param + ". " + err);
         delete iss;
         return false;

--- a/src/operators/inspect_file.cc
+++ b/src/operators/inspect_file.cc
@@ -38,7 +38,7 @@ bool InspectFile::init(const std::string &param2, std::string *error) {
     m_file = utils::find_resource(m_param, param2, &err);
     iss = new std::ifstream(m_file, std::ios::in);
 
-    if ((iss)->is_open() == false) {
+    if (iss->is_open() == false) {
         error->assign("Failed to open file: " + m_param + ". " + err);
         delete iss;
         return false;

--- a/src/operators/rbl.cc
+++ b/src/operators/rbl.cc
@@ -226,14 +226,14 @@ bool Rbl::evaluate(Transaction *t, RuleWithActions *rule,
         return false;
     }
 
-    // NOSONAR
     // SonarCloud suggested to use the init-statement to declare "addr" inside the if statement.
     // I think that's not good here, because we need that in the else block
-    struct sockaddr *addr = info->ai_addr;
-    // NOSONAR
-    if (addr->sa_family == AF_INET) { // only IPv4 address is allowed
-        auto sin = (struct sockaddr_in *) addr; // cppcheck-suppress[dangerousTypeCast]
-        furtherInfo(sin, ipStr, t, m_provider);
+    struct sockaddr *addr = info->ai_addr;  // NOSONAR
+    if (addr->sa_family == AF_INET) {  // NOSONAR
+        struct sockaddr_in sin{};  // initialize an empty struct; we don't need port info
+        memcpy(&sin.sin_addr, addr->sa_data + 2, sizeof(sin.sin_addr));
+        sin.sin_family = AF_INET;
+        furtherInfo(&sin, ipStr, t, m_provider);
     }
     else {
         ms_dbg_a(t, 7,  "Unsupported address family: " + std::to_string(addr->sa_family));

--- a/src/operators/rbl.cc
+++ b/src/operators/rbl.cc
@@ -226,9 +226,12 @@ bool Rbl::evaluate(Transaction *t, RuleWithActions *rule,
         return false;
     }
 
+    // NOSONAR
+    // SonarCloud suggested to use the init-statement to declare "addr" inside the if statement.
+    // I think that's not good here, because we need that in the else block
     struct sockaddr *addr = info->ai_addr;
     if (addr->sa_family == AF_INET) { // only IPv4 address is allowed
-        struct sockaddr_in *sin = reinterpret_cast<struct sockaddr_in *>(addr);
+        struct sockaddr_in *sin = (struct sockaddr_in *) addr; // cppcheck-suppress[dangerousTypeCast]
         furtherInfo(sin, ipStr, t, m_provider);
     }
     else {

--- a/src/operators/rbl.cc
+++ b/src/operators/rbl.cc
@@ -227,8 +227,15 @@ bool Rbl::evaluate(Transaction *t, RuleWithActions *rule,
     }
 
     struct sockaddr *addr = info->ai_addr;
-    struct sockaddr_in *sin = (struct sockaddr_in *) addr;
-    furtherInfo(sin, ipStr, t, m_provider);
+    if (addr->sa_family == AF_INET) { // only IPv4 address is allowed
+        struct sockaddr_in *sin = reinterpret_cast<struct sockaddr_in *>(addr);
+        furtherInfo(sin, ipStr, t, m_provider);
+    }
+    else {
+        ms_dbg_a(t, 7,  "Unsupported address family: " + std::to_string(addr->sa_family));
+        freeaddrinfo(info);
+        return false;
+    }
 
     freeaddrinfo(info);
     if (rule && t && rule->hasCaptureAction()) {

--- a/src/operators/rbl.cc
+++ b/src/operators/rbl.cc
@@ -228,7 +228,7 @@ bool Rbl::evaluate(Transaction *t, RuleWithActions *rule,
 
     // SonarCloud suggested to use the init-statement to declare "addr" inside the if statement.
     // I think that's not good here, because we need that in the else block
-    struct sockaddr *addr = info->ai_addr;  // NOSONAR
+    const struct sockaddr *addr = info->ai_addr;  // NOSONAR
     if (addr->sa_family == AF_INET) {  // NOSONAR
         struct sockaddr_in sin{};  // initialize an empty struct; we don't need port info
         memcpy(&sin.sin_addr, addr->sa_data + 2, sizeof(sin.sin_addr));

--- a/src/operators/rbl.cc
+++ b/src/operators/rbl.cc
@@ -230,8 +230,9 @@ bool Rbl::evaluate(Transaction *t, RuleWithActions *rule,
     // SonarCloud suggested to use the init-statement to declare "addr" inside the if statement.
     // I think that's not good here, because we need that in the else block
     struct sockaddr *addr = info->ai_addr;
+    // NOSONAR
     if (addr->sa_family == AF_INET) { // only IPv4 address is allowed
-        struct sockaddr_in *sin = (struct sockaddr_in *) addr; // cppcheck-suppress[dangerousTypeCast]
+        auto sin = (struct sockaddr_in *) addr; // cppcheck-suppress[dangerousTypeCast]
         furtherInfo(sin, ipStr, t, m_provider);
     }
     else {

--- a/src/operators/validate_dtd.cc
+++ b/src/operators/validate_dtd.cc
@@ -45,7 +45,7 @@ bool ValidateDTD::init(const std::string &file, std::string *error) {
 
 bool ValidateDTD::evaluate(Transaction *transaction, const std::string &str) {
 
-    XmlDtdPtrManager dtd(xmlParseDTD(NULL, (const xmlChar *)m_resource.c_str()));
+    XmlDtdPtrManager dtd(xmlParseDTD(NULL, reinterpret_cast<const xmlChar *>(m_resource.c_str())));
     if (dtd.get() == NULL) {
         std::string err = std::string("XML: Failed to load DTD: ") \
             + m_resource;

--- a/src/variables/xml.cc
+++ b/src/variables/xml.cc
@@ -91,7 +91,7 @@ void XML::evaluate(Transaction *t,
     } else {
         std::vector<actions::Action *> acts = rule->getActionsByName("xmlns", t);
         for (auto &x : acts) {
-            actions::XmlNS *z = reinterpret_cast<actions::XmlNS *>(x);
+            actions::XmlNS *z = static_cast<actions::XmlNS *>(x);
             if (xmlXPathRegisterNs(xpathCtx, reinterpret_cast<const xmlChar*>(z->m_scope.c_str()),
                     reinterpret_cast<const xmlChar*>(z->m_href.c_str())) != 0) {
                 ms_dbg_a(t, 1, "Failed to register XML namespace href \"" + \

--- a/src/variables/xml.cc
+++ b/src/variables/xml.cc
@@ -79,7 +79,7 @@ void XML::evaluate(Transaction *t,
     }
 
     /* Process the XPath expression. */
-    xpathExpr = (const xmlChar*)param.c_str();
+    xpathExpr = reinterpret_cast<const xmlChar*>(param.c_str());
     xpathCtx = xmlXPathNewContext(t->m_xml->m_data.doc);
     if (xpathCtx == NULL) {
         ms_dbg_a(t, 1, "XML: Unable to create new XPath context. : ");
@@ -91,9 +91,9 @@ void XML::evaluate(Transaction *t,
     } else {
         std::vector<actions::Action *> acts = rule->getActionsByName("xmlns", t);
         for (auto &x : acts) {
-            actions::XmlNS *z = (actions::XmlNS *)x;
-            if (xmlXPathRegisterNs(xpathCtx, (const xmlChar*)z->m_scope.c_str(),
-                    (const xmlChar*)z->m_href.c_str()) != 0) {
+            actions::XmlNS *z = reinterpret_cast<actions::XmlNS *>(x);
+            if (xmlXPathRegisterNs(xpathCtx, reinterpret_cast<const xmlChar*>(z->m_scope.c_str()),
+                    reinterpret_cast<const xmlChar*>(z->m_href.c_str())) != 0) {
                 ms_dbg_a(t, 1, "Failed to register XML namespace href \"" + \
                     z->m_href + "\" prefix \"" + z->m_scope + "\".");
                 return;

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -31,6 +31,8 @@ accessMoved:seclang-parser.hh
 returnTempReference:seclang-parser.hh
 duplInheritedMember:seclang-parser.hh
 constVariableReference:seclang-parser.hh
+uninitMemberVar:seclang-parser.hh
+
 
 unreadVariable:src/operators/rx.cc
 unreadVariable:src/operators/rx_global.cc
@@ -60,5 +62,3 @@ uselessCallsSubstr
 // Examples
 memleak:examples/using_bodies_in_chunks/simple_request.cc
 
-// supress seclang-parser.hh warnings
-uninitMemberVar:src/parser/seclang-parser.hh

--- a/test/cppcheck_suppressions.txt
+++ b/test/cppcheck_suppressions.txt
@@ -59,3 +59,6 @@ uselessCallsSubstr
 
 // Examples
 memleak:examples/using_bodies_in_chunks/simple_request.cc
+
+// supress seclang-parser.hh warnings
+uninitMemberVar:src/parser/seclang-parser.hh


### PR DESCRIPTION
## what

This PR collects a few small fixes which solves the issues with current (2.18.0) `cppcheck`.

Changes:
* src/operators/fuzzy_hash.cc: variable `iss` was declared as `std::istream` and later it was converted unnecessary
* src/operators/inspect_file.cc: same issue
* src/operators/pm_from_file.cc: similar issue, but here there are two options based on resource path; if the resource begins with `https://` then we should read from stream. Note that `std::stringstream` (case of `http` resource) and `std::ifstream` derived both from `std::istream`
* src/operators/rbl.cc: changed implicit cast to `reinterpret_cast<>` and add error report (if the socket type is not `AF_INET` (IPv4))
* src/operators/validate_dtd.cc: changed implicit cast to `reinterpret_cast<>`
* src/variables/xml.cc: same solution
* src/parser/seclang-parser.hh: this is a generated file by Bison so we can't change its content; therefore I added a new supression into `test/cppcheck_suppressions.txt`

## why

There are a few warnings by `cppcheck` in recent PR's.

## references

See PR #3432.
