### PR TITLE
Update SQLi/XSS operators for libinjection v4.0.0

### DIFF
--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -59,10 +59,10 @@ typedef struct Rules_t RulesSet;
       if (m_rules && m_rules->m_debugLog && m_rules->m_debugLog->m_debugLevel >= b) { \
           m_rules->debug(b, m_id, m_uri, c); \
       } \
-  } while (0)
+  } while (0);
 #else
 #define ms_dbg(b, c) \
-  do { } while (0)
+  do { } while (0);
 #endif
 
 #ifndef NO_LOGS
@@ -71,10 +71,10 @@ typedef struct Rules_t RulesSet;
       if (t && t->m_rules && t->m_rules->m_debugLog && t->m_rules->m_debugLog->m_debugLevel >= b) { \
           t->debug(b, c); \
       } \
-  } while (0)
+  } while (0);
 #else
 #define ms_dbg_a(t, b, c) \
-    do { } while (0)
+    do { } while (0);
 #endif
 
 

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -59,10 +59,10 @@ typedef struct Rules_t RulesSet;
       if (m_rules && m_rules->m_debugLog && m_rules->m_debugLog->m_debugLevel >= b) { \
           m_rules->debug(b, m_id, m_uri, c); \
       } \
-  } while (0);
+  } while (0)
 #else
 #define ms_dbg(b, c) \
-  do { } while (0);
+  do { } while (0)
 #endif
 
 #ifndef NO_LOGS
@@ -71,10 +71,10 @@ typedef struct Rules_t RulesSet;
       if (t && t->m_rules && t->m_rules->m_debugLog && t->m_rules->m_debugLog->m_debugLevel >= b) { \
           t->debug(b, c); \
       } \
-  } while (0);
+  } while (0)
 #else
 #define ms_dbg_a(t, b, c) \
-    do { } while (0);
+    do { } while (0)
 #endif
 
 

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -20,6 +20,7 @@
 
 #include "src/operators/operator.h"
 #include "libinjection/src/libinjection.h"
+#include "libinjection/src/libinjection_error.h"
 
 namespace modsecurity {
 namespace operators {
@@ -28,32 +29,52 @@ namespace operators {
 bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
     char fingerprint[8];
-    int issqli;
+    injection_result_t sqli_result;
+    bool is_match = false;
 
-    issqli = libinjection_sqli(input.c_str(), input.length(), fingerprint);
+    sqli_result = libinjection_sqli(input.c_str(), input.length(), fingerprint);
 
     if (!t) {
         goto tisempty;
     }
 
-    if (issqli) {
-        t->m_matched.push_back(fingerprint);
-        ms_dbg_a(t, 4, "detected SQLi using libinjection with " \
-            "fingerprint '" + std::string(fingerprint) + "' at: '" +
-            input + "'");
-        if (rule && rule->hasCaptureAction()) {
-            t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                "0", std::string(fingerprint));
-            ms_dbg_a(t, 7, "Added DetectSQLi match TX.0: " + \
-                std::string(fingerprint));
-        }
-    } else {
-        ms_dbg_a(t, 9, "detected SQLi: not able to find an " \
-            "inject on '" + input + "'");
+    switch (sqli_result) {
+        case LIBINJECTION_RESULT_TRUE:
+            is_match = true;
+            t->m_matched.push_back(fingerprint);
+            ms_dbg_a(t, 4, "detected SQLi using libinjection with " \
+                "fingerprint '" + std::string(fingerprint) + "' at: '" +
+                input + "'");
+            if (rule && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                    "0", std::string(fingerprint));
+                ms_dbg_a(t, 7, "Added DetectSQLi match TX.0: " + \
+                    std::string(fingerprint));
+            }
+            break;
+        case LIBINJECTION_RESULT_ERROR:
+            is_match = true;
+            ms_dbg_a(t, 4, "libinjection parser error during SQLi "
+                "analysis; treating as match (fail-safe). Input: '" + input + "'");
+            if (rule && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                    "0", std::string(input));
+                ms_dbg_a(t, 7, "Added DetectSQLi error input TX.0: " + \
+                    std::string(input));
+            }
+            break;
+        case LIBINJECTION_RESULT_FALSE:
+            ms_dbg_a(t, 9, "detected SQLi: not able to find an " \
+                "inject on '" + input + "'");
+            break;
     }
 
 tisempty:
-    return issqli != 0;
+    if (t == nullptr) {
+        is_match = sqli_result == LIBINJECTION_RESULT_TRUE
+            || sqli_result == LIBINJECTION_RESULT_ERROR;
+    }
+    return is_match;
 }
 
 

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <list>
 #include <array>
+
 #include "src/operators/operator.h"
 #include "src/operators/libinjection_utils.h"
 #include "libinjection/src/libinjection.h"
@@ -39,15 +40,19 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
 
     switch (sqli_result) {
         case LIBINJECTION_RESULT_TRUE:
-            t->m_matched.push_back(fingerprint);
+            t->m_matched.push_back(std::string(fingerprint.data()));
 
             ms_dbg_a(t, 4,
                 std::string("detected SQLi using libinjection with fingerprint '")
-                + fingerprint + "' at: '" + input + "'");
+                + fingerprint.data() + "' at: '" + input + "'");
 
             if (rule != nullptr && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst("0", fingerprint);
-                ms_dbg_a(t, 7, std::string("Added DetectSQLi match TX.0: ") + fingerprint);
+                t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                    "0", std::string(fingerprint.data()));
+
+                ms_dbg_a(t, 7,
+                    std::string("Added DetectSQLi match TX.0: ")
+                    + fingerprint.data());
             }
             break;
 
