### PR TITLE
fix: preserve value in t:base64Decode when input is not valid base64

### DIFF
--- a/src/actions/transformations/base64_decode.cc
+++ b/src/actions/transformations/base64_decode.cc
@@ -23,9 +23,14 @@ namespace modsecurity::actions::transformations {
 
 bool Base64Decode::transform(std::string &value, const Transaction *trans) const {
     if (value.empty()) return false;
-    value = Utils::Base64::decode(value);
+
+    std::string decoded;
+    if (!Utils::Base64::decode(value, decoded)) {
+        return false;
+    }
+
+    value = std::move(decoded);
     return true;
 }
-
 
 }  // namespace modsecurity::actions::transformations

--- a/src/utils/base64.cc
+++ b/src/utils/base64.cc
@@ -55,14 +55,33 @@ std::string Base64::decode(const std::string& data, bool forgiven) {
         return decode_forgiven(data);
     }
 
-    return decode(data);
+    std::string out;
+    decode(data, out);
+    return out;
 }
 
 
-std::string Base64::decode(const std::string& data) {
-    return base64Helper(data.c_str(), strlen(data.c_str()), mbedtls_base64_decode);
-}
+bool Base64::decode(const std::string& data, std::string &out) {
+    size_t out_len = 0;
+    const auto *src = reinterpret_cast<const unsigned char *>(data.c_str());
+    const size_t slen = strlen(data.c_str());
 
+    const int ret = mbedtls_base64_decode(nullptr, 0, &out_len, src, slen);
+
+    if (ret != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+        return false;
+    }
+
+    out.resize(out_len);
+    if (mbedtls_base64_decode(
+            reinterpret_cast<unsigned char *>(out.data()),
+            out.size(), &out_len, src, slen) != 0) {
+        return false;
+    }
+
+    out.resize(out_len);
+    return true;
+}
 
 std::string Base64::decode_forgiven(const std::string& data) {
     return base64Helper(data.c_str(), data.size(), decode_forgiven_engine);

--- a/src/utils/base64.h
+++ b/src/utils/base64.h
@@ -29,7 +29,7 @@ class Base64 {
     static std::string encode(const std::string& data);
 
     static std::string decode(const std::string& data, bool forgiven);
-    static std::string decode(const std::string& data);
+    static bool decode(const std::string& data, std::string &out);
     static std::string decode_forgiven(const std::string& data);
 
     static void decode_forgiven_engine(unsigned char *plain_text,

--- a/src/variables/remote_user.cc
+++ b/src/variables/remote_user.cc
@@ -54,7 +54,11 @@ void RemoteUser::evaluate(Transaction *transaction,
             base64 = std::string(header, 6, header.length());
         }
 
-        base64 = Utils::Base64::decode(base64);
+        if (std::string decoded; Utils::Base64::decode(base64, decoded)) {
+            base64 = std::move(decoded);
+        } else {
+            base64.clear();
+        }
 
         if (const auto pos{base64.find(":")}; pos != std::string::npos) {
             transaction->m_variableRemoteUser.assign(std::string(base64, 0, pos));


### PR DESCRIPTION
## What

When `t:base64Decode` encounters non-base64 input, the transformation now preserves the original value unchanged and returns `false` (no change), instead of silently replacing it with an empty string and returning `true`.

## Why

The `base64Helper()` function in `src/utils/base64.cc` calls `mbedtls_base64_decode` but ignores its error code return value. It only checks the `out_len` output parameter, which stays `0` when mbedtls returns `MBEDTLS_ERR_BASE64_INVALID_CHARACTER` (`-0x002C`). This causes `Base64Decode::transform()` to unconditionally replace the variable's value with an empty string for any non-base64 input.

**Impact:**
- All transformations **after** `t:base64Decode` in a pipeline run on an empty string — effectively dead code for non-base64 input
- CRS rules 934100, 934101, 934160 have degraded post-decode transformation pipelines
- CRS was forced to **remove** `t:base64Decode` from rules 934130/934131 as a workaround ([coreruleset/coreruleset#3376](https://github.com/coreruleset/coreruleset/issues/3376))

## How

Replaced the broken `std::string decode(const std::string&)` with `bool decode(const std::string&, std::string &out)` which checks the `mbedtls_base64_decode` return value before proceeding:
- Returns `MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL` → valid base64, proceed with decode
- Returns anything else → not valid base64, return `false` (value preserved)

This is a whitelist approach — only the known-good return code proceeds. Any current or future error codes from mbedtls (including the new `MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED` in mbedtls v4.x) are automatically handled.

The old single-arg `decode()` overload is removed rather than left alongside the fix, to prevent future callers from hitting the same silent-empty-string bug. All callers are updated in this PR.

**Files changed:**

| File | Change |
|------|--------|
| `src/utils/base64.h` | Replaced `decode(string)` with `bool decode(string, string&)` |
| `src/utils/base64.cc` | Implemented new `decode()` with mbedtls return code check, updated `decode(string, bool)` wrapper |
| `src/actions/transformations/base64_decode.cc` | Preserve value on decode failure, return `false` |
| `src/variables/remote_user.cc` | Updated to use new decode API, clear value on failure |

**Backward compatibility:**
- Valid base64 input: behavior is identical (decoded correctly, returns `true`)
- Invalid base64 input: value is now preserved instead of destroyed (returns `false`)
- `strlen` retained for input length to preserve existing embedded-NUL handling
- Compatible with both mbedtls v3.6.x and v4.x

## References

- Closes #1037 (base64 decoding generates no warning — open since 2015)
- Closes #3103 (base64decode behaviour — value destroyed on non-base64 input)
- Related: #3327 (base64Decode behaviour against payload with + and /)
- CRS workaround: [coreruleset/coreruleset#3376](https://github.com/coreruleset/coreruleset/issues/3376)
- CRS affected rules: 934100, 934101, 934160 (Node.js injection/DoS detection)

## Proposed test additions

For [secrules-language-tests](https://github.com/owasp-modsecurity/secrules-language-tests) `transformations/base64Decode.json`:

```json
{
   "ret" : 0,
   "input" : "not;valid;base64",
   "type" : "tfn",
   "name" : "base64Decode",
   "output" : "not;valid;base64"
},
{
   "ret" : 0,
   "input" : "hello world!",
   "type" : "tfn",
   "name" : "base64Decode",
   "output" : "hello world!"
}
```