### PR TITLE
fix: probably UB (left shift of neg. val) in ip_tree

### DIFF
--- a/src/utils/msc_tree.h
+++ b/src/utils/msc_tree.h
@@ -38,7 +38,7 @@ typedef struct TreeRoot TreeRoot;
 
 #define TREE_CHECK(x, y) ((x) & (y))
 #define MASK_BITS(x) ((x + 1) * 8)
-#define SHIFT_LEFT_MASK(x) ((-1) << (x))
+#define SHIFT_LEFT_MASK(x) ((int)(~0U << (x)))
 #define SHIFT_RIGHT_MASK(x,y) ((x) >> (y))
 
 #define NETMASK_256 0x100


### PR DESCRIPTION
## what

This PR fixes a possible undefined behavior (UB) in IP TREE during the execution of `@ipMatch`.

## why

There is a bug report, received in email from @fumfel and his team. Also they provided this fix.

## references

The original report:
```
Root Cause
----------

The SHIFT_LEFT_MASK(x) macro computes (-1) << (x) to create a bitmask
with x zero bits on the right. On two's complement architectures with
arithmetic shifts, this produces the expected result. However, it is
formally undefined behavior per the C and C++ standards. Aggressive
compiler optimizations (such as -fstrict-overflow) could produce
unexpected results.

The bug triggers when processing IP addresses for @ipMatch with certain
netmask values. Input "\0::1" (null byte + IPv6 loopback notation)
reaches CPTFindElement where ip_bitmask % 8 == 0, producing
(-1) << 8.
```

## other notes

The bug can only be exploited if the source code was built with different flags, like `-fsanitize=address,undefined -fno-sanitize-recover=all` and the admin puts a `\0` byte into operator's argument on some way.