@@ -59,14 +64,19 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
                 + input + "'");
 
             if (rule != nullptr && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst("0", input);
-                ms_dbg_a(t, 7, std::string("Added DetectSQLi error input TX.0: ") + input);
+                t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                    "0", input);
+
+                ms_dbg_a(t, 7,
+                    std::string("Added DetectSQLi error input TX.0: ")
+                    + input);
             }
             break;
 
         case LIBINJECTION_RESULT_FALSE:
             ms_dbg_a(t, 9,
-                std::string("libinjection was not able to find any SQLi in: ") + input);
+                std::string("libinjection was not able to find any SQLi in: ")
+                + input);
             break;
     }
 

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -19,6 +19,7 @@
 #include <list>
 
 #include "src/operators/operator.h"
+#include "src/operators/libinjection_utils.h"
 #include "libinjection/src/libinjection.h"
 #include "libinjection/src/libinjection_error.h"
 
@@ -29,18 +30,16 @@ namespace operators {
 bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
     char fingerprint[8];
-    injection_result_t sqli_result;
-    bool is_match = false;
+    injection_result_t sqli_result = LIBINJECTION_RESULT_FALSE;
 
     sqli_result = libinjection_sqli(input.c_str(), input.length(), fingerprint);
 
-    if (!t) {
-        goto tisempty;
+    if (t == nullptr) {
+        return isMaliciousLibinjectionResult(sqli_result);
     }
 
     switch (sqli_result) {
         case LIBINJECTION_RESULT_TRUE:
-            is_match = true;
             t->m_matched.push_back(fingerprint);
             ms_dbg_a(t, 4, "detected SQLi using libinjection with " \
                 "fingerprint '" + std::string(fingerprint) + "' at: '" +
@@ -53,9 +52,9 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
             }
             break;
         case LIBINJECTION_RESULT_ERROR:
-            is_match = true;
             ms_dbg_a(t, 4, "libinjection parser error during SQLi "
-                "analysis; treating as match (fail-safe). Input: '" + input + "'");
+                "analysis (" + std::string(libinjectionResultToString(sqli_result))
+                + "); treating as match (fail-safe). Input: '" + input + "'");
             if (rule && rule->hasCaptureAction()) {
                 t->m_collections.m_tx_collection->storeOrUpdateFirst(
                     "0", std::string(input));
@@ -69,12 +68,7 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
             break;
     }
 
-tisempty:
-    if (t == nullptr) {
-        is_match = sqli_result == LIBINJECTION_RESULT_TRUE
-            || sqli_result == LIBINJECTION_RESULT_ERROR;
-    }
-    return is_match;
+    return isMaliciousLibinjectionResult(sqli_result);
 }
 
 

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -28,10 +28,10 @@ namespace modsecurity::operators {
 bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
 
-    char fingerprint[8] = {0};
+    std::array<char, 8> fingerprint{};
 
     const injection_result_t sqli_result =
-        libinjection_sqli(input.c_str(), input.length(), fingerprint);
+        libinjection_sqli(input.c_str(), input.length(), fingerprint.data());
 
     if (t == nullptr) {
         return isMaliciousLibinjectionResult(sqli_result);

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -17,7 +17,7 @@
 
 #include <string>
 #include <list>
-
+#include <array>
 #include "src/operators/operator.h"
 #include "src/operators/libinjection_utils.h"
 #include "libinjection/src/libinjection.h"

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -44,7 +44,7 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
 
             ms_dbg_a(t, 4,
                 std::string("detected SQLi using libinjection with fingerprint '")
-                + fingerprint.data() + "' at: '" + input + "'");
+                + fingerprint.data() + "' at: '" + input + "'")
 
             if (rule != nullptr && rule->hasCaptureAction()) {
                 t->m_collections.m_tx_collection->storeOrUpdateFirst(
@@ -52,7 +52,7 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
 
                 ms_dbg_a(t, 7,
                     std::string("Added DetectSQLi match TX.0: ")
-                    + fingerprint.data());
+                    + fingerprint.data())
             }
             break;
 
@@ -61,7 +61,7 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
                 std::string("libinjection parser error during SQLi analysis (")
                 + libinjectionResultToString(sqli_result)
                 + "); treating as match (fail-safe). Input: '"
-                + input + "'");
+                + input + "'")
 
             if (rule != nullptr && rule->hasCaptureAction()) {
                 t->m_collections.m_tx_collection->storeOrUpdateFirst(
@@ -69,14 +69,14 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
 
                 ms_dbg_a(t, 7,
                     std::string("Added DetectSQLi error input TX.0: ")
-                    + input);
+                    + input)
             }
             break;
 
         case LIBINJECTION_RESULT_FALSE:
             ms_dbg_a(t, 9,
                 std::string("libinjection was not able to find any SQLi in: ")
-                + input);
+                + input)
             break;
     }
 

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -23,16 +23,15 @@
 #include "libinjection/src/libinjection.h"
 #include "libinjection/src/libinjection_error.h"
 
