### PR TITLE
fix(ci): pin Lua version on 5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,14 @@ jobs:
                        libtool \
                        yajl \
                        lmdb \
-                       lua \
+                       lua@5.4 \
                        libmaxminddb \
                        libxml2 \
                        ssdeep \
                        pcre \
                        bison \
                        flex
+          echo "/usr/local/opt/lua@5.4/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  LUA_VERSION: "5.4"
+
 jobs:
   build-linux:
     name: Linux (${{ matrix.platform.label }}, ${{ matrix.compiler.label }}, ${{ matrix.configure.label }})
@@ -40,7 +43,7 @@ jobs:
           sudo apt-get install -y libyajl-dev:${{ matrix.platform.arch }} \
                                   libcurl4-openssl-dev:${{ matrix.platform.arch }} \
                                   liblmdb-dev:${{ matrix.platform.arch }} \
-                                  liblua5.2-dev:${{ matrix.platform.arch }} \
+                                  liblua${{ env.LUA_VERSION }}-dev:${{ matrix.platform.arch }} \
                                   libmaxminddb-dev:${{ matrix.platform.arch }} \
                                   libpcre2-dev:${{ matrix.platform.arch }} \
                                   pcre2-utils:${{ matrix.platform.arch }} \
@@ -99,14 +102,14 @@ jobs:
                        libtool \
                        yajl \
                        lmdb \
-                       lua@5.4 \
+                       lua@${{ env.LUA_VERSION }} \
                        libmaxminddb \
                        libxml2 \
                        ssdeep \
                        pcre \
                        bison \
                        flex
-          echo "/usr/local/opt/lua@5.4/bin" >> $GITHUB_PATH
+          echo "/usr/local/opt/lua@${{ env.LUA_VERSION }}/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/ci_new.yml
+++ b/.github/workflows/ci_new.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  LUA_VERSION: "5.4"
+
 jobs:
   build-linux:
     name: Linux (${{ matrix.platform.label }}, ${{ matrix.compiler.label }}, ${{ matrix.configure.label }})
@@ -47,7 +50,7 @@ jobs:
             libyajl-dev \
             libcurl4-openssl-dev \
             liblmdb-dev \
-            liblua5.2-dev \
+            liblua${{ env.LUA_VERSION }}-dev \
             libmaxminddb-dev \
             libpcre2-dev \
             libxml2-dev \
@@ -109,14 +112,14 @@ jobs:
                        libtool \
                        yajl \
                        lmdb \
-                       lua@5.4 \
+                       lua@${{ env.LUA_VERSION }} \
                        libmaxminddb \
                        libxml2 \
                        ssdeep \
                        pcre \
                        bison \
                        flex
-          echo "/usr/local/opt/lua@5.4/bin" >> $GITHUB_PATH
+          echo "/usr/local/opt/lua@${{ env.LUA_VERSION }}/bin" >> $GITHUB_PATH
       - name: Run build preparation script
         run: ./build.sh
 
@@ -206,8 +209,8 @@ jobs:
 
       - name: Install cppcheck
         run: |
-          brew install autoconf automake libtool cppcheck libmaxminddb yajl lua@5.4 lmdb ssdeep
-          echo "/usr/local/opt/lua@5.4/bin" >> $GITHUB_PATH
+          brew install autoconf automake libtool cppcheck libmaxminddb yajl lua@${{ env.LUA_VERSION }} lmdb ssdeep
+          echo "/usr/local/opt/lua@${{ env.LUA_VERSION }}/bin" >> $GITHUB_PATH
 
       - name: Configure project
         run: |
@@ -250,7 +253,7 @@ jobs:
             libyajl-dev \
             libcurl4-openssl-dev \
             liblmdb-dev \
-            liblua5.2-dev \
+            liblua${{ env.LUA_VERSION }}-dev \
             libmaxminddb-dev \
             libpcre2-dev \
             libxml2-dev \

--- a/.github/workflows/ci_new.yml
+++ b/.github/workflows/ci_new.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-          
+
       - name: Install dependencies
         # curl and pcre2 are typically already available in the macOS runner image
         run: |
@@ -109,14 +109,14 @@ jobs:
                        libtool \
                        yajl \
                        lmdb \
-                       lua \
+                       lua@5.4 \
                        libmaxminddb \
                        libxml2 \
                        ssdeep \
                        pcre \
                        bison \
                        flex
-
+          echo "/usr/local/opt/lua@5.4/bin" >> $GITHUB_PATH
       - name: Run build preparation script
         run: ./build.sh
 
@@ -206,7 +206,8 @@ jobs:
 
       - name: Install cppcheck
         run: |
-          brew install autoconf automake libtool cppcheck libmaxminddb yajl lua lmdb ssdeep
+          brew install autoconf automake libtool cppcheck libmaxminddb yajl lua@5.4 lmdb ssdeep
+          echo "/usr/local/opt/lua@5.4/bin" >> $GITHUB_PATH
 
       - name: Configure project
         run: |


### PR DESCRIPTION
## what

This PR pins Lua version in OSX workflows on 5.4.

## why

It seems like the default Lua version is 5.5 if someone installs it on OSX, and the library is not ready to work with it.

This is a workaround, we should align the Lua related code.


## references

#3523 