### PR TITLE
fix: heap buffer overflow in acmp pm

### DIFF
--- a/src/utils/acmp.cc
+++ b/src/utils/acmp.cc
@@ -387,7 +387,7 @@ if (parser->is_active != 0) return -1;
             child->pattern = (char *)"";
             child->letter = letter;
             child->depth = i;
-            child->text = (char *)calloc(1, length + 2);
+            child->text = (char *)calloc(1, i + 2);
             /* ENH: Check alloc succeded */
             for (j = 0; j <= i; j++) child->text[j] = pattern[j];
         }
@@ -395,7 +395,7 @@ if (parser->is_active != 0) return -1;
             if (child->is_last == 0) {
                 parser->dict_count++;
                 child->is_last = 1;
-                child->pattern = (char *)calloc(1, length + 2);
+                child->pattern = (char *)calloc(1, length + 1);
                 /* ENH: Check alloc succeded */
                 memcpy(child->pattern, pattern, length);
                 child->pattern[length] = '\0';

--- a/src/utils/acmp.cc
+++ b/src/utils/acmp.cc
@@ -389,7 +389,9 @@ if (parser->is_active != 0) return -1;
             child->depth = i;
             child->text = (char *)calloc(1, i + 2);
             /* ENH: Check alloc succeded */
-            for (j = 0; j <= i; j++) child->text[j] = pattern[j];
+            for (j = 0; j <= i; j++) {
+                child->text[j] = pattern[j];
+            }
         }
         if (i == length - 1) {
             if (child->is_last == 0) {

--- a/src/utils/acmp.cc
+++ b/src/utils/acmp.cc
@@ -387,7 +387,7 @@ if (parser->is_active != 0) return -1;
             child->pattern = (char *)"";
             child->letter = letter;
             child->depth = i;
-            child->text = (char *)calloc(1, strlen(pattern) + 2);
+            child->text = (char *)calloc(1, length + 2);
             /* ENH: Check alloc succeded */
             for (j = 0; j <= i; j++) child->text[j] = pattern[j];
         }
@@ -395,9 +395,10 @@ if (parser->is_active != 0) return -1;
             if (child->is_last == 0) {
                 parser->dict_count++;
                 child->is_last = 1;
-                child->pattern = (char *)calloc(1, strlen(pattern) + 2);
+                child->pattern = (char *)calloc(1, length + 2);
                 /* ENH: Check alloc succeded */
-                strcpy(child->pattern, pattern);
+                memcpy(child->pattern, pattern, length);
+                child->pattern[length] = '\0';
             }
             child->callback = callback;
             child->callback_data = data;


### PR DESCRIPTION
## what

This PR fixes a  possible heap buffer overflow in ACMP (Aho Corasick) pattern matching function.

## why

There is a bug report, received in email from @fumfel and his team. Also they provided this fix.

## references

The original report:
```
Root Cause
----------

The function acmp_add_pattern() receives a pattern and its length as
separate parameters: (const char *pattern, size_t length). However, the
code uses strlen(pattern) instead of length to determine buffer sizes.

When pattern contains embedded null bytes (which is valid -- the length
parameter accounts for them), strlen() returns the offset of the first
null byte, which is shorter than the actual length. The buffer allocated
is too small, and subsequent operations (the for loop copying text, and
strcpy copying pattern) write past the end of the heap allocation.
```

## other notes

The bug can only be exploited if the admin puts a `\0` character into an argument of any `@pm` (or similar) operator.