### PR TITLE
fix: cppcheck warnings

### DIFF
--- a/headers/modsecurity/anchored_set_variable.h
+++ b/headers/modsecurity/anchored_set_variable.h
@@ -84,6 +84,11 @@ class AnchoredSetVariable : public std::unordered_multimap<std::string,
 
     void setCopy(std::string key, std::string value, size_t offset);
 
+    void resolve(std::vector<const VariableValue *> *l) const;
+    void resolve(std::vector<const VariableValue *> *l,
+        const variables::KeyExclusions &ke) const;
+
+    // keep the old signatures for ABI compatibility
     void resolve(std::vector<const VariableValue *> *l);
     void resolve(std::vector<const VariableValue *> *l,
         variables::KeyExclusions &ke);
@@ -91,6 +96,14 @@ class AnchoredSetVariable : public std::unordered_multimap<std::string,
     void resolve(const std::string &key,
         std::vector<const VariableValue *> *l);
 
+    void resolveRegularExpression(Utils::Regex *r,
+        std::vector<const VariableValue *> *l) const;
+
+    void resolveRegularExpression(Utils::Regex *r,
+        std::vector<const VariableValue *> *l,
+        const variables::KeyExclusions &ke) const;
+
+    // keep the old signatures for ABI compatibility
     void resolveRegularExpression(Utils::Regex *r,
         std::vector<const VariableValue *> *l);
 

