### PR TITLE
re-integrated remove redundant actions

### DIFF
--- a/apache2/re.c
+++ b/apache2/re.c
@@ -986,6 +986,41 @@ msre_action *msre_create_action(msre_engine *engine, apr_pool_t *mp, const char 
     return action;
 }
 
+// Return 1 if "name=value" is present in table (for supplied action)
+static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* action, const char* name, const char* value) {
+	if (strcmp(name, action) != 0) return 0;
+
+	const char* vars = apr_table_getm(p, vartable, name);
+	if (!vars) return 0;
+
+	char pattern[200];
+	sprintf(pattern, "(?:^|,)%.185s(?:,|$)", value);
+
+	const char* errptr = NULL;
+	int erroffset;
+	const pcre* regex = pcre_compile(pattern, 0, &errptr, &erroffset, NULL);
+	return !pcre_exec(regex, NULL, vars, strlen(vars), 0, 0, 0, 0);
+}
+
+// Return 1 if "name=value" is present in table for tags, logdata (and others)
+static int action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* name, const char* value) {
+	if (apr_table_action_exists(p, vartable, "capture", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "chain", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "initcol", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "logdata", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setrsc", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setsid", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "setuid", name, value)) return 1;
+	if (apr_table_action_exists(p, vartable, "tag", name, value)) return 1;
+	return 0;
+}
+
 /**
  * Generic parser that is used as basis for target and action parsing.
  * It breaks up the input string into name-parameter pairs and places
@@ -1103,9 +1138,11 @@ int msre_parse_generic(apr_pool_t *mp, const char *text, apr_table_t *vartable,
             value = apr_pstrmemdup(mp, value, p - value);
         }
 
-        /* add to table */
-        apr_table_addn(vartable, name, value);
-        count++;
+        /* add to table (only if not already present) */
+        if (!action_exists(mp, vartable, name, value)) {
+			apr_table_addn(vartable, name, value);
+			count++;
+		}
 
         /* move to the first character of the next name-value pair */
         while(isspace(*p)||(*p == ',')||(*p == '|')) p++;

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -986,38 +986,44 @@ msre_action *msre_create_action(msre_engine *engine, apr_pool_t *mp, const char 
     return action;
 }
 
-// Return 1 if "name=value" is present in table (for supplied action)
+/** 
+ * Helper function for action_exists. It checks if "name=value" is present in table for supplied action.
+ */
 static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* action, const char* name, const char* value) {
-	if (strcmp(name, action) != 0) return 0;
+    if (strcmp(name, action) != 0) return 0;
 
-	const char* vars = apr_table_getm(p, vartable, name);
-	if (!vars) return 0;
+    const char* vars = apr_table_getm(p, vartable, name);
+    if (!vars) return 0;
 
-	char pattern[200];
-	sprintf(pattern, "(?:^|,)%.185s(?:,|$)", value);
+    char pattern[200];
+    sprintf(pattern, "(?:^|,)%.185s(?:,|$)", value);
 
-	const char* errptr = NULL;
-	int erroffset;
-	const pcre* regex = pcre_compile(pattern, 0, &errptr, &erroffset, NULL);
-	return !pcre_exec(regex, NULL, vars, strlen(vars), 0, 0, 0, 0);
+    char* error_msg = NULL;
+    msc_regex_t* regex = msc_pregcomp(p, pattern, 0, NULL, NULL);
+    if (regex == NULL) return 0; // we could log an error here
+
+    return (msc_regexec(regex, vars, strlen(vars), &error_msg) >= 0);
 }
 
