### PR TITLE
v2: Accept requests whose body length is exactly equal to SecRequestBodyNoFilesLimit

### DIFF
--- a/apache2/msc_reqbody.c
+++ b/apache2/msc_reqbody.c
@@ -406,7 +406,7 @@ apr_status_t modsecurity_request_body_store(modsec_rec *msr,
     }
 
     /* Check that we are not over the request body no files limit. */
-    if (msr->msc_reqbody_no_files_length >= (unsigned long) msr->txcfg->reqbody_no_files_limit) {
+    if (msr->msc_reqbody_no_files_length > (unsigned long) msr->txcfg->reqbody_no_files_limit) {
         *error_msg = apr_psprintf(msr->mp, "Request body no files data length is larger than the "
                 "configured limit (%ld).", msr->txcfg->reqbody_no_files_limit);
         if (msr->txcfg->debuglog_level >= 1) {
@@ -671,7 +671,7 @@ apr_status_t modsecurity_request_body_end(modsec_rec *msr, char **error_msg) {
 
 
     /* Check that we are not over the request body no files limit. */
-    if (msr->msc_reqbody_no_files_length >= (unsigned long)msr->txcfg->reqbody_no_files_limit) {
+    if (msr->msc_reqbody_no_files_length > (unsigned long)msr->txcfg->reqbody_no_files_limit) {
         *error_msg = apr_psprintf(msr->mp, "Request body no files data length is larger than the "
             "configured limit (%ld).", msr->txcfg->reqbody_no_files_limit);
         if (msr->txcfg->debuglog_level >= 1) {

--- a/tests/regression/config/10-request-directives.t
+++ b/tests/regression/config/10-request-directives.t
@@ -750,3 +750,42 @@
 	),
 },
 
+# SecRequestBodyNoFilesLimit
+{
+	type => "config",
+	comment => "SecRequestBodyNoFilesLimit - length is equal to limit",
+	conf => q(
+		SecRuleEngine On
+		SecRequestBodyAccess On
+		SecRequestBodyNoFilesLimit 16
+	),
+	match_response => {
+		status => qr/^200$/,
+	},
+	request => new HTTP::Request(
+		POST => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt",
+		[
+			"Content-Type" => "application/x-www-form-urlencoded",
+		],
+		"a=0123456789ABCD",
+	),
+},
+{
+	type => "config",
+	comment => "SecRequestBodyNoFilesLimit - length is larger than limit",
+	conf => q(
+		SecRuleEngine On
+		SecRequestBodyAccess On
+		SecRequestBodyNoFilesLimit 16
+	),
+	match_response => {
+		status => qr/^413$/,
+	},
+	request => new HTTP::Request(
+		POST => "http://$ENV{SERVER_NAME}:$ENV{SERVER_PORT}/test.txt",
+		[
+			"Content-Type" => "application/x-www-form-urlencoded",
+		],
+		"a=0123456789ABCDE",
+	),
+},


### PR DESCRIPTION
## what

Accept requests whose body length is exactly equal to `SecRequestBodyNoFilesLimit`.

## why

The current implementation rejects requests when their body length is equal to `SecRequestBodyNoFilesLimit`.
However, according to the documented behavior, requests up to and including this limit should be accepted.

## references

- The documentation states: “Configures the maximum request body size ModSecurity will accept for buffering, excluding the size of any files being transported in the request.” https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v2.x%29#user-content-SecRequestBodyNoFilesLimit
- Tests verifying that requests with a body length equal to `SecRequestBodyNoFilesLimit` are accepted in v3:: https://github.com/owasp-modsecurity/ModSecurity/pull/3479