-namespace modsecurity {
-namespace operators {
-
+namespace modsecurity::operators {
 
 bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
-    char fingerprint[8];
-    injection_result_t sqli_result = LIBINJECTION_RESULT_FALSE;
 
-    sqli_result = libinjection_sqli(input.c_str(), input.length(), fingerprint);
+    char fingerprint[8] = {0};
+
+    const injection_result_t sqli_result =
+        libinjection_sqli(input.c_str(), input.length(), fingerprint);
 
     if (t == nullptr) {
         return isMaliciousLibinjectionResult(sqli_result);
@@ -41,36 +40,37 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
     switch (sqli_result) {
         case LIBINJECTION_RESULT_TRUE:
             t->m_matched.push_back(fingerprint);
-            ms_dbg_a(t, 4, "detected SQLi using libinjection with " \
-                "fingerprint '" + std::string(fingerprint) + "' at: '" +
-                input + "'");
-            if (rule && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                    "0", std::string(fingerprint));
-                ms_dbg_a(t, 7, "Added DetectSQLi match TX.0: " + \
-                    std::string(fingerprint));
+
+            ms_dbg_a(t, 4,
+                std::string("detected SQLi using libinjection with fingerprint '")
+                + fingerprint + "' at: '" + input + "'");
+
+            if (rule != nullptr && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst("0", fingerprint);
+                ms_dbg_a(t, 7, std::string("Added DetectSQLi match TX.0: ") + fingerprint);
             }
             break;
+
         case LIBINJECTION_RESULT_ERROR:
-            ms_dbg_a(t, 4, "libinjection parser error during SQLi "
-                "analysis (" + std::string(libinjectionResultToString(sqli_result))
-                + "); treating as match (fail-safe). Input: '" + input + "'");
-            if (rule && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                    "0", std::string(input));
-                ms_dbg_a(t, 7, "Added DetectSQLi error input TX.0: " + \
-                    std::string(input));
+            ms_dbg_a(t, 4,
+                std::string("libinjection parser error during SQLi analysis (")
+                + libinjectionResultToString(sqli_result)
+                + "); treating as match (fail-safe). Input: '"
+                + input + "'");
+
+            if (rule != nullptr && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst("0", input);
+                ms_dbg_a(t, 7, std::string("Added DetectSQLi error input TX.0: ") + input);
             }
             break;
+
         case LIBINJECTION_RESULT_FALSE:
-            ms_dbg_a(t, 9, "detected SQLi: not able to find an " \
-                "inject on '" + input + "'");
+            ms_dbg_a(t, 9,
+                std::string("libinjection was not able to find any SQLi in: ") + input);
             break;
     }
 
     return isMaliciousLibinjectionResult(sqli_result);
 }
 
-
-}  // namespace operators
-}  // namespace modsecurity
+}  // namespace modsecurity::operators

--- a/src/operators/detect_sqli.cc
+++ b/src/operators/detect_sqli.cc
@@ -40,7 +40,7 @@ bool DetectSQLi::evaluate(Transaction *t, RuleWithActions *rule,
 
     switch (sqli_result) {
         case LIBINJECTION_RESULT_TRUE:
-            t->m_matched.push_back(std::string(fingerprint.data()));
+            t->m_matched.emplace_back(fingerprint.data());
 
             ms_dbg_a(t, 4,
                 std::string("detected SQLi using libinjection with fingerprint '")

--- a/src/operators/detect_xss.cc
+++ b/src/operators/detect_xss.cc
@@ -36,10 +36,10 @@ bool DetectXSS::evaluate(Transaction *t, RuleWithActions *rule,
 
     switch (xss_result) {
         case LIBINJECTION_RESULT_TRUE:
-            ms_dbg_a(t, 5, std::string("detected XSS using libinjection."));
+            ms_dbg_a(t, 5, std::string("detected XSS using libinjection."))
             if (rule != nullptr && rule->hasCaptureAction()) {
                 t->m_collections.m_tx_collection->storeOrUpdateFirst("0", input);
-                ms_dbg_a(t, 7, std::string("Added DetectXSS match TX.0: ") + input);
+                ms_dbg_a(t, 7, std::string("Added DetectXSS match TX.0: ") + input)
             }
             break;
 
@@ -48,16 +48,16 @@ bool DetectXSS::evaluate(Transaction *t, RuleWithActions *rule,
                 std::string("libinjection parser error during XSS analysis (")
                 + libinjectionResultToString(xss_result)
                 + "); treating as match (fail-safe). Input: "
-                + input);
+                + input)
             if (rule != nullptr && rule->hasCaptureAction()) {
                 t->m_collections.m_tx_collection->storeOrUpdateFirst("0", input);
-                ms_dbg_a(t, 7, std::string("Added DetectXSS error input TX.0: ") + input);
+                ms_dbg_a(t, 7, std::string("Added DetectXSS error input TX.0: ") + input)
             }
             break;
 
         case LIBINJECTION_RESULT_FALSE:
             ms_dbg_a(t, 9,
-                std::string("libinjection was not able to find any XSS in: ") + input);
+                std::string("libinjection was not able to find any XSS in: ") + input)
             break;
     }
 

--- a/src/operators/detect_xss.cc
+++ b/src/operators/detect_xss.cc
@@ -19,6 +19,7 @@
 
 #include "src/operators/operator.h"
 #include "libinjection/src/libinjection.h"
+#include "libinjection/src/libinjection_error.h"
 
 
 namespace modsecurity {
@@ -27,25 +28,46 @@ namespace operators {
 
 bool DetectXSS::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
-    int is_xss;
-
-    is_xss = libinjection_xss(input.c_str(), input.length());
+    injection_result_t xss_result = libinjection_xss(input.c_str(),
+        input.length());
+    bool is_match = false;
 
     if (t) {
-        if (is_xss) {
-            ms_dbg_a(t, 5, "detected XSS using libinjection.");
-            if (rule && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                    "0", std::string(input));
-                ms_dbg_a(t, 7, "Added DetectXSS match TX.0: " + \
-                    std::string(input));
-            }
-        } else {
-            ms_dbg_a(t, 9, "libinjection was not able to " \
-                "find any XSS in: " + input);
-            }
+        switch (xss_result) {
+            case LIBINJECTION_RESULT_TRUE:
+                is_match = true;
+                ms_dbg_a(t, 5, "detected XSS using libinjection.");
+                if (rule && rule->hasCaptureAction()) {
+                    t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                        "0", std::string(input));
+                    ms_dbg_a(t, 7, "Added DetectXSS match TX.0: " + \
+                        std::string(input));
+                }
+                break;
+            case LIBINJECTION_RESULT_ERROR:
+                is_match = true;
+                ms_dbg_a(t, 4, "libinjection parser error during XSS "
+                    "analysis; treating as match (fail-safe). Input: " + input);
+                if (rule && rule->hasCaptureAction()) {
+                    t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                        "0", std::string(input));
+                    ms_dbg_a(t, 7, "Added DetectXSS error input TX.0: " + \
+                        std::string(input));
+                }
+                break;
+            case LIBINJECTION_RESULT_FALSE:
+                ms_dbg_a(t, 9, "libinjection was not able to " \
+                    "find any XSS in: " + input);
+                break;
+        }
     }
-    return is_xss != 0;
+
+    if (t == nullptr) {
+        is_match = xss_result == LIBINJECTION_RESULT_TRUE
+            || xss_result == LIBINJECTION_RESULT_ERROR;
+    }
+
+    return is_match;
 }
 
 

