### PR TITLE
fix: yajl detection for source installations (#3457)

### DIFF
--- a/build/find_yajl.m4
+++ b/build/find_yajl.m4
@@ -89,10 +89,14 @@ else
                 yajl_lib_path="${x}/"
                 yajl_lib_name="yajl"
                 break
-            else
+           elif test -e "${x}/lib/libyajl.${y}"; then
+                yajl_lib_path="${x}/lib/"
+                yajl_lib_name="yajl"
+                break
+           else
                 yajl_lib_path=""
                 yajl_lib_name=""
-            fi
+           fi
         done
         if test -n "$yajl_lib_path"; then
             break


### PR DESCRIPTION
<!-- Thank you for contributing to OWASP ModSecurity, your effort is greatly appreciated -->
<!-- Please help us by adding the information below in this PR so it aids reviewers -->

## what

- Modified `find_yajl.m4` to correctly detect yajl when installed from source.  
- Added a check for the `lib` subdirectory in addition to the top-level path.  
- Ensures that ModSecurity compilation succeeds when `--with-yajl` is specified. 

## why

- The build failed to detect yajl 2.1.0 compiled from source, even when the correct path was provided.  


## references

- Issue: #3457