### PR TITLE
fix: cppcheck warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,12 +44,13 @@ cppcheck:
 	    --library=gnu \
 	    --library=posix \
 	    --std=c++17 \
-		-I ./apache2 \
+	    -I ./apache2 \
 	    -I /usr/include/libxml2 \
-		-I @APXS_INCLUDEDIR@ \
+	    -I @APXS_INCLUDEDIR@ \
 	    -I @APR_INCLUDEDIR@ \
 	    -I @APU_INCLUDEDIR@ \
 	    --suppressions-list=./tests/cppcheck_suppressions.txt \
+	    --suppress=syntaxError:/usr/include/apr-1.0/* \
 	    --inline-suppr \
 	    --inconclusive \
 	    --template="warning: {file},{line},{severity},{id},{message}" \

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ cppcheck:
 	    -I @APR_INCLUDEDIR@ \
 	    -I @APU_INCLUDEDIR@ \
 	    --suppressions-list=./tests/cppcheck_suppressions.txt \
-	    --suppress=syntaxError:/usr/include/apr-1.0/* \
+	    --suppress=syntaxError:@APR_INCLUDEDIR@/* \
 	    --inline-suppr \
 	    --inconclusive \
 	    --template="warning: {file},{line},{severity},{id},{message}" \

--- a/standalone/server.c
+++ b/standalone/server.c
@@ -139,16 +139,15 @@ AP_DECLARE(int) ap_index_of_response(int status)
 {
     static const int shortcut[6] = {0, LEVEL_200, LEVEL_300, LEVEL_400,
     LEVEL_500, RESPONSE_CODES};
-    int i, pos;
 
     if (status < 100) {               /* Below 100 is illegal for HTTP status */
         return LEVEL_500;
     }
 
-    for (i = 0; i < 5; i++) {
+    for (int i = 0; i < 5; i++) {
         status -= 100;
         if (status < 100) {
-            pos = (status + shortcut[i]);
+            int pos = (status + shortcut[i]);
             if (pos < shortcut[i + 1]) {
                 return pos;
             }


### PR DESCRIPTION
cppcheck warning in standalone/server.c; add suppression to whole header's dir

## what

This PR fixes some `cppcheck` warnings:
* move variables to inner scope
* add system's include directory to the suppression list

I prefer this way (second item) because at this way we see the suppression, don't need top check the suppression's file.

## why

There were some cppcheck warnings and failed tests in recent PR's.

## references

#3527

