### PR TITLE
fix: probably UB (left shift of neg. val) in ip_tree code

### DIFF
--- a/apache2/msc_tree.h
+++ b/apache2/msc_tree.h
@@ -31,7 +31,7 @@ typedef struct TreeRoot TreeRoot;
 
 #define TREE_CHECK(x, y) ((x) & (y))
 #define MASK_BITS(x) ((x + 1) * 8)
-#define SHIFT_LEFT_MASK(x) ((-1) << (x))
+#define SHIFT_LEFT_MASK(x) ((int)(~0U << (x)))
 #define SHIFT_RIGHT_MASK(x,y) ((x) >> (y))
 
 #define NETMASK_256 0x100


### PR DESCRIPTION
## what

This PR fixes a possible undefined behavior (UB) in IP TREE during the execution of `@ipMatch`.

## why

See #3541 for details - same changes for v2.

## references
