### PR TITLE
fix: libxml2 related deprecated issues in v3

### DIFF
--- a/src/operators/validate_dtd.cc
+++ b/src/operators/validate_dtd.cc
@@ -33,12 +33,6 @@ bool ValidateDTD::init(const std::string &file, std::string *error) {
         return false;
     }
 
-    xmlThrDefSetGenericErrorFunc(NULL,
-        null_error);
-
-    xmlSetGenericErrorFunc(NULL,
-        null_error);
-
     return true;
 }
 

--- a/src/operators/validate_dtd.h
+++ b/src/operators/validate_dtd.h
@@ -78,9 +78,6 @@ class ValidateDTD : public Operator {
     }
 
 
-    static void null_error(void *, const char *, ...) { // cppcheck-suppress[constParameterPointer,constParameterCallback]
-    }
-
  private:
     std::string m_resource;
 #endif

--- a/src/operators/validate_schema.cc
+++ b/src/operators/validate_schema.cc
@@ -71,12 +71,6 @@ bool ValidateSchema::evaluate(Transaction *transaction,
         (xmlSchemaValidityErrorFunc)error_load,
         (xmlSchemaValidityWarningFunc)warn_load, &m_err);
 
-    xmlThrDefSetGenericErrorFunc(parserCtx,
-        null_error);
-
-    xmlSetGenericErrorFunc(parserCtx,
-        null_error);
-
     xmlSchemaPtr schema = xmlSchemaParse(parserCtx);
     if (schema == NULL) {
         std::stringstream err;

--- a/src/operators/validate_schema.h
+++ b/src/operators/validate_schema.h
@@ -75,8 +75,6 @@ class ValidateSchema : public Operator {
         va_end(args);
     }
 
-    static void null_error(void *, const char *, ...) { // cppcheck-suppress[constParameterPointer,constParameterCallback]
-    }
 
     template<typename Pred>
     static void callback_func(void *ctx, Pred pred, const char *base_msg, const char *msg, va_list args) {

--- a/src/request_body_processor/xml.cc
+++ b/src/request_body_processor/xml.cc
@@ -274,7 +274,6 @@ bool XML::processChunk(const char *buf, unsigned int size,
     if (m_data.parsing_ctx != NULL &&
         m_transaction->m_secXMLParseXmlIntoArgs
         != RulesSetProperties::OnlyArgsConfigXMLParseXmlIntoArgs) {
-        xmlSetGenericErrorFunc(m_data.parsing_ctx, null_error);
         xmlParseChunk(m_data.parsing_ctx, buf, size, 0);
         m_data.xml_parser_state->parsing_ctx_arg = m_data.parsing_ctx_arg;
         if (m_data.parsing_ctx->wellFormed != 1) {
@@ -292,7 +291,6 @@ bool XML::processChunk(const char *buf, unsigned int size,
             m_transaction->m_secXMLParseXmlIntoArgs
               == RulesSetProperties::TrueConfigXMLParseXmlIntoArgs)
         ) {
-        xmlSetGenericErrorFunc(m_data.parsing_ctx_arg, null_error);
         xmlParseChunk(m_data.parsing_ctx_arg, buf, size, 0);
         if (m_data.parsing_ctx_arg->wellFormed != 1) {
             error->assign("XML: Failed to parse document for ARGS.");

--- a/src/request_body_processor/xml.cc
+++ b/src/request_body_processor/xml.cc
@@ -249,6 +249,8 @@ bool XML::processChunk(const char *buf, unsigned int size,
                 error->assign("XML: Failed to create parsing context.");
                 return false;
             }
+            // disable parser errors being printed to stderr
+            m_data.parsing_ctx->options |= XML_PARSE_NOWARNING | XML_PARSE_NOERROR;
         }
 
         if (m_transaction->m_secXMLParseXmlIntoArgs
@@ -265,6 +267,8 @@ bool XML::processChunk(const char *buf, unsigned int size,
                 error->assign("XML: Failed to create parsing context for ARGS.");
                 return false;
             }
+            // disable parser errors being printed to stderr
+            m_data.parsing_ctx_arg->options |= XML_PARSE_NOWARNING | XML_PARSE_NOERROR;
         }
 
         return true;

--- a/src/request_body_processor/xml.h
+++ b/src/request_body_processor/xml.h
@@ -16,7 +16,7 @@
 #ifdef WITH_LIBXML2
 #include <libxml/xmlschemas.h>
 #include <libxml/xpath.h>
-#include <libxml/SAX.h>
+#include <libxml/SAX2.h>
 #endif
 
 #include <string>
@@ -92,10 +92,6 @@ class XML {
     bool complete(std::string *err);
     static xmlParserInputBufferPtr unloadExternalEntity(const char *URI,
         xmlCharEncoding enc);
-
-    static void null_error(void *ctx, const char *msg, ...) { // cppcheck-suppress[constParameterPointer,constParameterCallback]
-    }
-
 
     xml_data m_data;
 


### PR DESCRIPTION
Similar as #3454 for v2.

## what

This PR fixes libxml2 related deprecated warnings.

## why

With newest `clang` and `gcc` compilers and newest `libxml2` library there were a few deprecated warnings.
```
In file included from ../src/request_body_processor/xml.h:19,
                 from transaction.cc:40:
/usr/include/libxml2/libxml/SAX.h:15:4: warning: #warning "libxml/SAX.h is deprecated" [-Wcpp]
   15 |   #warning "libxml/SAX.h is deprecated"
      |    ^~~~~~~
```
```
operators/validate_dtd.cc: In member function 'virtual bool modsecurity::operators::ValidateDTD::init(const std::string&, std::string*)':
operators/validate_dtd.cc:36:33: warning: 'void xmlThrDefSetGenericErrorFunc(void*, xmlGenericErrorFunc)' is deprecated [-Wdeprecated-declarations]
   36 |     xmlThrDefSetGenericErrorFunc(NULL,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
   37 |         null_error);
      |         ~~~~~~~~~~~              
```
```
operators/validate_schema.cc: In member function 'virtual bool modsecurity::operators::ValidateSchema::evaluate(modsecurity::Transaction*, const std::string&)':
operators/validate_schema.cc:74:33: warning: 'void xmlThrDefSetGenericErrorFunc(void*, xmlGenericErrorFunc)' is deprecated [-Wdeprecated-declarations]
   74 |     xmlThrDefSetGenericErrorFunc(parserCtx,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
   75 |         null_error);
      |         ~~~~~~~~~~~              
```

I removed not just `xmlThrDefSetGenericErrorFunc()` call but the `xmlSetGenericErrorFunc()` too, because in libxml2 documentation both functions are marked as deprecated.

Beside of that, all error handlers are set to a `null_error()` function which did nothing, so I remove those handlers too, and set the contexts' options to `XML_PARSE_NOWARNING | XML_PARSE_NOERROR` as libxml2's documentation recommends that.

## references

* deprecated function [xmlThrDefSetGenericErrorFunc()](https://gnome.pages.gitlab.gnome.org/libxml2/html/xmlerror_8h.html#a51e487c25e90d402e187bab7e84a1f1d)
* deprecated function [xmlSetStructuredErrorFunc()](https://gnome.pages.gitlab.gnome.org/libxml2/html/xmlerror_8h.html#ab1b127a183bcaaf7de7f08928dd5994a)
* both description mention
_"If you only want to disable parser errors being printed to stderr, use [xmlParserOption](https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a7d2daaf67df051ca5ef0b319b640442c) `XML_PARSE_NOERROR`"_