-// Return 1 if "name=value" is present in table for tags, logdata (and others)
+/**
+ * Checks if "name=value" is present in table for tags, logdata (and others).
+ */
 static int action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* name, const char* value) {
-	if (apr_table_action_exists(p, vartable, "capture", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "chain", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "initcol", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "logdata", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "sanitiseArg", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "sanitiseMatched", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "sanitiseMatchedBytes", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "sanitiseRequestHeader", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "sanitiseResponseHeader", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "setrsc", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "setsid", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "setuid", name, value)) return 1;
-	if (apr_table_action_exists(p, vartable, "tag", name, value)) return 1;
+    /* logdata & msg cannot be used because ',' is used as entries separators */
+    if (apr_table_action_exists(p, vartable, "capture", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "chain", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "initcol", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "multiMatch", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "phase", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitizeArg", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitizeMatched", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitizeMatchedBytes", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitizeRequestHeader", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "sanitizeResponseHeader", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "setrsc", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "setsid", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "setuid", name, value)) return 1;
+    if (apr_table_action_exists(p, vartable, "tag", name, value)) return 1;
 	return 0;
 }
 

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -990,19 +990,46 @@ msre_action *msre_create_action(msre_engine *engine, apr_pool_t *mp, const char 
  * Helper function for action_exists. It checks if "name=value" is present in table for supplied action.
  */
 static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, const char* action, const char* name, const char* value) {
+    const apr_array_header_t *arr = NULL;
+    const apr_table_entry_t *elts = NULL;
+    int i = 0;
+    apr_size_t value_len = 0;
+    (void)p;
     if (strcmp(name, action) != 0) return 0;
-
-    const char* vars = apr_table_getm(p, vartable, name);
-    if (!vars) return 0;
-
-    char pattern[200];
-    apr_snprintf(pattern, sizeof(pattern), "(?:^|,)%.185s(?:,|$)", value);
-
-    char* error_msg = NULL;
-    msc_regex_t* regex = msc_pregcomp(p, pattern, 0, NULL, NULL);
-    if (regex == NULL) return 0;
-
-    return (msc_regexec(regex, vars, strlen(vars), &error_msg) >= 0);
+    if ((vartable == NULL) || (value == NULL)) return 0;
+    value_len = strlen(value);
+    arr = apr_table_elts(vartable);
+    if (arr == NULL) return 0;
+    elts = (const apr_table_entry_t *)arr->elts;
+    for (i = 0; i < arr->nelts; i++) {
+        const char *vars = NULL;
+        const char *segment_start = NULL;
+        const char *cursor = NULL;
+        if ((elts[i].key == NULL) || (strcmp(elts[i].key, name) != 0)) {
+            continue;
+        }
+        vars = elts[i].val;
+        if (vars == NULL) {
+            continue;
+        }
+        segment_start = vars;
+        cursor = vars;
+        for (;;) {
+            if ((*cursor == ',') || (*cursor == '\0')) {
+                apr_size_t segment_len = (apr_size_t)(cursor - segment_start);
+                if ((segment_len == value_len) &&
+                    (strncmp(segment_start, value, value_len) == 0)) {
+                    return 1;
+                }
+                if (*cursor == '\0') {
+                    break;
+                }
+                segment_start = cursor + 1;
+            }
+            cursor++;
+        }
+    }
+    return 0;
 }
 
 /**

--- a/apache2/re.c
+++ b/apache2/re.c
@@ -996,11 +996,11 @@ static int apr_table_action_exists(apr_pool_t* p, const apr_table_t* vartable, c
     if (!vars) return 0;
 
     char pattern[200];
-    sprintf(pattern, "(?:^|,)%.185s(?:,|$)", value);
+    apr_snprintf(pattern, sizeof(pattern), "(?:^|,)%.185s(?:,|$)", value);
 
     char* error_msg = NULL;
     msc_regex_t* regex = msc_pregcomp(p, pattern, 0, NULL, NULL);
-    if (regex == NULL) return 0; // we could log an error here
+    if (regex == NULL) return 0;
 
     return (msc_regexec(regex, vars, strlen(vars), &error_msg) >= 0);
 }


### PR DESCRIPTION
This is a Marc Stern modification, I don't have much more insight on the code he made. To be reviewed with caution and check if this is still relevant

**Example**
In the configuration, I used:
`Use SecAction "tag:ok,tag:ok,tag:ok,logdata:'ok'`
Without this modification, the log shows:
```
--f2f99046-A--
[13/Apr/2026:16:03:06.779497 +0200] adz3miH5jzx_M_q_TC69xgAAAAA x.x.x.x 57133 x.x.x.x 443
--f2f99046-B--
POST /api/toto2 HTTP/1.1
Accept-Language: en
X-Forwarded-For: 198.200.1.4
Cache-Control: no-cache
Postman-Token: b978be69-7049-415e-b090-02ff42601566
Host: mock-server
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
Content-Length: 0
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36
Accept: */*
Cookie:

--f2f99046-F--
HTTP/1.1 200 OK
X-Unique-id: waf-dev-SED/1/20260413160306/adz3miH5jzx_M_q_TC69xgAAAAA/-/20250509/-/20230503
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
X-Robots-Tag: noindex
Reporting-Endpoints: coop=/!report/coop, csp=/!report/csp, default=/!report/default
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: report-to csp;report-uri /!report/csp;default-src 'self' blob:;script-src 'self' blob: 'unsafe-eval' 'report-sample';connect-src 'self' blob:;frame-ancestors 'self' blob:;frame-src 'self' blob: javascript:;img-src * data: blob:;font-src * data: blob:;media-src * data: blob:;form-action 'self' blob:;upgrade-insecure-requests
Content-Length: 3
Keep-Alive: timeout=5
Connection: Keep-Alive

--f2f99046-H--
Message: Warning. Unconditional match in SecAction. [data "ok"] [tag "ok"] [tag "ok"] [tag "ok"]
Apache-Error: [level 3] ModSecurity: Warning. Unconditional match in SecAction. [data "ok"] [tag "ok"] [tag "ok"] [tag "ok"] [hostname "mock-server"] [uri "/api/toto2"] [unique_id "adz3miH5jzx_M_q_TC69xgAAAAA"]
Apache-Handler: proxy-server
Stopwatch: 1776088986677111 102470 (- - -)
Stopwatch2: 1776088986677111 102470; combined=34051, p1=4530, p2=24029, p3=855, p4=555, p5=3488, sr=1137, sw=594, l=0, gc=0
Producer: ModSecurity for Apache/2.9.12 (http://www.modsecurity.org/);
Server: Apache/2.4.62 (Rocky Linux) OpenSSL/3.5.1
WebApp-Info: "mock-server-s" "-" "-"
Sensor-Id: "waf-dev-SED/waf-dev-SED/1"
Engine-Mode: "ENABLED"

--f2f99046-Z--
```

And with the modification:
```
--395b846f-A--
[13/Apr/2026:15:53:20.865413 +0200] adz1UI2HHICzTKXSDCx9aQAAAAA x.x.x.x 49612 x.x.x.x 443
--395b846f-B--
POST /api/toto2 HTTP/1.1
Accept-Language: en
X-Forwarded-For: 198.200.1.4
Cache-Control: no-cache
Postman-Token: d2c53f94-b011-4ea7-b8ab-30c8034fa4f4
Host: mock-server
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
Content-Length: 0
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36
Accept: */*
Cookie:

--395b846f-F--
HTTP/1.1 200 OK
X-Unique-id: waf-dev-SED/1/20260413155320/adz1UI2HHICzTKXSDCx9aQAAAAA/-/20250509/-/20230503
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
X-Robots-Tag: noindex
Reporting-Endpoints: coop=/!report/coop, csp=/!report/csp, default=/!report/default
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: report-to csp;report-uri /!report/csp;default-src 'self' blob:;script-src 'self' blob: 'unsafe-eval' 'report-sample';connect-src 'self' blob:;frame-ancestors 'self' blob:;frame-src 'self' blob: javascript:;img-src * data: blob:;font-src * data: blob:;media-src * data: blob:;form-action 'self' blob:;upgrade-insecure-requests
Content-Length: 3
Keep-Alive: timeout=5
Connection: Keep-Alive

--395b846f-H--
Message: Warning. Unconditional match in SecAction. [data "ok"] [tag "ok"]
Apache-Error: [level 3] ModSecurity: Warning. Unconditional match in SecAction. [data "ok"] [tag "ok"] [hostname "mock-server"] [uri "/api/toto2"] [unique_id "adz1UI2HHICzTKXSDCx9aQAAAAA"]
Apache-Handler: proxy-server
Stopwatch: 1776088400801312 64187 (- - -)
Stopwatch2: 1776088400801312 64187; combined=27574, p1=2607, p2=20304, p3=725, p4=479, p5=2963, sr=736, sw=496, l=0, gc=0
Producer: ModSecurity for Apache/2.9.12 (http://www.modsecurity.org/);
Server: Apache/2.4.62 (Rocky Linux) OpenSSL/3.5.1
WebApp-Info: "mock-server-s" "-" "-"
Sensor-Id: "waf-dev-SED/waf-dev-SED/1"
Engine-Mode: "ENABLED"

--395b846f-Z--
```