--- a/headers/modsecurity/audit_log.h
+++ b/headers/modsecurity/audit_log.h
@@ -172,6 +172,7 @@ class AuditLog {
 
     bool saveIfRelevant(Transaction *transaction);
     bool saveIfRelevant(Transaction *transaction, int parts);
+    bool isRelevant(const int status) const;
     bool isRelevant(int status);
 
     static int addParts(int parts, std::string_view new_parts);

--- a/headers/modsecurity/audit_log.h
+++ b/headers/modsecurity/audit_log.h
@@ -172,7 +172,7 @@ class AuditLog {
 
     bool saveIfRelevant(Transaction *transaction);
     bool saveIfRelevant(Transaction *transaction, int parts);
-    bool isRelevant(const int status) const;
+    bool isRelevant(int status) const;
     bool isRelevant(int status);
 
     static int addParts(int parts, std::string_view new_parts);

--- a/headers/modsecurity/rules_set.h
+++ b/headers/modsecurity/rules_set.h
@@ -75,6 +75,7 @@ class RulesSet : public RulesSetProperties {
     int merge(RulesSet *rules);
 
     int evaluate(int phase, Transaction *transaction);
+    std::string getParserError() const;
     std::string getParserError();
 
     void debug(int level, const std::string &id, const std::string &uri,

--- a/src/actions/transformations/url_decode_uni.cc
+++ b/src/actions/transformations/url_decode_uni.cc
@@ -35,7 +35,7 @@ static inline bool inplace(std::string &value,
     const auto input_len = value.length();
 
     std::string::size_type i, count, fact, j, xv;
-    int Code, hmap = -1;
+    int hmap = -1;
 
     i = count = 0;
     while (i < input_len) {
@@ -50,13 +50,16 @@ static inline bool inplace(std::string &value,
                         (VALID_HEX(input[i + 3])) &&
                         (VALID_HEX(input[i + 4])) &&
                         (VALID_HEX(input[i + 5]))) {
-                        Code = 0;
+
                         fact = 1;
 
                         if (t
                             && t->m_rules->m_unicodeMapTable.m_set == true
                             && t->m_rules->m_unicodeMapTable.m_unicodeMapTable != NULL
                             && t->m_rules->m_unicodeMapTable.m_unicodeCodePage > 0)  {
+
+                            int Code = 0;
+
                             for (j = 5; j >= 2; j--) {
                                 if (isxdigit((input[i+j]))) {
                                     if (input[i+j] >= 97) {

--- a/src/anchored_set_variable.cc
+++ b/src/anchored_set_variable.cc
@@ -67,7 +67,7 @@ void AnchoredSetVariable::set(const std::string &key,
 
 
 void AnchoredSetVariable::resolve(
-    std::vector<const VariableValue *> *l) {
+    std::vector<const VariableValue *> *l) const {
     for (const auto& x : *this) {
         l->insert(l->begin(), new VariableValue(x.second));
     }
@@ -75,8 +75,14 @@ void AnchoredSetVariable::resolve(
 
 
 void AnchoredSetVariable::resolve(
+    std::vector<const VariableValue *> *l) {
+    static_cast<const AnchoredSetVariable&>(*this).resolve(l);
+}
+
+
+void AnchoredSetVariable::resolve(
     std::vector<const VariableValue *> *l,
-    variables::KeyExclusions &ke) {
+    const variables::KeyExclusions &ke) const {
     for (const auto& x : *this) {
         if (!ke.toOmit(x.first)) {
             l->insert(l->begin(), new VariableValue(x.second));
@@ -85,6 +91,13 @@ void AnchoredSetVariable::resolve(
                 + " from target value.");
         }
     }
+}
+
+
+void AnchoredSetVariable::resolve(
+    std::vector<const VariableValue *> *l,
+    variables::KeyExclusions &ke) {  // cppcheck-suppress constParameterReference
+    static_cast<const AnchoredSetVariable&>(*this).resolve(l, ke);
 }
 
 
@@ -109,7 +122,7 @@ std::unique_ptr<std::string> AnchoredSetVariable::resolveFirst(
 
 
 void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
-    std::vector<const VariableValue *> *l) {
+    std::vector<const VariableValue *> *l) const {
     for (const auto& x : *this) {
         int ret = Utils::regex_search(x.first, *r);
         if (ret <= 0) {
@@ -121,8 +134,14 @@ void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
 
 
 void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
+    std::vector<const VariableValue *> *l) {
+    static_cast<const AnchoredSetVariable&>(*this).resolveRegularExpression(r, l);
+}
+
+
+void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
     std::vector<const VariableValue *> *l,
-    variables::KeyExclusions &ke) {
+    const variables::KeyExclusions &ke) const {
     for (const auto& x : *this) {
         int ret = Utils::regex_search(x.first, *r);
         if (ret <= 0) {
@@ -135,6 +154,13 @@ void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
                 + " from target value.");
         }
     }
+}
+
+
+void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
+    std::vector<const VariableValue *> *l,
+    variables::KeyExclusions &ke) {  // cppcheck-suppress constParameterReference
+    static_cast<const AnchoredSetVariable&>(*this).resolveRegularExpression(r, l);
 }
 
 

--- a/src/anchored_set_variable.cc
+++ b/src/anchored_set_variable.cc
@@ -160,7 +160,7 @@ void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
 void AnchoredSetVariable::resolveRegularExpression(Utils::Regex *r,
     std::vector<const VariableValue *> *l,
     variables::KeyExclusions &ke) {  // cppcheck-suppress constParameterReference
-    static_cast<const AnchoredSetVariable&>(*this).resolveRegularExpression(r, l);
+    static_cast<const AnchoredSetVariable&>(*this).resolveRegularExpression(r, l, ke);
 }
 
 

--- a/src/audit_log/audit_log.cc
+++ b/src/audit_log/audit_log.cc
@@ -248,7 +248,7 @@ bool AuditLog::init(std::string *error) {
 }
 
 
-bool AuditLog::isRelevant(const int status) const {
+bool AuditLog::isRelevant(int status) const {
     std::string sstatus = std::to_string(status);
 
     if (m_relevant.empty()) {

--- a/src/audit_log/audit_log.cc
+++ b/src/audit_log/audit_log.cc
@@ -248,7 +248,7 @@ bool AuditLog::init(std::string *error) {
 }
 
 
-bool AuditLog::isRelevant(int status) {
+bool AuditLog::isRelevant(const int status) const {
     std::string sstatus = std::to_string(status);
 
     if (m_relevant.empty()) {
@@ -262,6 +262,10 @@ bool AuditLog::isRelevant(int status) {
 
     return Utils::regex_search(sstatus,
         Utils::Regex(m_relevant)) != 0;
+}
+
+bool AuditLog::isRelevant(int status) {
+    return static_cast<const AuditLog&>(*this).isRelevant(status);
 }
 
 

--- a/src/rules_set.cc
+++ b/src/rules_set.cc
@@ -101,8 +101,12 @@ int RulesSet::load(const char *plainRules) {
 }
 
 
-std::string RulesSet::getParserError() {
+std::string RulesSet::getParserError() const {
     return this->m_parserError.str();
+}
+
+std::string RulesSet::getParserError() {
+    return static_cast<const RulesSet&>(*this).getParserError();
 }
 
 void RulesSet::cleanMatchedVars(Transaction *trans) {
@@ -119,7 +123,7 @@ int RulesSet::evaluate(int phase, Transaction *t) {
        return 0;
     }
 
-    Rules *rules = m_rulesSetPhases[phase];
+    const Rules *rules = m_rulesSetPhases[phase];
 
     ms_dbg_a(t, 9, "This phase consists of " \
         + std::to_string(rules->size()) + " rule(s).");

--- a/src/rules_set_properties.cc
+++ b/src/rules_set_properties.cc
@@ -32,7 +32,6 @@ void ConfigUnicodeMap::loadConfig(std::string f, double configCodePage,
     char *hmap = NULL;
     const char *p = NULL;
     char *savedptr = NULL;
-    const char *ucode = NULL;
     int found = 0;
     int length = 0;
     int processing = 0;
@@ -99,7 +98,7 @@ void ConfigUnicodeMap::loadConfig(std::string f, double configCodePage,
             processing = 1;
 
             if (mapping != NULL) {
-                ucode = strtok_r(mapping, ":", &hmap);
+                const char *ucode = strtok_r(mapping, ":", &hmap);
                 int code = strtol(ucode, nullptr, 16);
                 int map = strtol(hmap, nullptr, 16);
                 if (code >= 0 && code <= 65535)    {

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -527,7 +527,7 @@ int Transaction::addRequestHeader(const std::string& key,
 
             // find the first '='
             pos = c.find_first_of("=", 0);
-            std::string ckey = "";
+            std::string ckey;
             std::string cval = "";
 
             // if the cookie doesn't contains '=', its just a key

--- a/src/unique_id.cc
+++ b/src/unique_id.cc
@@ -229,7 +229,7 @@ std::string UniqueId::ethernetMacAddress() {
 
     return std::string(reinterpret_cast<const char *>(mac));
 #if defined(__linux__) || defined(__gnu_linux__) || defined(DARWIN) || defined(WIN32)
-failed:
+failed:  // cppcheck-suppress unusedLabelConfiguration
     return std::string("");
 #endif
 }

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -163,7 +163,7 @@ class KeyExclusions : public std::deque<std::unique_ptr<KeyExclusion>> {
         return false;
     }
 
-    bool toOmit(std::string a) {
+    bool toOmit(std::string a) { // cppcheck-suppress passedByValue
         return static_cast<const KeyExclusions&>(*this).toOmit(a);
     }
 };

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -162,6 +162,10 @@ class KeyExclusions : public std::deque<std::unique_ptr<KeyExclusion>> {
         }
         return false;
     }
+
+    bool toOmit(std::string a) {
+        return static_cast<const KeyExclusions&>(*this).toOmit(a);
+    }
 };
 
 

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -154,7 +154,7 @@ class KeyExclusions : public std::deque<std::unique_ptr<KeyExclusion>> {
     KeyExclusions() {
     }
 
-    bool toOmit(std::string a) {
+    bool toOmit(std::string a) const {
         for (auto &z : *this) {
             if (z->match(a)) {
                 return true;

--- a/test/fuzzer/afl_fuzzer.cc
+++ b/test/fuzzer/afl_fuzzer.cc
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
         read_bytes = read(STDIN_FILENO, buf, 128);
 
         std::string currentString = std::string(read_bytes, 128);
-        std::string s = currentString;
+        const std::string& s = currentString;
 #if 0
         std::string z = lastString;
 #endif


### PR DESCRIPTION
## what

This PR contains several `cppcheck` warnings' fixes:
* make `toOmit()` to `const` in `src/variables/variable.h`
* make `resolve()` and `resolveRegularExpression()` functions to `const` in `anchored_set_variable.cc|h`
* move `Code` variable to inner block in `url_decode_uni.cc`
* make `isRelevant()` to `const` in `audit_log.cc|h`
* make `getParserError()` to `const` in `rules_set.cc|h`
* move `ucode` variable to inner block in `rules_set_properties.cc`
* remove redundant initialization of `ckey` in `transaction.cc`
* add inline `cppcheck-suppress` flag to avoid warning in `unique_id.cc`
* make variable 's' const reference to avoid the copy in `afl_fuzzer.cc`

## why

`cppcheck`'s new version (2.20.0) warned these issues.

## references

See #3504's failed [job](https://github.com/owasp-modsecurity/ModSecurity/actions/runs/22790837280/job/66135568725?pr=3504)

## other notes

where the modified functions' signature has changed, I added a wrapper with an old signature to keep the symbols in ABI. Therefore these changes don't break the library's ABI.