### PR TITLE
fix: cppcheck warnings, cppcheck 2.19.0

### DIFF
--- a/src/engine/lua.h
+++ b/src/engine/lua.h
@@ -36,6 +36,9 @@ class LuaScriptBlob {
         m_data(NULL),
         m_len(0) { }
 
+    LuaScriptBlob(const LuaScriptBlob&) = delete;
+    LuaScriptBlob& operator=(const LuaScriptBlob&) = delete;
+
     ~LuaScriptBlob() {
         if (m_data) {
             free(m_data);

--- a/src/operators/pm.h
+++ b/src/operators/pm.h
@@ -40,6 +40,10 @@ class Pm : public Operator {
         : Operator(n, std::move(param)) {
         m_p = acmp_create(0);
     }
+
+    Pm(const Pm&) = delete;
+    Pm& operator=(const Pm&) = delete;
+
     ~Pm() override;
     bool evaluate(Transaction *transaction, RuleWithActions *rule,
         const std::string &str,

--- a/src/operators/rx.h
+++ b/src/operators/rx.h
@@ -42,6 +42,9 @@ class Rx : public Operator {
             m_couldContainsMacro = true;
         }
 
+    Rx(const Rx&) = delete;
+    Rx& operator=(const Rx&) = delete;
+
     ~Rx() override {
         if (m_string->m_containsMacro == false && m_re != NULL) {
             delete m_re;

--- a/src/operators/rx_global.h
+++ b/src/operators/rx_global.h
@@ -42,6 +42,9 @@ class RxGlobal : public Operator {
             m_couldContainsMacro = true;
         }
 
+    RxGlobal(const RxGlobal&) = delete;
+    RxGlobal& operator=(const RxGlobal&) = delete;
+
     ~RxGlobal() override {
         if (m_string->m_containsMacro == false && m_re != NULL) {
             delete m_re;

--- a/src/request_body_processor/multipart.h
+++ b/src/request_body_processor/multipart.h
@@ -150,6 +150,10 @@ class MultipartPart {
 class Multipart {
  public:
     Multipart(const std::string &header, Transaction *transaction);
+
+    Multipart(const Multipart&) = delete;
+    Multipart& operator=(const Multipart&) = delete;
+
     ~Multipart();
 
     bool init(std::string *err);

--- a/src/utils/ip_tree.h
+++ b/src/utils/ip_tree.h
@@ -31,6 +31,8 @@ namespace Utils {
 class IpTree {
  public:
     IpTree();
+    IpTree(const IpTree&) = delete;
+    IpTree& operator=(const IpTree&) = delete;
     ~IpTree();
 
     bool contains(const std::string &ip);

--- a/src/variables/rule.h
+++ b/src/variables/rule.h
@@ -40,7 +40,7 @@ class Rule_DictElement : public VariableDictElement { \
     static void id(Transaction *t,
         RuleWithActions *rule,
         std::vector<const VariableValue *> *l) {
-        RuleWithActions *r = rule;
+        const RuleWithActions *r = rule;
 
         while (r && r->m_ruleId == 0) {
             r = r->m_chainedRuleParent;
@@ -74,7 +74,7 @@ class Rule_DictElement : public VariableDictElement { \
     static void severity(Transaction *t,
         RuleWithActions *rule,
         std::vector<const VariableValue *> *l) {
-        RuleWithActions *r = rule;
+        const RuleWithActions *r = rule;
 
         while (r && !r->hasSeverity()) {
             r = r->m_chainedRuleParent;

--- a/src/variables/rule.h
+++ b/src/variables/rule.h
@@ -38,7 +38,7 @@ class Rule_DictElement : public VariableDictElement { \
         : VariableDictElement(m_rule, dictElement) { }
 
     static void id(Transaction *t,
-        RuleWithActions *rule,
+        const RuleWithActions *rule,
         std::vector<const VariableValue *> *l) {
         const RuleWithActions *r = rule;
 
@@ -72,7 +72,7 @@ class Rule_DictElement : public VariableDictElement { \
 
 
     static void severity(Transaction *t,
-        RuleWithActions *rule,
+        const RuleWithActions *rule,
         std::vector<const VariableValue *> *l) {
         const RuleWithActions *r = rule;
 


### PR DESCRIPTION
## what

This PR fixes a few `cppcheck` warnings:

 * `src/engine/lua.h`: added copy and `=` operator constructors
 * `src/operators/pm.h`: added copy and `=` operator constructors
 * `src/operators/rx.h`: added copy and `=` operator constructors
 * `src/operators/rx_global.h`: added copy and `=` operator constructors
 * `src/request_body_processor/multipart.h`: added copy and `=` operator constructors
 * `src/utils/ip_tree.h`: added copy and `=` operator constructors
 * `src/variables/rule.h`: change pointer declarations to `const` where it's possible

## why

After a recently merged [PR](https://github.com/owasp-modsecurity/ModSecurity/commit/0ad6e8fd4e0e71a4ecf195e25efe7b83ef5882a6) I got a notification about a failed [test](https://github.com/owasp-modsecurity/ModSecurity/actions/runs/21259358049/job/61182633108).

I downloaded the report and found these issues:

```
2026-01-22T18:05:30.2906400Z warning: src/operators/rx.h,47,warning,noCopyConstructor,Class 'Rx' does not have a copy constructor which is recommended since it has dynamic memory/resource management.
2026-01-22T18:05:30.3305610Z warning: src/operators/rx.h,47,warning,noOperatorEq,Class 'Rx' does not have a operator= which is recommended since it has dynamic memory/resource management.
2026-01-22T18:05:54.8985410Z warning: src/engine/lua.h,41,warning,noCopyConstructor,Class 'LuaScriptBlob' does not have a copy constructor which is recommended since it has dynamic memory/resource management.
2026-01-22T18:05:54.8988130Z warning: src/engine/lua.h,41,warning,noOperatorEq,Class 'LuaScriptBlob' does not have a operator= which is recommended since it has dynamic memory/resource management.
2026-01-22T18:14:35.7366650Z warning: src/operators/rx_global.h,47,warning,noCopyConstructor,Class 'RxGlobal' does not have a copy constructor which is recommended since it has dynamic memory/resource management.
2026-01-22T18:14:35.7374120Z warning: src/operators/rx_global.h,47,warning,noOperatorEq,Class 'RxGlobal' does not have a operator= which is recommended since it has dynamic memory/resource management.
2026-01-22T18:14:52.8542470Z warning: src/operators/pm.cc,101,warning,noCopyConstructor,Class 'Pm' does not have a copy constructor which is recommended since it has dynamic memory/resource management.
2026-01-22T18:14:52.8545010Z warning: src/operators/pm.cc,101,warning,noOperatorEq,Class 'Pm' does not have a operator= which is recommended since it has dynamic memory/resource management.
2026-01-22T18:18:03.0682420Z warning: src/variables/rule.h,43,style,constVariablePointer,Variable 'r' can be declared as pointer to const
2026-01-22T18:18:03.0685470Z warning: src/variables/rule.h,77,style,constVariablePointer,Variable 'r' can be declared as pointer to const
2026-01-22T18:18:38.7002810Z warning: src/request_body_processor/multipart.cc,170,warning,noCopyConstructor,Class 'Multipart' does not have a copy constructor which is recommended since it has dynamic memory/resource management.
2026-01-22T18:18:38.7004560Z warning: src/request_body_processor/multipart.cc,170,warning,noOperatorEq,Class 'Multipart' does not have a operator= which is recommended since it has dynamic memory/resource management.
2026-01-22T18:20:39.2194320Z warning: src/utils/ip_tree.cc,87,warning,noCopyConstructor,Class 'IpTree' does not have a copy constructor which is recommended since it has dynamic memory/resource management.
2026-01-22T18:20:39.2204500Z warning: src/utils/ip_tree.cc,87,warning,noOperatorEq,Class 'IpTree' does not have a operator= which is recommended since it has dynamic memory/resource management.
```

## references

**cppcheck** new version (2.19.0) was released on 2025.12.21, see the [release](https://github.com/danmar/cppcheck/releases/tag/2.19.0) page. This new version was probably released into the GH workflow later than the mentioned [PR](https://github.com/owasp-modsecurity/ModSecurity/pull/3482) was (2025.12.28).

