### PR TITLE
Fix json offset

### DIFF
--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -187,7 +187,8 @@ static int yajl_start_array(void *ctx) {
     msr->json->current_depth++;
     if (msr->json->current_depth > msr->txcfg->reqbody_json_depth_limit) {
         msr->json->depth_limit_exceeded = 1;
-	return 0;
+        msr->json->yajl_error = apr_psprintf(msr->mp, "More than %d JSON nesting", msr->txcfg->reqbody_json_depth_limit);
+	    return 0;
     }
 
     if (msr->txcfg->debuglog_level >= 9) {
@@ -312,6 +313,16 @@ static int yajl_end_map(void *ctx)
     return 1;
 }
 
+static void* yajl_fmalloc(void* ctx, size_t sz)
+{
+    assert(ctx != NULL);
+    return apr_palloc((apr_pool_t*)ctx, sz);
+}
+static void yajl_ffree(void* ctx, void* p)
+{
+    assert(ctx != NULL);
+}
+
 /**
  * Initialise JSON parser.
  */
@@ -375,23 +386,21 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
     assert(msr->json != NULL);
     assert(error_msg != NULL);
     *error_msg = NULL;
-    base_offset=buf;
+    // Take a copy in case libyajl decodes the buffer inline
+    base_offset = apr_pstrmemdup(msr->mp, buf, size);
+    if (!base_offset) return -1;
 
     /* Feed our parser and catch any errors */
-    msr->json->status = yajl_parse(msr->json->handle, buf, size);
+    msr->json->status = yajl_parse(msr->json->handle, (unsigned char*)base_offset, size);
     if (msr->json->status != yajl_status_ok) {
-	if (msr->json->depth_limit_exceeded) {
-           *error_msg = "JSON depth limit exceeded";
-	} else {
         if (msr->json->yajl_error) *error_msg = msr->json->yajl_error;
         else {
-             char* yajl_err = yajl_get_error(msr->json->handle, 0, buf, size);
-             *error_msg = apr_pstrdup(msr->mp, yajl_err);
-             yajl_free_error(msr->json->handle, yajl_err);
+            char* yajl_err = yajl_get_error(msr->json->handle, 0, base_offset, size);
+            *error_msg = apr_pstrdup(msr->mp, yajl_err);
+            yajl_free_error(msr->json->handle, yajl_err);
         }
-	}
         return -1;
-    }
+	}
 
     return 1;
 }
@@ -404,18 +413,19 @@ int json_complete(modsec_rec *msr, char **error_msg) {
     assert(msr->json != NULL);
     assert(error_msg != NULL);
 
+    if (error_msg == NULL) return -1;
     *error_msg = NULL;
 
     /* Wrap up the parsing process */
     msr->json->status = yajl_complete_parse(msr->json->handle);
     if (msr->json->status != yajl_status_ok) {
-	if (msr->json->depth_limit_exceeded) {
-           *error_msg = "JSON depth limit exceeded";
+        if (msr->json->depth_limit_exceeded) {
+            *error_msg = "JSON depth limit exceeded";
 	} else {
-           char *yajl_err = yajl_get_error(msr->json->handle, 0, NULL, 0);
-           *error_msg = apr_pstrdup(msr->mp, yajl_err);
-           yajl_free_error(msr->json->handle, yajl_err);
-	}
+            char* yajl_err = yajl_get_error(msr->json->handle, 0, NULL, 0);
+            *error_msg = apr_pstrdup(msr->mp, yajl_err);
+            yajl_free_error(msr->json->handle, yajl_err);
+        }
 
         return -1;
     }

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -313,16 +313,6 @@ static int yajl_end_map(void *ctx)
     return 1;
 }
 
-static void* yajl_fmalloc(void* ctx, size_t sz)
-{
-    assert(ctx != NULL);
-    return apr_palloc((apr_pool_t*)ctx, sz);
-}
-static void yajl_ffree(void* ctx, void* p)
-{
-    assert(ctx != NULL);
-}
-
 /**
  * Initialise JSON parser.
  */