--- a/src/operators/detect_xss.cc
+++ b/src/operators/detect_xss.cc
@@ -22,15 +22,13 @@
 #include "libinjection/src/libinjection.h"
 #include "libinjection/src/libinjection_error.h"
 
-
-namespace modsecurity {
-namespace operators {
-
+namespace modsecurity::operators {
 
 bool DetectXSS::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
-    injection_result_t xss_result = libinjection_xss(input.c_str(),
-        input.length());
+
+    const injection_result_t xss_result =
+        libinjection_xss(input.c_str(), input.length());
 
     if (t == nullptr) {
         return isMaliciousLibinjectionResult(xss_result);
@@ -38,34 +36,32 @@ bool DetectXSS::evaluate(Transaction *t, RuleWithActions *rule,
 
     switch (xss_result) {
         case LIBINJECTION_RESULT_TRUE:
-            ms_dbg_a(t, 5, "detected XSS using libinjection.");
-            if (rule && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                    "0", std::string(input));
-                ms_dbg_a(t, 7, "Added DetectXSS match TX.0: " + \
-                    std::string(input));
+            ms_dbg_a(t, 5, std::string("detected XSS using libinjection."));
+            if (rule != nullptr && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst("0", input);
+                ms_dbg_a(t, 7, std::string("Added DetectXSS match TX.0: ") + input);
             }
             break;
+
         case LIBINJECTION_RESULT_ERROR:
-            ms_dbg_a(t, 4, "libinjection parser error during XSS analysis ("
-                + std::string(libinjectionResultToString(xss_result))
-                + "); treating as match (fail-safe). Input: " + input);
-            if (rule && rule->hasCaptureAction()) {
-                t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                    "0", std::string(input));
-                ms_dbg_a(t, 7, "Added DetectXSS error input TX.0: " + \
-                    std::string(input));
+            ms_dbg_a(t, 4,
+                std::string("libinjection parser error during XSS analysis (")
+                + libinjectionResultToString(xss_result)
+                + "); treating as match (fail-safe). Input: "
+                + input);
+            if (rule != nullptr && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst("0", input);
+                ms_dbg_a(t, 7, std::string("Added DetectXSS error input TX.0: ") + input);
             }
             break;
+
         case LIBINJECTION_RESULT_FALSE:
-            ms_dbg_a(t, 9, "libinjection was not able to " \
-                "find any XSS in: " + input);
+            ms_dbg_a(t, 9,
+                std::string("libinjection was not able to find any XSS in: ") + input);
             break;
     }
 
     return isMaliciousLibinjectionResult(xss_result);
 }
 
-
-}  // namespace operators
-}  // namespace modsecurity
+}  // namespace modsecurity::operators

--- a/src/operators/detect_xss.cc
+++ b/src/operators/detect_xss.cc
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "src/operators/operator.h"
+#include "src/operators/libinjection_utils.h"
 #include "libinjection/src/libinjection.h"
 #include "libinjection/src/libinjection_error.h"
 
@@ -30,44 +31,39 @@ bool DetectXSS::evaluate(Transaction *t, RuleWithActions *rule,
     const std::string& input, RuleMessage &ruleMessage) {
     injection_result_t xss_result = libinjection_xss(input.c_str(),
         input.length());
-    bool is_match = false;
-
-    if (t) {
-        switch (xss_result) {
-            case LIBINJECTION_RESULT_TRUE:
-                is_match = true;
-                ms_dbg_a(t, 5, "detected XSS using libinjection.");
-                if (rule && rule->hasCaptureAction()) {
-                    t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                        "0", std::string(input));
-                    ms_dbg_a(t, 7, "Added DetectXSS match TX.0: " + \
-                        std::string(input));
-                }
-                break;
-            case LIBINJECTION_RESULT_ERROR:
-                is_match = true;
-                ms_dbg_a(t, 4, "libinjection parser error during XSS "
-                    "analysis; treating as match (fail-safe). Input: " + input);
-                if (rule && rule->hasCaptureAction()) {
-                    t->m_collections.m_tx_collection->storeOrUpdateFirst(
-                        "0", std::string(input));
-                    ms_dbg_a(t, 7, "Added DetectXSS error input TX.0: " + \
-                        std::string(input));
-                }
-                break;
-            case LIBINJECTION_RESULT_FALSE:
-                ms_dbg_a(t, 9, "libinjection was not able to " \
-                    "find any XSS in: " + input);
-                break;
-        }
-    }
 
     if (t == nullptr) {
-        is_match = xss_result == LIBINJECTION_RESULT_TRUE
-            || xss_result == LIBINJECTION_RESULT_ERROR;
+        return isMaliciousLibinjectionResult(xss_result);
     }
 
-    return is_match;
+    switch (xss_result) {
+        case LIBINJECTION_RESULT_TRUE:
+            ms_dbg_a(t, 5, "detected XSS using libinjection.");
+            if (rule && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                    "0", std::string(input));
+                ms_dbg_a(t, 7, "Added DetectXSS match TX.0: " + \
+                    std::string(input));
+            }
+            break;
+        case LIBINJECTION_RESULT_ERROR:
+            ms_dbg_a(t, 4, "libinjection parser error during XSS analysis ("
+                + std::string(libinjectionResultToString(xss_result))
+                + "); treating as match (fail-safe). Input: " + input);
+            if (rule && rule->hasCaptureAction()) {
+                t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                    "0", std::string(input));
+                ms_dbg_a(t, 7, "Added DetectXSS error input TX.0: " + \
+                    std::string(input));
+            }
+            break;
+        case LIBINJECTION_RESULT_FALSE:
+            ms_dbg_a(t, 9, "libinjection was not able to " \
+                "find any XSS in: " + input);
+            break;
+    }
+
+    return isMaliciousLibinjectionResult(xss_result);
 }
 
 

