### PR TITLE
fix: cppcheck warnings in nginx/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,8 @@ cppcheck:
 	    --inconclusive \
 	    --template="warning: {file},{line},{severity},{id},{message}" \
 	    --error-exitcode=1 \
-	    standalone/
+		standalone/ \
+	    nginx/
 
 check-static: cppcheck
 

--- a/nginx/modsecurity/apr_bucket_nginx.c
+++ b/nginx/modsecurity/apr_bucket_nginx.c
@@ -54,7 +54,6 @@ static apr_status_t nginx_bucket_read(apr_bucket *b, const char **str,
     apr_bucket_nginx *n = b->data;
     ngx_buf_t        *buf = n->buf;
     u_char           *data;
-    ssize_t           size;
 
     if (buf->pos == NULL && ngx_buf_size(buf) != 0) {
         data = apr_bucket_alloc(ngx_buf_size(buf), b->list);
@@ -62,7 +61,7 @@ static apr_status_t nginx_bucket_read(apr_bucket *b, const char **str,
             return APR_EGENERAL;
         }
 
-        size = ngx_read_file(buf->file, data, ngx_buf_size(buf), buf->file_pos);
+        ssize_t size = ngx_read_file(buf->file, data, ngx_buf_size(buf), buf->file_pos);
         if (size != ngx_buf_size(buf)) {
             apr_bucket_free(data);
             return APR_EGENERAL;
@@ -80,9 +79,9 @@ static apr_status_t nginx_bucket_read(apr_bucket *b, const char **str,
 static void nginx_bucket_destroy(void *data)
 {
     apr_bucket_nginx *n = data;
-    ngx_buf_t *buf = n->buf;
 
     if (apr_bucket_shared_destroy(n)) {
+        ngx_buf_t *buf = n->buf;
         if (!ngx_buf_in_memory(buf) && buf->pos != NULL) {
             apr_bucket_free(buf->pos);
             buf->pos = NULL;
@@ -92,8 +91,7 @@ static void nginx_bucket_destroy(void *data)
 }
 
 ngx_buf_t * apr_bucket_to_ngx_buf(apr_bucket *e, ngx_pool_t *pool) {
-    ngx_buf_t         *buf, *b;
-    apr_bucket_nginx  *n;
+    ngx_buf_t         *buf;
     ngx_uint_t         len;
     u_char            *data;
 
@@ -102,8 +100,8 @@ ngx_buf_t * apr_bucket_to_ngx_buf(apr_bucket *e, ngx_pool_t *pool) {
     }
 
     if (e->type == &apr_bucket_type_nginx) {
-        n = e->data;
-        b = n->buf;
+        apr_bucket_nginx *n = e->data;
+        ngx_buf_t *b = n->buf;
 
         /* whole buf */
         if (e->length == (apr_size_t)ngx_buf_size(b)) {
@@ -156,7 +154,6 @@ ngx_buf_t * apr_bucket_to_ngx_buf(apr_bucket *e, ngx_pool_t *pool) {
 ngx_int_t
 move_chain_to_brigade(ngx_chain_t *chain, apr_bucket_brigade *bb, ngx_pool_t *pool, ngx_int_t last_buf) {
     apr_bucket         *e;
-    ngx_chain_t        *cl;
 
     while (chain) {
         e = ngx_buf_to_apr_bucket(chain->buf, bb->p, bb->bucket_alloc);
@@ -171,7 +168,7 @@ move_chain_to_brigade(ngx_chain_t *chain, apr_bucket_brigade *bb, ngx_pool_t *po
             chain->buf->last_buf = 0;
             return NGX_OK;
         }
-        cl = chain;
+        ngx_chain_t *cl = chain;
         chain = chain->next;
         ngx_free_chain(pool, cl);
     }

--- a/nginx/modsecurity/ngx_http_modsecurity.c
+++ b/nginx/modsecurity/ngx_http_modsecurity.c
@@ -81,7 +81,7 @@ static ngx_command_t  ngx_http_modsecurity_commands[] =  {
         |NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
     ngx_http_modsecurity_enable,
     NGX_HTTP_LOC_CONF_OFFSET,
-    offsetof(ngx_http_modsecurity_loc_conf_t, enable),
+    offsetof(ngx_http_modsecurity_loc_conf_t, enable),  // cppcheck-suppress syntaxError
     NULL },
   ngx_null_command
 };
@@ -210,9 +210,9 @@ ngx_http_modsecurity_load_request(ngx_http_request_t *r)
     size_t                       root;
     ngx_str_t                    path;
     ngx_uint_t                   port;
-    struct sockaddr_in          *sin;
+    const struct sockaddr_in    *sin;
 #if (NGX_HAVE_INET6)
-    struct sockaddr_in6         *sin6;
+    const struct sockaddr_in6   *sin6;
 #endif
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
@@ -616,11 +616,9 @@ ngx_http_modsecurity_load_headers_out(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t  *ctx;
     char                        *data;
     request_rec                 *req;
-    ngx_http_variable_value_t   *vv;
-    ngx_list_part_t             *part;
+    const ngx_list_part_t       *part;
     ngx_table_elt_t             *h;
     ngx_uint_t                   i;
-    char                        *key, *value;
     u_char                      *buf = NULL;
     size_t                       size = 0;
 
@@ -651,11 +649,11 @@ ngx_http_modsecurity_load_headers_out(ngx_http_request_t *r)
             return NGX_ERROR;
         }
 
-        key = (char *)buf;
+        char *key = (char *)buf;
         buf = ngx_cpymem(buf, h[i].key.data, h[i].key.len);
         *buf++ = '\0';
 
-        value = (char *)buf;
+        char *value = (char *)buf;
         buf = ngx_cpymem(buf, h[i].value.data, h[i].value.len);
         *buf++ = '\0';
 
@@ -668,7 +666,7 @@ ngx_http_modsecurity_load_headers_out(ngx_http_request_t *r)
 
     for (i = 0; special_headers_out[i].name; i++) {
 
-        vv = ngx_http_get_variable(r, &special_headers_out[i].variable_name,
+        ngx_http_variable_value_t   *vv = ngx_http_get_variable(r, &special_headers_out[i].variable_name,
                                    ngx_hash_key(special_headers_out[i].variable_name.data,
                                                 special_headers_out[i].variable_name.len));
 
@@ -892,7 +890,7 @@ modsec_pcre_malloc(size_t size)
 }
 
 static void
-modsec_pcre_free(void *ptr)
+modsec_pcre_free(const void *ptr)
 {
 }
 
@@ -928,7 +926,7 @@ ngx_http_modsecurity_preconfiguration(ngx_conf_t *cf)
 
 
 static void
-ngx_http_modsecurity_terminate(ngx_cycle_t *cycle)
+ngx_http_modsecurity_terminate(const ngx_cycle_t *cycle)
 {
     if (modsec_server) {
         modsecTerminate();
@@ -981,7 +979,7 @@ ngx_http_modsecurity_init_process(ngx_cycle_t *cycle)
 static ngx_int_t
 ngx_http_modsecurity_handler(ngx_http_request_t *r)
 {
-    ngx_http_modsecurity_loc_conf_t *cf;
+    const ngx_http_modsecurity_loc_conf_t *cf;
     ngx_http_modsecurity_ctx_t      *ctx;
     ngx_int_t                        rc;
 
@@ -1089,11 +1087,9 @@ ngx_http_modsecurity_body_handler(ngx_http_request_t *r)
 
 static ngx_int_t
 ngx_http_modsecurity_header_filter(ngx_http_request_t *r) {
-    ngx_http_modsecurity_loc_conf_t *cf;
+    const ngx_http_modsecurity_loc_conf_t *cf;
     ngx_http_modsecurity_ctx_t      *ctx;
-    const char                      *location;
-    ngx_table_elt_t                 *h;
-
+    
     cf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity);
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);
 
@@ -1103,13 +1099,13 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r) {
                && r->err_status < 308) {
 
         /* 3XX load redirect location header so that we can do redirect in phase 3,4 */
-        location = apr_table_get(ctx->req->headers_out, "Location");
+        const char *location = apr_table_get(ctx->req->headers_out, "Location");
 
         if (location == NULL) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
 
-        h = ngx_list_push(&r->headers_out.headers);
+        ngx_table_elt_t *h = ngx_list_push(&r->headers_out.headers);
         if (h == NULL) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }
@@ -1137,12 +1133,12 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r) {
 static ngx_int_t
 ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
-    ngx_http_modsecurity_loc_conf_t *cf;
-    ngx_http_modsecurity_ctx_t      *ctx;
-    ngx_int_t                        rc;
-    apr_off_t                        content_length;
-    ngx_chain_t                     *cl, *out;
-    ngx_int_t                        last_buf = 0;
+    const ngx_http_modsecurity_loc_conf_t   *cf;
+    ngx_http_modsecurity_ctx_t              *ctx;
+    ngx_int_t                                rc;
+    apr_off_t                                content_length;
+    ngx_chain_t                             *cl, *out;
+    ngx_int_t                                last_buf = 0;
 
     cf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity);
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity);


### PR DESCRIPTION
## what

- This pull request fixes the `cppcheck` warnings in nginx directory.
 
## why

- The `nginx` drectory can be checked with `cppcheck` command and will result zero warnings.

## references

- These changes are the continuation of PR #3488.
