### PR TITLE
fix: eliminate non-posix standard variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/location.hh
 src/position.hh
 src/stack.hh
 src/stamp-h1
+src/headers.mk
 /test/rules_optimization
 /test/regression_tests
 /test/unit_tests

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ rm -rf autom4te.cache
 rm -f aclocal.m4
 
 cd src
-rm -f haders.mk
+rm -f headers.mk
 echo "noinst_HEADERS = \\" > headers.mk
 ls -1 \
     actions/*.h \

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,28 @@
 
 rm -rf autom4te.cache
 rm -f aclocal.m4
+
+cd src
+rm -f haders.mk
+echo "noinst_HEADERS = \\" > headers.mk
+ls -1 \
+    actions/*.h \
+    actions/ctl/*.h \
+    actions/data/*.h \
+    actions/disruptive/*.h \
+    actions/transformations/*.h \
+    debug_log/*.h \
+    audit_log/writer/*.h \
+    collection/backend/*.h \
+    operators/*.h \
+    parser/*.h \
+    request_body_processor/*.h \
+    utils/*.h \
+    variables/*.h \
+    engine/*.h \
+    *.h | tr "\012" " " >> headers.mk
+cd ../
+
 case `uname` in Darwin*) glibtoolize --force --copy ;;
   *) libtoolize --force --copy ;; esac
 autoreconf --install

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,24 +66,7 @@ libmodsecurity_includesub_collection_HEADERS = \
 libmodsecurity_includesub_actions_HEADERS = \
 	../headers/modsecurity/actions/action.h
 
-
-noinst_HEADERS = \
-	$(wildcard actions/*.h) \
-	$(wildcard actions/ctl/*.h) \
-	$(wildcard actions/data/*.h) \
-	$(wildcard actions/disruptive/*.h) \
-	$(wildcard actions/transformations/*.h) \
-	$(wildcard debug_log/*.h) \
-	$(wildcard audit_log/writer/*.h) \
-	$(wildcard collection/backend/*.h) \
-	$(wildcard operators/*.h) \
-	$(wildcard parser/*.h) \
-	$(wildcard request_body_processor/*.h) \
-	$(wildcard utils/*.h) \
-	$(wildcard variables/*.h) \
-	$(wildcard engine/*.h) \
-	$(wildcard *.h)
-
+include headers.mk
 
 ENGINES = \
 	engine/lua.cc


### PR DESCRIPTION
## what

This PR fixes the error that `./build.sh` gives namely the `src/Makefile.am` contains non-POSIX variables.

## why

GNU `automake` does not support `wildcard`, but the project uses that in [src/Makefile.am](https://github.com/owasp-modsecurity/ModSecurity/blob/a07ed61e74b0ba61a35471c4689f082815204887/src/Makefile.am#L70-L85). There is an open issue about this so we should fix that.

## references

#3435 
https://www.gnu.org/software/automake/manual/html_node/Wildcards.html

## fix

As the documentation says above GNU automake expects a programmer should list the files instead of using `wildcard`, I used a hack: in `build.sh` I collect all header files in previously mentioned directories, and generate a file: `src/headers.mk`. This file is included in `src/Makefile.am`. The file is generated all cases when user runs `./build.sh`. The generated file is not part of the source tree - see `.gitignore` changes in this PR.