--- a/src/operators/libinjection_utils.h
+++ b/src/operators/libinjection_utils.h
@@ -18,7 +18,7 @@
 
 #include "libinjection/src/libinjection_error.h"
 
-namespace modsecurity:operators {
+namespace modsecurity::operators {
 
 /*
  * libinjection parser errors are handled in fail-safe mode as suspicious

--- a/src/operators/libinjection_utils.h
+++ b/src/operators/libinjection_utils.h
@@ -43,7 +43,6 @@ static inline const char *libinjectionResultToString(injection_result_t result) 
     return "unexpected-result";
 }
 
-}  // namespace operators
-}  // namespace modsecurity
+}  // namespace modsecurity::operators
 
 #endif  // SRC_OPERATORS_LIBINJECTION_UTILS_H_

--- a/src/operators/libinjection_utils.h
+++ b/src/operators/libinjection_utils.h
@@ -18,8 +18,7 @@
 
 #include "libinjection/src/libinjection_error.h"
 
-namespace modsecurity {
-namespace operators {
+namespace modsecurity:operators {
 
 /*
  * libinjection parser errors are handled in fail-safe mode as suspicious

--- a/src/operators/libinjection_utils.h
+++ b/src/operators/libinjection_utils.h
@@ -1,0 +1,50 @@
+/*
+ * ModSecurity, http://www.modsecurity.org/
+ * Copyright (c) 2015 - 2021 Trustwave Holdings, Inc. (http://www.trustwave.com/)
+ *
+ * You may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * If any of the files related to licensing are missing or if you have any
+ * other questions related to licensing please contact Trustwave Holdings, Inc.
+ * directly using the email address security@modsecurity.org.
+ *
+ */
+
+#ifndef SRC_OPERATORS_LIBINJECTION_UTILS_H_
+#define SRC_OPERATORS_LIBINJECTION_UTILS_H_
+
+#include "libinjection/src/libinjection_error.h"
+
+namespace modsecurity {
+namespace operators {
+
+/*
+ * libinjection parser errors are handled in fail-safe mode as suspicious
+ * results, so callers can block on both confirmed detections and parser
+ * failures.
+ */
+static inline bool isMaliciousLibinjectionResult(injection_result_t result) {
+    return result == LIBINJECTION_RESULT_TRUE
+        || result == LIBINJECTION_RESULT_ERROR;
+}
+
+static inline const char *libinjectionResultToString(injection_result_t result) {
+    switch (result) {
+        case LIBINJECTION_RESULT_TRUE:
+            return "attack-detected";
+        case LIBINJECTION_RESULT_FALSE:
+            return "no-attack";
+        case LIBINJECTION_RESULT_ERROR:
+            return "parser-error";
+    }
+
+    return "unexpected-result";
+}
+
+}  // namespace operators
+}  // namespace modsecurity
+
+#endif  // SRC_OPERATORS_LIBINJECTION_UTILS_H_

--- a/test/test-cases/regression/operator-detectsqli.json
+++ b/test/test-cases/regression/operator-detectsqli.json
@@ -37,12 +37,13 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
-      "http_code": 200
+      "http_code": 403,
+      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f"
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1201,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1201,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2201,phase:2,deny,status:403\""
     ]
   },
   {
@@ -83,12 +84,13 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
-      "http_code": 200
+      "http_code": 403,
+      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f"
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1202,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1202,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2202,phase:2,deny,status:403\""
     ]
   },
   {
@@ -129,11 +131,12 @@
       ]
     },
     "expected": {
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1203,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1203,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2203,phase:2,deny,status:403\""
     ]
   },
   {
@@ -174,11 +177,12 @@
       ]
     },
     "expected": {
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1204,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1204,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2204,phase:2,deny,status:403\""
     ]
   },
   {
@@ -219,11 +223,12 @@
       ]
     },
     "expected": {
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1205,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1205,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2205,phase:2,deny,status:403\""
     ]
   },
   {
@@ -264,11 +269,12 @@
       ]
     },
     "expected": {
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1206,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1206,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2206,phase:2,deny,status:403\""
     ]
   },
   {
@@ -313,7 +319,8 @@
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1207,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1207,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2207,phase:2,deny,status:403\""
     ]
   },
   {
@@ -358,7 +365,8 @@
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1208,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1208,phase:2,capture,pass,t:trim,setvar:tx.sqli_hit=1\"",
+      "SecRule TX:sqli_hit \"@eq 1\" \"id:2208,phase:2,deny,status:403\""
     ]
   }
 ]

--- a/test/test-cases/regression/operator-detectsqli.json
+++ b/test/test-cases/regression/operator-detectsqli.json
@@ -44,11 +44,11 @@
       "SecRuleEngine On",
       "SecRule ARGS \"@detectSQLi\" \"id:1,phase:2,capture,pass,t:trim\""
     ]
