### PR TITLE
Collection: Include `<cstdint>`.

### DIFF
--- a/headers/modsecurity/collection/collection.h
+++ b/headers/modsecurity/collection/collection.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <algorithm>
 #include <memory>
+#include <cstdint>
 #endif
 
 


### PR DESCRIPTION
This fixes builds on Alpine v3.23.0 (GCC v15.2.0, musl v1.2.5).

```
headers/modsecurity/collection/collection.h:x:x: error: 'int32_t' has not been declared
headers/modsecurity/collection/collection.h:x:x: note: 'int32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```