### PR TITLE
feat: added Lua5.5 support

### DIFF
--- a/build/lua.m4
+++ b/build/lua.m4
@@ -7,7 +7,7 @@ dnl  LUA_DISPLAY
 dnl  LUA_FOUND
 
 AC_DEFUN([CHECK_LUA], [
-MSC_CHECK_LIB([LUA], [lua54 lua5.4 lua-5.4 lua53 lua5.3 lua-5.3 lua52 lua5.2 lua-5.2 lua51 lua5.1 lua-5.1 luajit lua], [lua.h], [lua5.4 lua5.3 lua5.2 lua5.1 luajit-5.1 lua], [-DWITH_LUA])
+MSC_CHECK_LIB([LUA], [lua55 lua5.5 lua-5.5 lua54 lua5.4 lua-5.4 lua53 lua5.3 lua-5.3 lua52 lua5.2 lua-5.2 lua51 lua5.1 lua-5.1 luajit lua], [lua.h], [lua5.5 lua5.4 lua5.3 lua5.2 lua5.1 luajit-5.1 lua], [-DWITH_LUA])
 
 # Post-processing: detect Lua version and add version-specific defines
 if test "x${LUA_FOUND}" = "x1"; then
@@ -19,6 +19,7 @@ if test "x${LUA_FOUND}" = "x1"; then
             5.2*) LUA_CFLAGS="-DWITH_LUA_5_2 ${LUA_CFLAGS}" ;;
             5.3*) LUA_CFLAGS="-DWITH_LUA_5_3 ${LUA_CFLAGS}" ;;
             5.4*) LUA_CFLAGS="-DWITH_LUA_5_4 ${LUA_CFLAGS}" ;;
+            5.5*) LUA_CFLAGS="-DWITH_LUA_5_5 ${LUA_CFLAGS}" ;;
             2.0*) LUA_CFLAGS="-DWITH_LUA_5_1 ${LUA_CFLAGS}" ;;
             2.1*) LUA_CFLAGS="-DWITH_LUA_5_1 -DWITH_LUA_JIT_2_1 ${LUA_CFLAGS}" ;;
         esac
@@ -30,6 +31,14 @@ if test "x${LUA_FOUND}" = "x1"; then
         LUA_VERSION=""
         _msc_save_CFLAGS=$CFLAGS
         CFLAGS="${LUA_CFLAGS} ${CFLAGS}"
+
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <lua.h> ]],
+            [[ #if (LUA_VERSION_NUM == 505)
+               return 0;
+               #else
+               #error not 5.5
+               #endif ]])],
+            [ _msc_lua_ver=505 ], [ _msc_lua_ver="" ])
 
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ #include <lua.h> ]],
             [[ #if (LUA_VERSION_NUM == 504)
@@ -76,6 +85,7 @@ if test "x${LUA_FOUND}" = "x1"; then
             502) LUA_CFLAGS="-DWITH_LUA_5_2 ${LUA_CFLAGS}" ;;
             503) LUA_CFLAGS="-DWITH_LUA_5_3 ${LUA_CFLAGS}" ;;
             504) LUA_CFLAGS="-DWITH_LUA_5_4 ${LUA_CFLAGS}" ;;
+            505) LUA_CFLAGS="-DWITH_LUA_5_5 ${LUA_CFLAGS}" ;;
         esac
         if test -n "$_msc_lua_ver"; then
             AC_MSG_NOTICE([LUA version from compile test: $_msc_lua_ver])

--- a/src/engine/lua.cc
+++ b/src/engine/lua.cc
@@ -154,7 +154,7 @@ int Lua::run(Transaction *t, const std::string &str) { // cppcheck-suppress cons
             case LUA_ERRMEM:
                 e.assign("Memory error. ");
                 break;
-#if !defined(WITH_LUA_5_1) and !defined(WITH_LUA_5_4)
+#if !defined(WITH_LUA_5_1) and !defined(WITH_LUA_5_4) and !defined(WITH_LUA_5_5)
             case LUA_ERRGCMM:
                 e.assign("Garbage Collector error. ");
                 break;

--- a/test/test-cases/data/match-getvars.lua
+++ b/test/test-cases/data/match-getvars.lua
@@ -2,9 +2,9 @@ function dump(o)
    if type(o) == 'table' then
       local s = '{ '
       for k,v in pairs(o) do
-         -- we create a local var because in Lua55
-         -- variables k and v get an implicit 'const' modifier
-         -- this works in previous Lua versions too
+         -- In Lua 5.5, generic-for loop variables (k and v) are read-only,
+         -- so we copy k into a local before formatting. This works in earlier
+         -- Lua versions too.
          local key_str = k
          if type(key_str) ~= 'number' then
             key_str = '"'..key_str..'"'

--- a/test/test-cases/data/match-getvars.lua
+++ b/test/test-cases/data/match-getvars.lua
@@ -3,8 +3,8 @@ function dump(o)
       local s = '{ '
       for k,v in pairs(o) do
          -- we create a local var because in Lua55
-	 -- variables k and v get an implicit 'const' modifier
-	 -- this works in previous Lua versions too
+         -- variables k and v get an implicit 'const' modifier
+         -- this works in previous Lua versions too
          local key_str = k
          if type(key_str) ~= 'number' then
             key_str = '"'..key_str..'"'

--- a/test/test-cases/data/match-getvars.lua
+++ b/test/test-cases/data/match-getvars.lua
@@ -2,8 +2,14 @@ function dump(o)
    if type(o) == 'table' then
       local s = '{ '
       for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
+         -- we create a local var because in Lua55
+	 -- variables k and v get an implicit 'const' modifier
+	 -- this works in previous Lua versions too
+         local key_str = k
+         if type(key_str) ~= 'number' then
+            key_str = '"'..key_str..'"'
+         end
+         s = s .. '['..key_str..'] = ' .. dump(v) .. ','
       end
       return s .. '} '
    else


### PR DESCRIPTION
## what

This PR adds Lua5.5 support.

Steps of implementation:
* I added Lua5.5 as possible version in `build/lua.m4`
* in `lua.cc` I had to add this version as an exception
  * note, that probably we should change this build logic in the future, eg. if a new Lua version will be released or Lua 5.1 will be unsupported
* I had to align the `test/test-cases/data/match-getvars.lua` which is used in one of the regression test with operator `@inspectFile`. Lua5.5 does not allow to change the iterator variable's value, so we need to create a local variable.

## why

Lua5.5 was released and added to macOS, where we also run regression tests. Tests were failed there because Lua5.5 wasn't supported in libmodsecurity3.

## references

Closes #3523


