### PR TITLE
Add is_interrupted flag in the audit JSON log

### DIFF
--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -594,6 +594,14 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     ModSecurityIntervention m_it;
 
     /**
+     * Sticky flag: set to true the first time the connector consumes a
+     * disruptive intervention via Transaction::intervention(). Unlike
+     * m_it.disruptive, this is NOT cleared by intervention::reset(), so
+     * it remains a reliable signal at audit-log time.
+     */
+    bool m_isInterrupted = false;
+
+    /**
      * Holds the creation time stamp, using std::time.
      *
      * TODO: m_timeStamp and m_creationTimeStamp may be merged into a single

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -1366,6 +1366,7 @@ int Transaction::processLogging() {
 bool Transaction::intervention(ModSecurityIntervention *it) {
     const auto disruptive = m_it.disruptive;
     if (m_it.disruptive) {
+        m_isInterrupted = true;
         if (m_it.url) {
             it->url = strdup(m_it.url);
         } else {
@@ -1594,6 +1595,10 @@ std::string Transaction::toJSON(int parts) {
     LOGFY_ADD("host_ip", m_serverIpAddress);
     LOGFY_ADD_NUM("host_port", m_serverPort);
     LOGFY_ADD("unique_id", m_id);
+
+    yajl_gen_string(g, reinterpret_cast<const unsigned char*>("is_interrupted"),
+        strlen("is_interrupted"));
+    yajl_gen_bool(g, m_isInterrupted);
 
     /* request */
     yajl_gen_string(g, reinterpret_cast<const unsigned char*>("request"),

--- a/test/test-cases/regression/auditlog.json
+++ b/test/test-cases/regression/auditlog.json
@@ -782,5 +782,106 @@
       "SecAuditLogType Serial",
       "SecAuditLogRelevantStatus \"^(?:5|4(?!04))\""
     ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "version_max": 0,
+    "title": "auditlog : is_interrupted is true when a disruptive rule blocks the request",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 2313
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "www.modsecurity.org",
+        "Content-Length": "0"
+      },
+      "uri": "/test.pl?param1=test",
+      "method": "GET",
+      "http_version": 1.1,
+      "body": [
+        ""
+      ]
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "plain/text\n\r",
+        "Content-Length": "4"
+      },
+      "body": [
+        "test"
+      ]
+    },
+    "expected": {
+      "audit_log": "\"is_interrupted\":true",
+      "http_code": 403
+    },
+    "rules": [
+      "SecRuleEngine On",
+      "SecRule ARGS \"@contains test\" \"id:1900,phase:1,deny,auditlog\"",
+      "SecAuditEngine RelevantOnly",
+      "SecAuditLogFormat JSON",
+      "SecAuditLogParts ABCFHZ",
+      "SecAuditLog /tmp/audit_test_is_interrupted_true.log",
+      "SecAuditLogDirMode 0766",
+      "SecAuditLogFileMode 0600",
+      "SecAuditLogType Serial",
+      "SecAuditLogRelevantStatus \"^(?:5|4(?!04))\""
+    ]
+  },
+  {
+    "enabled": 1,
+    "version_min": 300000,
+    "version_max": 0,
+    "title": "auditlog : is_interrupted is false when SecRuleEngine is DetectionOnly",
+    "client": {
+      "ip": "200.249.12.31",
+      "port": 2313
+    },
+    "server": {
+      "ip": "200.249.12.31",
+      "port": 80
+    },
+    "request": {
+      "headers": {
+        "Host": "www.modsecurity.org",
+        "Content-Length": "0"
+      },
+      "uri": "/test.pl?param1=test",
+      "method": "GET",
+      "http_version": 1.1,
+      "body": [
+        ""
+      ]
+    },
+    "response": {
+      "headers": {
+        "Content-Type": "plain/text\n\r",
+        "Content-Length": "4"
+      },
+      "body": [
+        "test"
+      ]
+    },
+    "expected": {
+      "audit_log": "\"is_interrupted\":false",
+      "http_code": 200
+    },
+    "rules": [
+      "SecRuleEngine DetectionOnly",
+      "SecRule ARGS \"@contains test\" \"id:1901,phase:1,deny,auditlog\"",
+      "SecAuditEngine On",
+      "SecAuditLogFormat JSON",
+      "SecAuditLogParts ABCFHZ",
+      "SecAuditLog /tmp/audit_test_is_interrupted_false.log",
+      "SecAuditLogDirMode 0766",
+      "SecAuditLogFileMode 0600",
+      "SecAuditLogType Serial"
+    ]
   }
 ]


### PR DESCRIPTION
## what

Add an `is_interrupted` flag to the audit JSON log.

## why

From the audit logs, it's not possible to determine whether ModSecurity actually interfered with the request.

Neither `producer.secrules_engine` nor `messages.*.details.ruleId` reliably indicate this, since rule actions can be modified dynamically.

For example:

```
SecRule REMOTE_ADDR "@streq 1.1.1.1" \
    "id:1000,\
    phase:1,\
    log,\
    msg:'test'"

SecRuleUpdateActionById 1000 "deny,status:403"
```

## references

Coraza has introduced a similar flag:
https://github.com/corazawaf/coraza/blob/8b28b72ec16d01ed5b9b664699d1f69386f67029/internal/auditlog/auditlog.go#L89
