### PR TITLE
Fix #3547 - int32_t not declared

### DIFF
--- a/headers/modsecurity/collection/collection.h
+++ b/headers/modsecurity/collection/collection.h
@@ -26,6 +26,7 @@
 
 
 #include "modsecurity/variable_value.h"
+#include <stdint.h>
 
 
 #ifndef HEADERS_MODSECURITY_COLLECTION_COLLECTION_H_


### PR DESCRIPTION
This fixes build failures on Alpine Linux since version 3.23

## what

- added `#include <stdint.h>` to `headers/modsecurity/collection/collection.h`
- tested successfully against Alpine 3.23 and Ubuntu 24.04.

## why

Fix compile error on Alpine Linux 3.23+

## references

- closes #3547