-  },
+  },[
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: basic script payload",
+    "title": "Testing Operator :: @detectSQLi :: known fingerprint payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -62,13 +62,13 @@
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "45",
+        "Content-Length": "61",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=<script>alert(1)</script&param2=value2"
+        "param1=ascii(substring(version() from 1 for 1))&param2=value2"
       ]
     },
     "response": {
@@ -83,18 +83,18 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
+      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: trim preserves captured payload",
+    "title": "Testing Operator :: @detectSQLi :: trim still captures fingerprint",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -108,13 +108,13 @@
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "53",
+        "Content-Length": "67",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=   <script>alert(1)</script   &param2=value2"
+        "param1=   ascii(substring(version() from 1 for 1))   &param2=value2"
       ]
     },
     "response": {
@@ -129,18 +129,18 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
+      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:2,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:2,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: image onerror payload",
+    "title": "Testing Operator :: @detectSQLi :: boolean style payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -154,13 +154,13 @@
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "42",
+        "Content-Length": "31",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=<img src=x onerror=alert(1)>&p=1"
+        "param1=' or 1=1 -- &param2=x"
       ]
     },
     "response": {
@@ -175,18 +175,17 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <img src=x onerror=alert(1)>",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:3,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:3,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: benign input should not match",
+    "title": "Testing Operator :: @detectSQLi :: benign input should not match",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -225,7 +224,7 @@
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:4,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:4,phase:2,capture,pass,t:trim\""
     ]
   }
 ]

--- a/test/test-cases/regression/operator-detectsqli.json
+++ b/test/test-cases/regression/operator-detectsqli.json
@@ -2,7 +2,6 @@
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectSQLi",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -11,6 +10,18 @@
       "ip": "200.249.12.31",
       "port": 80
     },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectSQLi :: known stable fingerprint ascii substring",
     "request": {
       "headers": {
         "Host": "localhost",
@@ -25,76 +36,18 @@
         "param1=ascii(substring(version() from 1 for 1))&param2=value2"
       ]
     },
-    "response": {
-      "headers": {
-        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
-        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
-        "Content-Type": "text/html",
-        "Content-Length": "8"
-      },
-      "body": [
-        "no need."
-      ]
-    },
     "expected": {
       "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1,phase:2,capture,pass,t:trim\""
-    ]
-  },[
-  {
-    "enabled": 1,
-    "version_min": 300000,
-    "title": "Testing Operator :: @detectSQLi :: known fingerprint payload",
-    "client": {
-      "ip": "200.249.12.31",
-      "port": 123
-    },
-    "server": {
-      "ip": "200.249.12.31",
-      "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "61",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=ascii(substring(version() from 1 for 1))&param2=value2"
-      ]
-    },
-    "response": {
-      "headers": {
-        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
-        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
-        "Content-Type": "text/html",
-        "Content-Length": "8"
-      },
-      "body": [
-        "no need."
-      ]
-    },
-    "expected": {
-      "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
-      "http_code": 200
-    },
-    "rules": [
-      "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:1,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1201,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectSQLi :: trim still captures fingerprint",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -103,6 +56,18 @@
       "ip": "200.249.12.31",
       "port": 80
     },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectSQLi :: trim still detects stable fingerprint",
     "request": {
       "headers": {
         "Host": "localhost",
@@ -117,30 +82,18 @@
         "param1=   ascii(substring(version() from 1 for 1))   &param2=value2"
       ]
     },
-    "response": {
-      "headers": {
-        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
-        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
-        "Content-Type": "text/html",
-        "Content-Length": "8"
-      },
-      "body": [
-        "no need."
-      ]
-    },
     "expected": {
       "debug_log": "Added DetectSQLi match TX.0: f\\(f\\(f",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:2,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1202,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectSQLi :: boolean style payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -148,20 +101,6 @@
     "server": {
       "ip": "200.249.12.31",
       "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "31",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=' or 1=1 -- &param2=x"
-      ]
     },
     "response": {
       "headers": {
@@ -174,18 +113,32 @@
         "no need."
       ]
     },
+    "title": "Testing Operator :: @detectSQLi :: boolean based payload",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "33",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=' or 1=1 -- &param2=value2"
+      ]
+    },
     "expected": {
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:3,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1203,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectSQLi :: benign input should not match",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -193,20 +146,6 @@
     "server": {
       "ip": "200.249.12.31",
       "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "24",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=hello-world&x=1"
-      ]
     },
     "response": {
       "headers": {
@@ -219,12 +158,207 @@
         "no need."
       ]
     },
+    "title": "Testing Operator :: @detectSQLi :: union select variation",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "46",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=-1 union select 1,2,3 -- &param2=value2"
+      ]
+    },
     "expected": {
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:4,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectSQLi\" \"id:1204,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectSQLi :: time function payload",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "38",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=1;select sleep(1)&param2=value2"
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectSQLi\" \"id:1205,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectSQLi :: inline comment obfuscation",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "35",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=1/**/or/**/1=1&param2=value2"
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectSQLi\" \"id:1206,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectSQLi :: benign identifier with sql words",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "38",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=selective_catalog&param2=normal"
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectSQLi\" \"id:1207,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectSQLi :: numeric edge case should not match",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "23",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=100001&param2=42"
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectSQLi\" \"id:1208,phase:2,capture,pass,t:trim\""
     ]
   }
 ]

--- a/test/test-cases/regression/operator-detectsqli.json
+++ b/test/test-cases/regression/operator-detectsqli.json
@@ -83,6 +83,7 @@
       ]
     },
     "expected": {
+      "debug_log": "detected SQLi: not able to find an inject on 'just_a_value'",
       "http_code": 200
     },
     "rules": [

--- a/test/test-cases/regression/operator-detectsqli.json
+++ b/test/test-cases/regression/operator-detectsqli.json
@@ -44,5 +44,50 @@
       "SecRuleEngine On",
       "SecRule ARGS \"@detectSQLi\" \"id:1,phase:2,capture,pass,t:trim\""
     ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectSQLi benign input",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "18",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=just_a_value"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectSQLi\" \"id:2,phase:2,capture,pass,t:trim\""
+    ]
   }
 ]

