### PR TITLE
fix: ignore case when evaluating exceptions

### DIFF
--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -158,7 +158,7 @@ inline void RuleWithOperator::getFinalVars(variables::Variables *vars,
     variables::Variables addition;
     getVariablesExceptions(*trans, exclusion, &addition); // cppcheck-suppress ctunullpointer
 
-    for (int i = 0; i < m_variables->size(); i++) {
+    for (std::size_t i = 0; i < m_variables->size(); i++) {
         Variable *variable = m_variables->at(i);
         if (exclusion->contains(variable)) {
             continue;

--- a/src/rule_with_operator.cc
+++ b/src/rule_with_operator.cc
@@ -166,8 +166,15 @@ inline void RuleWithOperator::getFinalVars(variables::Variables *vars,
         if (std::find_if(trans->m_ruleRemoveTargetById.begin(),
                 trans->m_ruleRemoveTargetById.end(),
                 [&, variable, this](const auto &m) -> bool {
-                    return m.first == m_ruleId
-                        && m.second == *variable->m_fullName.get();
+                    const auto& str1 = m.second;
+                    const auto& str2 = *variable->m_fullName.get();
+                    return m.first == m_ruleId &&
+                           str1.size() == str2.size() &&
+                           std::equal(str1.begin(), str1.end(), str2.begin(),
+                                      [](char a, char b) {
+                                          return std::tolower(static_cast<unsigned char>(a)) ==
+                                                 std::tolower(static_cast<unsigned char>(b));
+                                      }); // end-of std::equal
                 }) != trans->m_ruleRemoveTargetById.end()) {
             continue;
         }

--- a/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
@@ -133,7 +133,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing CtlRuleRemoveTargetById (5)",
+    "title":"Testing CtlRuleRemoveTargetById (5): lowercase `Referer` header",
     "expected":{
       "http_code": 200
     },

--- a/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
@@ -99,7 +99,7 @@
   {
     "enabled":1,
     "version_min":300000,
-    "title":"Testing CtlRuleRemoveTargetById (4)",
+    "title":"Testing CtlRuleRemoveTargetById (4): uppercase `Referer` header",
     "expected":{
       "http_code": 200
     },

--- a/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
+++ b/test/test-cases/regression/action-ctl_rule_remove_target_by_id.json
@@ -95,5 +95,73 @@
         "SecRule REQUEST_FILENAME \"@endsWith /wp-login.php\" \"id:9002100,phase:2,t:none,nolog,pass,ctl:ruleRemoveTargetById=1;ARGS\"",
         "SecRule ARGS \"@contains lhebs\" \"id:1,phase:3,t:none,status:202,block,deny,tag:'CRS'\""
     ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing CtlRuleRemoveTargetById (4)",
+    "expected":{
+      "http_code": 200
+    },
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
+        "Content-Type": "text/xml",
+        "Referer": "This is an attack"
+      },
+      "uri":"/index.html",
+      "method":"GET",
+      "body": [ ]
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "rules":[
+        "SecRuleEngine On",
+        "SecRule REQUEST_FILENAME \"@unconditionalMatch\" \"id:1,phase:1,pass,t:none,ctl:ruleRemoveTargetById=2;REQUEST_HEADERS:referer\"",
+        "SecRule REQUEST_HEADERS:Referer \"@contains attack\" \"id:2,phase:1,deny,t:none,log\""
+    ]
+  },
+  {
+    "enabled":1,
+    "version_min":300000,
+    "title":"Testing CtlRuleRemoveTargetById (5)",
+    "expected":{
+      "http_code": 200
+    },
+    "client":{
+      "ip":"200.249.12.31",
+      "port":123
+    },
+    "request":{
+      "headers":{
+        "Host":"localhost",
+        "User-Agent":"curl/7.38.0",
+        "Accept":"*/*",
+        "Cookie": "PHPSESSID=rAAAAAAA2t5uvjq435r4q7ib3vtdjq120",
+        "Content-Type": "text/xml",
+        "referer": "This is an attack"
+      },
+      "uri":"/index.html",
+      "method":"GET",
+      "body": [ ]
+    },
+    "server":{
+      "ip":"200.249.12.31",
+      "port":80
+    },
+    "rules":[
+        "SecRuleEngine On",
+        "SecRule REQUEST_FILENAME \"@unconditionalMatch\" \"id:1,phase:1,pass,t:none,ctl:ruleRemoveTargetById=2;REQUEST_HEADERS:referer\"",
+        "SecRule REQUEST_HEADERS:Referer \"@contains attack\" \"id:2,phase:1,deny,t:none,log\""
+    ]
   }
 ]


### PR DESCRIPTION
## what

This PR fixes the wrong behavior: variable names are treated as case sensitive. Also it contains two new test cases for regression tests.

## why

An issue opened (see below) where the reporter explained the problem: if an exclusion adds a collection member with lowercase, it won't have any effect during the rule evaluation.

The issue mentions only the `REQUEST_HEADERS` collection, but that's true for all targets.

mod_security2 Apache module [uses](https://github.com/owasp-modsecurity/ModSecurity/blob/9d9a72734988bbd4f101cbea0d5df60eabcc1435/apache2/re.c#L118) `strncasecmp()` in all cases, not just `REQUEST_HEADERS`.

## additional notes

I didn't want to mix C and C++ functions, this is why I ignored `strncasecmp()`. I also wanted to avoid copying strings and create new functions to comparing strings, so the only solution seemed to be to use `std::equal()` with a lambda function.

## references

#3441 