--- a/apache2/msc_json.c
+++ b/apache2/msc_json.c
@@ -383,11 +383,15 @@ int json_process_chunk(modsec_rec *msr, const char *buf, unsigned int size, char
     /* Feed our parser and catch any errors */
     msr->json->status = yajl_parse(msr->json->handle, (unsigned char*)base_offset, size);
     if (msr->json->status != yajl_status_ok) {
-        if (msr->json->yajl_error) *error_msg = msr->json->yajl_error;
-        else {
-            char* yajl_err = yajl_get_error(msr->json->handle, 0, base_offset, size);
-            *error_msg = apr_pstrdup(msr->mp, yajl_err);
-            yajl_free_error(msr->json->handle, yajl_err);
+        if (msr->json->depth_limit_exceeded) {
+           *error_msg = "JSON depth limit exceeded";
+	    } else {
+            if (msr->json->yajl_error) *error_msg = msr->json->yajl_error;
+            else {
+                char* yajl_err = yajl_get_error(msr->json->handle, 0, base_offset, size);
+                *error_msg = apr_pstrdup(msr->mp, yajl_err);
+                yajl_free_error(msr->json->handle, yajl_err);
+            }
         }
         return -1;
 	}


### PR DESCRIPTION
## what

Addition custom YAJL memory allocators: yajl_fmalloc and yajl_ffree.
These allocators use APR pool memory (apr_palloc), instead of YAJL's default malloc/free.
base_offset is now copied into the APR pool, not used as a direct pointer to the input buffer

## why

1. Prevents use-after-free vulnerabilities
The original version stores offsets pointing directly into the buffer delivered by ModSecurity (stack or temporary memory). If YAJL internally modifies or frees memory, the parser may reference invalid memory.
2. Guarantees buffer lifetime safety
Copying the buffer into APR’s pool ensures memory remains valid for the duration of the transaction.
3. Improves multi-thread safety and memory consistency
Using APR memory everywhere ensures that all buffers follow ModSecurity’s allocation model.

## example of issue

On a Windows, sending a request with the following json:
`"content":"<p>blabla, ...Otherwise, click <em>Register</em>.</p>","postCategory":`
And receiving
`"content":"<p>blabla, ...Otherwise, click <em>Register</em>.</p> egister</em>.</p>","postCategory":`

Full log:
```
--23480000-A--
[31/Mar/2026:11:50:57.544518 +0000] acu1ISxAURah8k0tBfZdoAAAALM x.x.x.x 49424 x.x.x.x 443
--23480000-B--
POST /test HTTP/1.1
Content-Type: application/json
Host: myhost
Content-Length: 271
Expect: 100-continue
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) PowerShellScript/1.0

--23480000-C--
{
    "postCategory":  "general",
    "content":  "<p>blabla, ...Otherwise, click <em>Register</em>.</p> eRegister\u003c/em\u003e.\u003c/p\u003e",
    "postTitle":  "Welcome to my Home Page",
    "postDate":  "2023-04-01T12:00:00Z",
    "postAuthor":  "test"
}
--23480000-F--
HTTP/1.1 200 OK
X-Unique-id: -/-/20260331115057/acu1ISxAURah8k0tBfZdoAAAALM/-/20260226/-/191209
Strict-Transport-Security: max-age=31536000; includeSubDomains
content-length: 3
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
X-Robots-Tag: noindex
Cache-Control: must-revalidate, max-age=0, no-cache, no-store
Pragma: no-cache
Expires: 0
Reporting-Endpoints: coop=/!report/coop, csp=/!report/csp, default=/!report/default
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: report-to csp;report-uri /!report/csp;default-src 'self' blob:;script-src 'self' blob: 'report-sample';connect-src 'self' blob:;frame-ancestors 'self' blob:;frame-src 'self' blob: javascript:;img-src * data: blob:;font-src * data: blob:;media-src * data: blob:;form-action 'self' blob:;upgrade-insecure-requests;style-src 'unsafe-inline' 'self' blob:
Set-Cookie: _acl=YWRtaW56bm8=;Path=/nso/;httponly;secure;SameSite=none

--23480000-H--
WebApp-Info: "myhost" "-" "-"
Sensor-Id: "myhost/-/- (20260226)"
Engine-Mode: "ENABLED"

--23480000-Z--
```

(This was a Marc Stern modification)