### PR TITLE
Fix libxml2 related deprecated issues

### DIFF
--- a/apache2/msc_crypt.c
+++ b/apache2/msc_crypt.c
@@ -1091,14 +1091,22 @@ int inject_hashed_response_body(modsec_rec *msr, int elts) {
         msr_log(msr, 4, "inject_hashed_response_body: Detected encoding type [%s].",
                 encoding ? encoding : "(none)");
 
-    if (handler == NULL)
+    if (handler == NULL) {
         handler = xmlFindCharEncodingHandler("UTF-8");
-    if (handler == NULL)
+        encoding = apr_pstrdup(msr->mp, "UTF-8");
+    }
+    if (handler == NULL) {
         handler = xmlFindCharEncodingHandler("ISO-8859-1");
-    if (handler == NULL)
+        encoding = apr_pstrdup(msr->mp, "ISO-8859-1");
+    }
+    if (handler == NULL) {
         handler = xmlFindCharEncodingHandler("HTML");
-    if (handler == NULL)
+        encoding = apr_pstrdup(msr->mp, "HTML");
+    }
+    if (handler == NULL) {
         handler = xmlFindCharEncodingHandler("ascii");
+        encoding = apr_pstrdup(msr->mp, "ascii");
+    }
 
     if(handler == NULL) {
         xmlFreeDoc(msr->crypto_html_tree);
@@ -1106,11 +1114,11 @@ int inject_hashed_response_body(modsec_rec *msr, int elts) {
     }
 
     apr_table_unset(msr->r->headers_out,"Content-Type");
-    new_ct = (char*)apr_psprintf(msr->mp, "text/html;%s",handler->name);
+    new_ct = (char*)apr_psprintf(msr->mp, "text/html;%s",encoding);
     apr_table_set(msr->r->err_headers_out,"Content-Type",new_ct);
 
     if (msr->txcfg->debuglog_level >= 4)
-        msr_log(msr, 4, "inject_hashed_response_body: Using content-type [%s].", handler->name);
+        msr_log(msr, 4, "inject_hashed_response_body: Using content-type [%s].", encoding);
 
     output_buf = xmlAllocOutputBuffer(handler);
     if (output_buf == NULL) {

--- a/apache2/msc_xml.h
+++ b/apache2/msc_xml.h
@@ -20,7 +20,7 @@ typedef struct xml_data xml_data;
 #include "modsecurity.h"
 #include <libxml/xmlschemas.h>
 #include <libxml/xpath.h>
-#include <libxml/SAX.h>
+#include <libxml/SAX2.h>
 
 /* Structures */
 


### PR DESCRIPTION
## what

This PR fixes `libxml2` related deprecated warnings.

## why

With newest `clang` and `gcc` compilers and newest `libxml2` library there were a few deprecated warnings.
```
In file included from msc_xml.h:23,
                 from modsecurity.h:42,
                 from re.h:38,
                 from re.c:17:
/usr/include/libxml2/libxml/SAX.h:15:4: warning: #warning "libxml/SAX.h is deprecated" [-Wcpp]
   15 |   #warning "libxml/SAX.h is deprecated"
      |    ^~~~~~~
```
and
```
msc_crypt.c: In function 'inject_hashed_response_body':
msc_crypt.c:1109:5: warning: 'name' is deprecated [-Wdeprecated-declarations]
 1109 |     new_ct = (char*)apr_psprintf(msr->mp, "text/html;%s",handler->name);
      |     ^~~~~~
In file included from /usr/include/libxml2/libxml/parser.h:25,
                 from /usr/include/libxml2/libxml/tree.h:17,
                 from modsecurity.h:22:
/usr/include/libxml2/libxml/encoding.h:169:11: note: declared here
  169 |     char *name XML_DEPRECATED_MEMBER;
      |           ^~~~
```