### PR TITLE
Fix multipart boundaries in regression tests

### DIFF
--- a/test/test-cases/regression/action-ctl_request_body_access.json
+++ b/test/test-cases/regression/action-ctl_request_body_access.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/test",
@@ -78,7 +78,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/test",
@@ -139,7 +139,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/test",

--- a/test/test-cases/regression/config-body_limits.json
+++ b/test/test-cases/regression/config-body_limits.json
@@ -95,7 +95,8 @@
       "headers":{  
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
-        "Accept":"*/*"
+        "Accept":"*/*",
+        "Content-Type": "multipart/form-data; boundary=------------------------756b6d74fa1a8ee2"
       },
       "uri":"/?key=value&key=other_value",
       "method":"POST",
@@ -152,7 +153,8 @@
       "headers":{  
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
-        "Accept":"*/*"
+        "Accept":"*/*",
+        "Content-Type": "multipart/form-data; boundary=------------------------756b6d74fa1a8ee2"
       },
       "uri":"/?key=value&key=other_value",
       "method":"POST",
@@ -209,7 +211,8 @@
       "headers":{  
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
-        "Accept":"*/*"
+        "Accept":"*/*",
+        "Content-Type": "multipart/form-data; boundary=------------------------756b6d74fa1a8ee2"
       },
       "uri":"/?key=value&key=other_value",
       "method":"POST",
@@ -266,7 +269,7 @@
       "headers":{  
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
-        "Accept":"*/*"
+        "Content-Type": "multipart/form-data; boundary=------------------------756b6d74fa1a8ee2"
       },
       "uri":"/?key=value&key=other_value",
       "method":"POST",

--- a/test/test-cases/regression/variable-FULL_REQUEST.json
+++ b/test/test-cases/regression/variable-FULL_REQUEST.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -50,8 +50,8 @@
         "no need."
       ]
     },
-    "expected":{  
-      "debug_log":"Multipart: Boundary: --------------------------756b6d74fa1a8ee2"
+    "expected":{
+      "debug_log":"Multipart: Boundary: ------------------------756b6d74fa1a8ee2"
     },
     "rules":[  
       "SecRuleEngine On",

--- a/test/test-cases/regression/variable-FULL_REQUEST_LENGTH.json
+++ b/test/test-cases/regression/variable-FULL_REQUEST_LENGTH.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -50,8 +50,8 @@
         "no need."
       ]
     },
-    "expected":{  
-      "debug_log":"Target value: \"690\" \\(Variable: FULL_REQUEST_LENGTH\\)"
+    "expected":{
+      "debug_log":"Target value: \"688\" \\(Variable: FULL_REQUEST_LENGTH\\)"
     },
     "rules":[  
       "SecRuleEngine On",

--- a/test/test-cases/regression/variable-INBOUND_DATA_ERROR.json
+++ b/test/test-cases/regression/variable-INBOUND_DATA_ERROR.json
@@ -56,7 +56,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-MULTIPART_STRICT_ERROR.json
+++ b/test/test-cases/regression/variable-MULTIPART_STRICT_ERROR.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary= --------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary= ------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -76,7 +76,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=\"--------------------------756b6d74fa1a8ee2\"",
+        "Content-Type":"multipart/form-data; boundary=\"------------------------756b6d74fa1a8ee2\"",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-OUTBOUND_DATA_ERROR.json
+++ b/test/test-cases/regression/variable-OUTBOUND_DATA_ERROR.json
@@ -57,7 +57,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-REQBODY_PROCESSOR.json
+++ b/test/test-cases/regression/variable-REQBODY_PROCESSOR.json
@@ -94,7 +94,7 @@
         "Host":"localhost",
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
-        "Content-Type": "multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2"
+        "Content-Type": "multipart/form-data; boundary=------------------------756b6d74fa1a8ee2"
       },
       "uri":"/?key=value&key=other_value",
       "http_version":1.1,

--- a/test/test-cases/regression/variable-REQUEST_BODY.json
+++ b/test/test-cases/regression/variable-REQUEST_BODY.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-REQUEST_BODY_LENGTH.json
+++ b/test/test-cases/regression/variable-REQUEST_BODY_LENGTH.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-REQUEST_HEADERS.json
+++ b/test/test-cases/regression/variable-REQUEST_HEADERS.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-REQUEST_HEADERS_NAMES.json
+++ b/test/test-cases/regression/variable-REQUEST_HEADERS_NAMES.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -76,7 +76,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -135,7 +135,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -194,7 +194,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -253,7 +253,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -312,7 +312,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-RESPONSE_HEADERS.json
+++ b/test/test-cases/regression/variable-RESPONSE_HEADERS.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",

--- a/test/test-cases/regression/variable-RESPONSE_HEADERS_NAMES.json
+++ b/test/test-cases/regression/variable-RESPONSE_HEADERS_NAMES.json
@@ -17,7 +17,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -76,7 +76,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",
@@ -135,7 +135,7 @@
         "User-Agent":"curl/7.38.0",
         "Accept":"*/*",
         "Content-Length":"330",
-        "Content-Type":"multipart/form-data; boundary=--------------------------756b6d74fa1a8ee2",
+        "Content-Type":"multipart/form-data; boundary=------------------------756b6d74fa1a8ee2",
         "Expect":"100-continue"
       },
       "uri":"/",


### PR DESCRIPTION
## what

- Remove the redundant "--" prefix from boundaries.
- Add the missing Content-Type header for multipart bodies.

## why

- To make it clear that the tests assume the multipart body is correct and are intended to verify other aspects.

## references

None
