### PR TITLE
fix: buffer overflow in multipart body proc

### DIFF
--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -362,7 +362,7 @@ int Multipart::parse_content_disposition(const char *c_d_value, int offset) {
             const char* start_of_filename = p;
             while ((*p != '\0') && (*p != ';')) {
                 if (*p == '%') {
-                    if ((*(p+1) == '\0') || (!isxdigit(*(p+1))) || (*(p+2) == '\0') || (!isxdigit(static_cast<unsigned char>(*(p+2))))) {
+                    if ((*(p+1) == '\0') || (*(p+2) == '\0') || (!isxdigit(static_cast<unsigned char>(*(p+1)))) || (!isxdigit(static_cast<unsigned char>(*(p+2))))) {
                         return -18;
                     }
                     p += 3;

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -417,6 +417,9 @@ int Multipart::parse_content_disposition(const char *c_d_value, int offset) {
 
             if (*p == quote) {
                 p++; /* go over the quote at the end */
+            } else {
+                m_flag_invalid_quoting = 1;
+                return -15; /* closing quote not found */
             }
 
         } else {

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -362,11 +362,11 @@ int Multipart::parse_content_disposition(const char *c_d_value, int offset) {
             const char* start_of_filename = p;
             while ((*p != '\0') && (*p != ';')) {
                 if (*p == '%') {
-                    if ((*(p+1) == '\0') || (!isxdigit(*(p+1))) || (*(p+2) == '\0') || (!isxdigit(*(p+2)))) {
+                    if ((*(p+1) == '\0') || (!isxdigit(*(p+1))) || (*(p+2) == '\0') || (!isxdigit(static_cast<unsigned char>(*(p+2))))) {
                         return -18;
                     }
                     p += 3;
-                } else if (isalnum(*p) || strchr(attr_char_special, *p)) {
+                } else if (isalnum(static_cast<unsigned char>(*p)) || strchr(attr_char_special, *p)) {
                     p++;
                 } else {
                     return -19;

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -362,7 +362,7 @@ int Multipart::parse_content_disposition(const char *c_d_value, int offset) {
             const char* start_of_filename = p;
             while ((*p != '\0') && (*p != ';')) {
                 if (*p == '%') {
-                    if ((*(p+1) == '\0') || (!isxdigit(*(p+1))) || (!isxdigit(*(p+2)))) {
+                    if ((*(p+1) == '\0') || (!isxdigit(*(p+1))) || (*(p+2) == '\0') || (!isxdigit(*(p+2)))) {
                         return -18;
                     }
                     p += 3;
@@ -415,7 +415,9 @@ int Multipart::parse_content_disposition(const char *c_d_value, int offset) {
                 value.append((p++), 1);
             }
 
-            p++; /* go over the quote at the end */
+            if (*p == quote) {
+                p++; /* go over the quote at the end */
+            }
 
         } else {
             /* not quoted */

--- a/test/test-cases/regression/request-body-parser-multipart.json
+++ b/test/test-cases/regression/request-body-parser-multipart.json
@@ -3417,5 +3417,56 @@
       "SecruleEngine On",
       "SecRule REQBODY_PROCESSOR_ERROR \"@eq 1\" \"phase:2,deny,status:403,id:500077\""
     ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "title": "multipart parser (invalid part header - missing trailing quote)",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 123
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "localhost",
+        "User-Agent": "curl/7.38.0",
+        "Accept": "*/*",
+        "Content-Length": "145",
+        "Content-Type": "multipart/form-data; boundary=a",
+        "Expect": "100-continue"
+      },
+      "uri": "/",
+      "method": "POST",
+      "body": [
+        "--a\r\n",
+        "Content-Disposition: form-data; name=\"file\"; filename=\"1.jsp\r\n",
+        "\r\n",
+        "Some content\r\n",
+        "--a--\r\n"
+      ]
+    },
+    "response": {
+      "headers": {
+        "Date": "Mon, 13 Jul 2015 20:02:41 GMT",
+        "Last-Modified": "Sun, 26 Oct 2014 22:33:37 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "8"
+      },
+      "body": [
+        "no need."
+      ]
+    },
+    "expected": {
+      "debug_log": "Multipart: Invalid Content-Disposition header \\(-15\\): form-data; name=\"file\"; filename=\"1.jsp",
+      "http_code": 403
+    },
+    "rules": [
+      "SecruleEngine On",
+      "SecRule REQBODY_PROCESSOR_ERROR \"@eq 1\" \"phase:2,deny,status:403,id:500077\""
+    ]
   }
 ]


### PR DESCRIPTION
## what

This PR fixes a possible heap buffer overflow in multipart body processor.

## why

There is a bug report, received in email from @fumfel and his team. Also they provided this fix.

## references

The original report:

```
Root Cause
----------

Bug A: The condition checks *(p+1) and *(p+2) for hex digits. When
*(p+1) is the last byte before the null terminator, the short-circuit
evaluation of the || chain does NOT prevent *(p+2) from being read.
The condition (!isxdigit(*(p+1))) is false when *(p+1) is a hex digit,
so evaluation continues to (!isxdigit(*(p+2))) which reads past the
allocation.

Bug B: After the while loop that scans a quoted value, the code
unconditionally does p++ to skip the closing quote. But if the string
ended without a closing quote (the loop exited on *p == '\0'), this
advances the pointer past the null terminator, causing subsequent
reads to access out-of-bounds memory.
```

## other notes

After a review and a short discussion, @fumfel and his team confirmed that this issue can occur if the source code was built with ASAN flags.