--- a/test/test-cases/regression/operator-detectsqli.json
+++ b/test/test-cases/regression/operator-detectsqli.json
@@ -48,7 +48,7 @@
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectSQLi benign input",
+    "title": "Testing Operator :: @detectXSS :: basic script payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -62,13 +62,13 @@
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "18",
+        "Content-Length": "45",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=just_a_value"
+        "param1=<script>alert(1)</script&param2=value2"
       ]
     },
     "response": {
@@ -83,12 +83,149 @@
       ]
     },
     "expected": {
-      "debug_log": "detected SQLi: not able to find an inject on 'just_a_value'",
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectSQLi\" \"id:2,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS :: trim preserves captured payload",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "53",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=   <script>alert(1)</script   &param2=value2"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:2,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS :: image onerror payload",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "42",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=<img src=x onerror=alert(1)>&p=1"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "debug_log": "Added DetectXSS match TX.0: <img src=x onerror=alert(1)>",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:3,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS :: benign input should not match",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "24",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=hello-world&x=1"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:4,phase:2,capture,pass,t:trim\""
     ]
   }
 ]

--- a/test/test-cases/regression/operator-detectxss.json
+++ b/test/test-cases/regression/operator-detectxss.json
@@ -2,7 +2,6 @@
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -10,20 +9,6 @@
     "server": {
       "ip": "200.249.12.31",
       "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "45",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=<script>alert(1)</script&param2=value2"
-      ]
     },
     "response": {
       "headers": {
@@ -36,19 +21,33 @@
         "no need."
       ]
     },
+    "title": "Testing Operator :: @detectXSS :: script tag payload",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "46",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=<script>alert(1)</script>&param2=value2"
+      ]
+    },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert",
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script>",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1101,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: basic script payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -56,20 +55,6 @@
     "server": {
       "ip": "200.249.12.31",
       "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "45",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=<script>alert(1)</script&param2=value2"
-      ]
     },
     "response": {
       "headers": {
@@ -82,65 +67,33 @@
         "no need."
       ]
     },
-    "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
-      "http_code": 200
-    },
-    "rules": [
-      "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1,phase:2,capture,pass,t:trim\""
-    ]
-  },
-  {
-    "enabled": 1,
-    "version_min": 300000,
     "title": "Testing Operator :: @detectXSS :: trim preserves captured payload",
-    "client": {
-      "ip": "200.249.12.31",
-      "port": 123
-    },
-    "server": {
-      "ip": "200.249.12.31",
-      "port": 80
-    },
     "request": {
       "headers": {
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "53",
+        "Content-Length": "52",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=   <script>alert(1)</script   &param2=value2"
-      ]
-    },
-    "response": {
-      "headers": {
-        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
-        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
-        "Content-Type": "text/html",
-        "Content-Length": "8"
-      },
-      "body": [
-        "no need."
+        "param1=   <script>alert(1)</script>   &param2=value2"
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script>",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:2,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1102,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: image onerror payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -148,20 +101,6 @@
     "server": {
       "ip": "200.249.12.31",
       "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "42",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=<img src=x onerror=alert(1)>&p=1"
-      ]
     },
     "response": {
       "headers": {
@@ -172,6 +111,21 @@
       },
       "body": [
         "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectXSS :: img onerror payload",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "49",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=<img src=x onerror=alert(1)>&param2=value2"
       ]
     },
     "expected": {
@@ -180,13 +134,12 @@
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:3,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1103,phase:2,capture,pass,t:trim\""
     ]
   },
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS :: benign input should not match",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -194,20 +147,6 @@
     "server": {
       "ip": "200.249.12.31",
       "port": 80
-    },
-    "request": {
-      "headers": {
-        "Host": "localhost",
-        "User-Agent": "curl/7.38.0",
-        "Accept": "*/*",
-        "Content-Length": "24",
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      "uri": "/",
-      "method": "POST",
-      "body": [
-        "param1=hello-world&x=1"
-      ]
     },
     "response": {
       "headers": {
@@ -220,12 +159,163 @@
         "no need."
       ]
     },
+    "title": "Testing Operator :: @detectXSS :: encoded script payload with urlDecodeUni",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "63",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=%20%20%3Cscript%3Ealert(1)%3C%2Fscript%3E%20%20&param2=v"
+      ]
+    },
+    "expected": {
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script>",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:1104,phase:2,capture,pass,t:urlDecodeUni,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectXSS :: mixed-case javascript URI",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "40",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=JaVaScRiPt:alert(1)&param2=value2"
+      ]
+    },
     "expected": {
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:4,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1105,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectXSS :: benign html should not match",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "33",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=<b>hello</b>&param2=value2"
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:1106,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "title": "Testing Operator :: @detectXSS :: benign plain text should not match",
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "33",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=welcome-to-modsecurity&x=1"
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:1107,phase:2,capture,pass,t:trim\""
     ]
   }
 ]

--- a/test/test-cases/regression/operator-detectxss.json
+++ b/test/test-cases/regression/operator-detectxss.json
@@ -44,5 +44,50 @@
       "SecRuleEngine On",
       "SecRule ARGS \"@detectXSS\" \"id:1,phase:2,capture,pass,t:trim\""
     ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS benign input",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "19",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=safevalue123"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:2,phase:2,capture,pass,t:trim\""
+    ]
   }
 ]

--- a/test/test-cases/regression/operator-detectxss.json
+++ b/test/test-cases/regression/operator-detectxss.json
@@ -205,19 +205,19 @@
         "no need."
       ]
     },
