### PR TITLE
v3: fix readme on running tests (fixes #3328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,7 @@ the utilities, follow the commands listed below:
 ```shell
 $ cd /path/to/your/ModSecurity
 $ git submodule foreach git pull
-$ cd test
-$ ./regression_tests
-$ ./unit_tests
+$ make check
  ```
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ the utilities, follow the commands listed below:
 
 ```shell
 $ cd /path/to/your/ModSecurity
-$ git submodule foreach git pull
+$ git submodule update --init --recursive
 $ make check
  ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -68,8 +68,7 @@ AC_MSG_ERROR([\
 
   You can download libInjection using git:
 
-     $ git submodule init
-     $ git submodule update
+     $ git submodule update --init --recursive
 
    ])
 fi
@@ -90,8 +89,7 @@ AC_MSG_ERROR([\
 
   You can download Mbed TLS using git:
 
-     $ git submodule init
-     $ git submodule update
+     $ git submodule update --init --recursive
 
    ])
 fi


### PR DESCRIPTION
## what

- Fix instructions for running regression and unit tests.
- Also fix instructions for updating git submodules.

## why

- The previous instructions caused test failures when running unit tests and errors when updating git submodules.

## references

- closes #3328
