### PR TITLE
Refine SecRequestBodyNoFilesLimit test cases to cover edge scenarios

### DIFF
--- a/test/test-cases/regression/config-body_limits.json
+++ b/test/test-cases/regression/config-body_limits.json
@@ -404,7 +404,7 @@
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
-	"Content-Length": "41",
+        "Content-Length": "42",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri":"/",
@@ -430,7 +430,7 @@
     "rules":[
       "SecRuleEngine On",
       "SecRequestBodyAccess On",
-      "SecRequestBodyNoFilesLimit 20",
+      "SecRequestBodyNoFilesLimit 41",
       "SecRule REQBODY_ERROR \"!@eq 0\" \"id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2\""
     ]
   },
@@ -451,7 +451,7 @@
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
-	"Content-Length": "41",
+        "Content-Length": "42",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri":"/",
@@ -476,7 +476,7 @@
     "rules":[
       "SecRuleEngine On",
       "SecRequestBodyAccess On",
-      "SecRequestBodyNoFilesLimit 60",
+      "SecRequestBodyNoFilesLimit 42",
       "SecRule REQBODY_ERROR \"!@eq 0\" \"id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2\""
     ]
   },


### PR DESCRIPTION
## what

Extend and adjust existing tests for the `SecRequestBodyNoFilesLimit` directive in config-body_limits.json to ensure correct handling of edge boundary values.

Also fix the Content-Length of the requests. Note that an LF is added for each line in the body field. see https://github.com/owasp-modsecurity/ModSecurity/blob/cebcde3b9c4ee2620018955507943cb0023d103f/test/regression/regression_test.cc#L51

```
$ echo "param1=value1&param2=value2&param3=value3" | wc -c
42
```

## why

The existing tests do not cover edge boundary lengths. As a result, we cannot verify whether a request body whose length is exactly equal to `SecRequestBodyNoFilesLimit` is accepted.

## references

None.
