### PR TITLE
fix: heap buffer overflow in acmp pm

### DIFF
--- a/apache2/acmp.c
+++ b/apache2/acmp.c
@@ -514,7 +514,7 @@ apr_status_t acmp_add_pattern(ACMP *parser, const char *pattern,
             child->pattern = "";
             child->letter = letter;
             child->depth = i;
-            child->text = apr_pcalloc(parser->pool, strlen(pattern) + 2);
+            child->text = apr_pcalloc(parser->pool, i + 2);
             /* ENH: Check alloc succeded */
             for (j = 0; j <= i; j++) child->text[j] = pattern[j];
         }
@@ -522,9 +522,10 @@ apr_status_t acmp_add_pattern(ACMP *parser, const char *pattern,
             if (child->is_last == 0) {
                 parser->dict_count++;
                 child->is_last = 1;
-                child->pattern = apr_pcalloc(parser->pool, strlen(pattern) + 2);
+                child->pattern = apr_pcalloc(parser->pool, length + 1);
                 /* ENH: Check alloc succeded */
-                strcpy(child->pattern, pattern);
+                memcpy(child->pattern, pattern, length);
+                child->pattern[length] = '\0';
             }
             child->callback = callback;
             child->callback_data = data;

--- a/apache2/acmp.c
+++ b/apache2/acmp.c
@@ -516,7 +516,9 @@ apr_status_t acmp_add_pattern(ACMP *parser, const char *pattern,
             child->depth = i;
             child->text = apr_pcalloc(parser->pool, i + 2);
             /* ENH: Check alloc succeded */
-            for (j = 0; j <= i; j++) child->text[j] = pattern[j];
+            for (j = 0; j <= i; j++) {
+                child->text[j] = pattern[j];
+            }
         }
         if (i == length - 1) {
             if (child->is_last == 0) {


### PR DESCRIPTION
## what

This PR fixes a possible heap buffer overflow in ACMP (Aho Corasick) pattern matching function.

## why

See #3544 for details - same changes for v2.
