### PR TITLE
Fix memory leak

### DIFF
--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -205,9 +205,12 @@ class TransactionAnchoredVariables {
         m_variableFilesTmpNames(t, "FILES_TMPNAMES"),
         m_variableMultipartPartHeaders(t, "MULTIPART_PART_HEADERS"),
         m_variableOffset(0),
-        m_variableArgsNames("ARGS_NAMES", &m_variableArgs),
-        m_variableArgsGetNames("ARGS_GET_NAMES", &m_variableArgsGet),
-        m_variableArgsPostNames("ARGS_POST_NAMES", &m_variableArgsPost)
+        m_pVariableArgsNames(std::make_unique<AnchoredSetVariableTranslationProxy>("ARGS_NAMES", &m_variableArgs)),
+        m_variableArgsNames(*m_pVariableArgsNames),
+        m_pVariableArgsGetNames(std::make_unique<AnchoredSetVariableTranslationProxy>("ARGS_GET_NAMES", &m_variableArgsGet)),
+        m_variableArgsGetNames(*m_pVariableArgsGetNames),
+        m_pVariableArgsPostNames(std::make_unique<AnchoredSetVariableTranslationProxy>("ARGS_POST_NAMES", &m_variableArgsPost)),
+        m_variableArgsPostNames(*m_pVariableArgsPostNames)
         { }
 
     AnchoredSetVariable m_variableRequestHeadersNames;
@@ -291,9 +294,12 @@ class TransactionAnchoredVariables {
 
     int m_variableOffset;
 
-    AnchoredSetVariableTranslationProxy m_variableArgsNames;
-    AnchoredSetVariableTranslationProxy m_variableArgsGetNames;
-    AnchoredSetVariableTranslationProxy m_variableArgsPostNames;
+    std::unique_ptr<AnchoredSetVariableTranslationProxy> m_pVariableArgsNames;
+    AnchoredSetVariableTranslationProxy &m_variableArgsNames;
+    std::unique_ptr<AnchoredSetVariableTranslationProxy> m_pVariableArgsGetNames;
+    AnchoredSetVariableTranslationProxy &m_variableArgsGetNames;
+    std::unique_ptr<AnchoredSetVariableTranslationProxy> m_pVariableArgsPostNames;
+    AnchoredSetVariableTranslationProxy &m_variableArgsPostNames;
 };
 
 class TransactionSecMarkerManagement {

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -170,6 +170,12 @@ Transaction::~Transaction() {
 
     m_rulesMessages.clear();
 
+    m_ruleRemoveById.clear();
+    m_ruleRemoveByIdRange.clear();
+    m_ruleRemoveByTag.clear();
+    m_ruleRemoveTargetById.clear();
+    m_ruleRemoveTargetByTag.clear();
+
     intervention::free(&m_it);
     intervention::clean(&m_it);
 


### PR DESCRIPTION
This is a potential fix to https://github.com/owasp-modsecurity/ModSecurity/issues/2848

It was AI generated by Google AI Studio

Here are it's workings:

Based on the Valgrind output and the provided code, the memory leak is located in the **`TransactionAnchoredVariables`** class (which is part of the `Transaction` object).

The stack trace indicates that memory allocated during the construction of `AnchoredSetVariableTranslationProxy` (specifically inside a `std::function` initialization) is never freed.

```text
==27426== 1 bytes in 1 blocks are possibly lost ...
==27426== at 0x482BBB5: operator new(unsigned int) ...
==27426== by 0x94EB43A: ... function<...>::operator= ...
==27426== by 0x94EB43A: AnchoredSetVariableTranslationProxy ...
==27426== by 0x94EB43A: modsecurity::TransactionAnchoredVariables::TransactionAnchoredVariables(modsecurity::Transaction*) ...
```

In `src/transaction.cc`, the `Transaction` constructor initializes `TransactionAnchoredVariables`:

```cpp
Transaction::Transaction(ModSecurity *ms, RulesSet *rules, const char *id,
    void *logCbData, const time_t timestamp)
    : ...
    TransactionAnchoredVariables(this) { // <--- Initialization here
    ...
```

And in `src/variables/variable.h`, the code accesses `m_variableArgsNames` as if it were an object (using `&`), not a pointer:

```cpp
anchoredSetVariableTranslationProxy = &t->m_variableArgsNames;
```

This usage pattern combined with the leak indicates that **`TransactionAnchoredVariables` declares its members (like `m_variableArgsNames`) as references (`&`) but initializes them using `new` in its constructor.**

Because they are references, the `TransactionAnchoredVariables` destructor does not (and cannot) delete the objects they refer to. Consequently, the `AnchoredSetVariableTranslationProxy` objects (and their internal `std::function` members) are leaked when the `Transaction` is destroyed.

**To fix this:**
The members in `TransactionAnchoredVariables` should be changed from references (e.g., `AnchoredSetVariableTranslationProxy &`) to pointers (e.g., `std::unique_ptr<AnchoredSetVariableTranslationProxy>`), or they should be deleted manually in the `TransactionAnchoredVariables` destructor if raw pointers are used. Given the `&t->member` usage, they were likely intended to be value members or references binding to dynamic memory (which is the bug).