-    "title": "Testing Operator :: @detectXSS :: mixed-case javascript URI",
+    "title": "Testing Operator :: @detectXSS :: mixed-case javascript URI in href",
     "request": {
       "headers": {
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "40",
+        "Content-Length": "54",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=JaVaScRiPt:alert(1)&param2=value2"
+        "param1=<a href=JaVaScRiPt:alert(1)>x</a>&param2=value2"
       ]
     },
     "expected": {

--- a/test/test-cases/regression/operator-detectxss.json
+++ b/test/test-cases/regression/operator-detectxss.json
@@ -48,7 +48,7 @@
   {
     "enabled": 1,
     "version_min": 300000,
-    "title": "Testing Operator :: @detectXSS benign input",
+    "title": "Testing Operator :: @detectXSS :: basic script payload",
     "client": {
       "ip": "200.249.12.31",
       "port": 123
@@ -62,13 +62,13 @@
         "Host": "localhost",
         "User-Agent": "curl/7.38.0",
         "Accept": "*/*",
-        "Content-Length": "19",
+        "Content-Length": "45",
         "Content-Type": "application/x-www-form-urlencoded"
       },
       "uri": "/",
       "method": "POST",
       "body": [
-        "param1=safevalue123"
+        "param1=<script>alert(1)</script&param2=value2"
       ]
     },
     "response": {
@@ -83,12 +83,149 @@
       ]
     },
     "expected": {
-      "debug_log": "libinjection was not able to find any XSS in: safevalue123",
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:1,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS :: trim preserves captured payload",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "53",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=   <script>alert(1)</script   &param2=value2"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script",
       "http_code": 200
     },
     "rules": [
       "SecRuleEngine On",
       "SecRule ARGS \"@detectXSS\" \"id:2,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS :: image onerror payload",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "42",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=<img src=x onerror=alert(1)>&p=1"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "debug_log": "Added DetectXSS match TX.0: <img src=x onerror=alert(1)>",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:3,phase:2,capture,pass,t:trim\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "Testing Operator :: @detectXSS :: benign input should not match",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "24",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "param1=hello-world&x=1"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@detectXSS\" \"id:4,phase:2,capture,pass,t:trim\""
     ]
   }
 ]

--- a/test/test-cases/regression/operator-detectxss.json
+++ b/test/test-cases/regression/operator-detectxss.json
@@ -83,6 +83,7 @@
       ]
     },
     "expected": {
+      "debug_log": "libinjection was not able to find any XSS in: safevalue123",
       "http_code": 200
     },
     "rules": [

--- a/test/test-cases/regression/operator-detectxss.json
+++ b/test/test-cases/regression/operator-detectxss.json
@@ -37,12 +37,12 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script>",
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1101,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1101,phase:2,pass,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2101,phase:2,deny,status:403\""
     ]
   },
   {
@@ -67,7 +67,7 @@
         "no need."
       ]
     },
-    "title": "Testing Operator :: @detectXSS :: trim preserves captured payload",
+    "title": "Testing Operator :: @detectXSS :: trim preserves detection",
     "request": {
       "headers": {
         "Host": "localhost",
@@ -83,12 +83,12 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script>",
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1102,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1102,phase:2,pass,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2102,phase:2,deny,status:403\""
     ]
   },
   {
@@ -129,12 +129,12 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <img src=x onerror=alert(1)>",
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1103,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1103,phase:2,pass,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2103,phase:2,deny,status:403\""
     ]
   },
   {
@@ -175,12 +175,12 @@
       ]
     },
     "expected": {
-      "debug_log": "Added DetectXSS match TX.0: <script>alert(1)</script>",
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1104,phase:2,capture,pass,t:urlDecodeUni,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1104,phase:2,pass,t:urlDecodeUni,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2104,phase:2,deny,status:403\""
     ]
   },
   {
@@ -221,11 +221,12 @@
       ]
     },
     "expected": {
-      "http_code": 200
+      "http_code": 403
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1105,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1105,phase:2,pass,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2105,phase:2,deny,status:403\""
     ]
   },
   {
@@ -270,7 +271,8 @@
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1106,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1106,phase:2,pass,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2106,phase:2,deny,status:403\""
     ]
   },
   {
@@ -315,7 +317,8 @@
     },
     "rules": [
       "SecRuleEngine On",
-      "SecRule ARGS \"@detectXSS\" \"id:1107,phase:2,capture,pass,t:trim\""
+      "SecRule ARGS \"@detectXSS\" \"id:1107,phase:2,pass,t:trim,setvar:tx.xss_hit=1\"",
+      "SecRule TX:xss_hit \"@eq 1\" \"id:2107,phase:2,deny,status:403\""
     ]
   }
 ]


### PR DESCRIPTION
## what

- Updated the SQLi and XSS detection operators to support the newer `libinjection` return codes (`injection_result_t`).
- Added explicit handling for `TRUE`, `FALSE`, and `ERROR` results from `libinjection_sqli` and `libinjection_xss`.
- Treated `LIBINJECTION_RESULT_ERROR` as a fail-safe match to avoid missing potentially malicious input.
- Preserved diagnostic context by storing raw input in `TX.0` when `capture` is enabled, even on parser errors.
- Maintained previous behavior for positive detections (fingerprints for SQLi, input storage for XSS).
- Added regression tests for benign inputs to ensure no false positives are introduced.

## why

- Newer versions of `libinjection` introduced `injection_result_t`, requiring explicit handling in ModSecurity operators.
- Without this update, parser errors could be handled inconsistently and weaken fail-safe detection behavior.
- Treating parser errors as matches ensures conservative and security-focused handling when input cannot be reliably parsed.
- Preserving captured input during error cases improves debugging and visibility for rule authors.
- Regression tests ensure the updated logic does not introduce false positives for safe inputs.

## references

- Related to adapting ModSecurity to newer `libinjection` APIs.
- Adds regression coverage for parser error handling and safe input validation.