### PR TITLE
Exlude .gitignore from release tarballs

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -11,7 +11,7 @@ MY_DIR=${PWD##*/}
 ./build.sh
 
 cd ..
-tar --transform "s/^$MY_DIR/$DIR_NAME/" -cvzf $TAR_NAME --exclude .git $MY_DIR
+tar --transform "s/^$MY_DIR/$DIR_NAME/" -cvzf $TAR_NAME --exclude .git --exclude .gitignore $MY_DIR
 
 sha256sum $TAR_NAME > $TAR_NAME.sha256
 gpg --detach-sign -a $TAR_NAME


### PR DESCRIPTION
The `.gitignore` files should not be included in the release tarballs because they hide required files and can conflict with existing `.gitignore` files when the tarball is extracted into a git repository.

Closes: https://github.com/owasp-modsecurity/ModSecurity/issues/3559
Fixes: 04f70099 ("Adds a simple release script")