### PR TITLE
Fix GCC -Wall warnings on Fedora/RHEL builds

### DIFF
--- a/headers/modsecurity/anchored_set_variable_translation_proxy.h
+++ b/headers/modsecurity/anchored_set_variable_translation_proxy.h
@@ -43,7 +43,8 @@ class AnchoredSetVariableTranslationProxy {
         m_fount(fount)
     {
         m_translate = [](const std::string *name, std::vector<const VariableValue *> *l) {
-            for (int i = 0; i < l->size(); ++i) {
+            for (std::vector<const VariableValue *>::size_type i = 0;
+                i < l->size(); ++i) {
                 VariableValue *newVariableValue = new VariableValue(name, &l->at(i)->getKey(), &l->at(i)->getKey());
                 const VariableValue *oldVariableValue = l->at(i);
                 l->at(i) = newVariableValue;

--- a/headers/modsecurity/intervention.h
+++ b/headers/modsecurity/intervention.h
@@ -30,33 +30,33 @@ typedef struct ModSecurityIntervention_t {
 
 #ifdef __cplusplus
 namespace intervention {
-    static void reset(ModSecurityIntervention_t *i) {
+    inline void reset(ModSecurityIntervention_t *i) {
         i->status = 200;
         i->pause = 0;
         i->disruptive = 0;
     }
 
-    static void clean(ModSecurityIntervention_t *i) {
+    inline void clean(ModSecurityIntervention_t *i) {
         i->url = NULL;
         i->log = NULL;
         reset(i);
     }
 
-    static void freeUrl(ModSecurityIntervention_t *i) {
+    inline void freeUrl(ModSecurityIntervention_t *i) {
         if (i->url) {
             free(i->url);
             i->url = NULL;
         }
     }
 
-    static void freeLog(ModSecurityIntervention_t *i) {
+    inline void freeLog(ModSecurityIntervention_t *i) {
         if (i->log) {
             free(i->log);
             i->log = NULL;
         }
     }
 
-    static void free(ModSecurityIntervention_t *i) {
+    inline void free(ModSecurityIntervention_t *i) {
         freeUrl(i);
         freeLog(i);
     }

--- a/src/actions/init_col.cc
+++ b/src/actions/init_col.cc
@@ -28,7 +28,7 @@ namespace actions {
 
 
 bool InitCol::init(std::string *error) {
-    int posEquals = m_parser_payload.find("=");
+    const std::string::size_type posEquals = m_parser_payload.find("=");
 
     if (m_parser_payload.size() < 2) {
         error->assign("Something wrong with initcol format: too small");

--- a/src/actions/transformations/compress_whitespace.cc
+++ b/src/actions/transformations/compress_whitespace.cc
@@ -38,8 +38,8 @@ bool CompressWhitespace::transform(std::string &value, const Transaction *trans)
         }
     }
 
-    const auto new_len = d - value.c_str();
-    const auto changed = new_len != value.length();
+    const auto new_len = static_cast<std::string::size_type>(d - value.data());
+    const bool changed = new_len != value.length();
     value.resize(new_len);
     return changed;
 }

--- a/src/actions/transformations/html_entity_decode.cc
+++ b/src/actions/transformations/html_entity_decode.cc
@@ -154,7 +154,7 @@ static inline bool inplace(std::string &value) {
 
 HTML_ENT_OUT:
 
-        for (auto z = 0; z < copy; z++) {
+        for (std::string::size_type z = 0; z < copy; z++) {
             *d++ = input[i++];
         }
     }

--- a/src/actions/transformations/utf8_to_unicode.cc
+++ b/src/actions/transformations/utf8_to_unicode.cc
@@ -27,6 +27,42 @@ constexpr int UNICODE_ERROR_INVALID_ENCODING     = -2;
 namespace modsecurity::actions::transformations {
 
 
+static inline bool writeUnicodeEscape(char *&data, char *unicode,
+    size_t unicode_size, unsigned int d) {
+    *data++ = '%';
+    *data++ = 'u';
+    const int written = std::snprintf(unicode, unicode_size, "%x", d);
+    if (written < 0 || static_cast<size_t>(written) >= unicode_size) {
+        return false;
+    }
+
+    const auto length = static_cast<size_t>(written);
+    switch (length) {
+        case 1:
+            *data++ = '0';
+            *data++ = '0';
+            *data++ = '0';
+            break;
+        case 2:
+            *data++ = '0';
+            *data++ = '0';
+            break;
+        case 3:
+            *data++ = '0';
+            break;
+        case 4:
+        case 5:
+            break;
+    }
+
+    for (size_t j = 0; j < length; j++) {
+        *data++ = unicode[j];
+    }
+
+    return true;
+}
+
+
 static inline bool encode(std::string &value) {
     auto input = reinterpret_cast<unsigned char*>(value.data());
     const auto input_len = value.length();
@@ -78,39 +114,11 @@ static inline bool encode(std::string &value) {
                 unicode_len = 2;
                 count += 6;
                 if (count <= len) {
-                    size_t length = 0;
                     /* compute character number */
                     d = ((c & 0x1F) << 6) | (*(utf + 1) & 0x3F);
-                    *data++ = '%';
-                    *data++ = 'u';
-                    const int written = std::snprintf(unicode, sizeof(unicode),
-                        "%x", d);
-                    if (written < 0
-                        || static_cast<size_t>(written) >= sizeof(unicode)) {
+                    if (writeUnicodeEscape(data, unicode,
+                        sizeof(unicode), d) == false) {
                         return changed;
-                    }
-                    length = static_cast<size_t>(written);
-
-                    switch (length) {
-                        case 1:
-                            *data++ = '0';
-                            *data++ = '0';
-                            *data++ = '0';
-                            break;
-                        case 2:
-                            *data++ = '0';
-                            *data++ = '0';
-                            break;
-                        case 3:
-                            *data++ = '0';
-                            break;
-                        case 4:
-                        case 5:
-                            break;
-                    }
-
-                    for (size_t j = 0; j < length; j++) {
-                        *data++ = unicode[j];
                     }
 
                     changed = true;
@@ -131,41 +139,13 @@ static inline bool encode(std::string &value) {
                 unicode_len = 3;
                 count+=6;
                 if (count <= len) {
-                    size_t length = 0;
                     /* compute character number */
                     d = ((c & 0x0F) << 12)
                         | ((*(utf + 1) & 0x3F) << 6)
                         | (*(utf + 2) & 0x3F);
-                    *data++ = '%';
-                    *data++ = 'u';
-                    const int written = std::snprintf(unicode, sizeof(unicode),
-                        "%x", d);
-                    if (written < 0
-                        || static_cast<size_t>(written) >= sizeof(unicode)) {
+                    if (writeUnicodeEscape(data, unicode,
+                        sizeof(unicode), d) == false) {
                         return changed;
-                    }
-                    length = static_cast<size_t>(written);
-
-                    switch (length)  {
-                        case 1:
-                            *data++ = '0';
-                            *data++ = '0';
-                            *data++ = '0';
-                            break;
-                        case 2:
-                            *data++ = '0';
-                            *data++ = '0';
-                            break;
-                        case 3:
-                            *data++ = '0';
-                            break;
-                        case 4:
-                        case 5:
-                            break;
-                    }
-
-                    for (size_t j = 0; j < length; j++) {
-                        *data++ = unicode[j];
                     }
 
                     changed = true;
@@ -195,42 +175,14 @@ static inline bool encode(std::string &value) {
                 unicode_len = 4;
                 count+=7;
                 if (count <= len) {
-                    size_t length = 0;
                     /* compute character number */
                     d = ((c & 0x07) << 18)
                         | ((*(utf + 1) & 0x3F) << 12)
                         | ((*(utf + 2) & 0x3F) << 6)
                         | (*(utf + 3) & 0x3F);
-                    *data++ = '%';
-                    *data++ = 'u';
-                    const int written = std::snprintf(unicode, sizeof(unicode),
-                        "%x", d);
-                    if (written < 0
-                        || static_cast<size_t>(written) >= sizeof(unicode)) {
+                    if (writeUnicodeEscape(data, unicode,
+                        sizeof(unicode), d) == false) {
                         return changed;
-                    }
-                    length = static_cast<size_t>(written);
-
-                    switch (length)  {
-                        case 1:
-                            *data++ = '0';
-                            *data++ = '0';
-                            *data++ = '0';
-                            break;
-                        case 2:
-                            *data++ = '0';
-                            *data++ = '0';
-                            break;
-                        case 3:
-                            *data++ = '0';
-                            break;
-                        case 4:
-                        case 5:
-                            break;
-                    }
-
-                    for (size_t j = 0; j < length; j++) {
-                        *data++ = unicode[j];
                     }
 
                     changed = true;

--- a/src/actions/transformations/utf8_to_unicode.cc
+++ b/src/actions/transformations/utf8_to_unicode.cc
@@ -15,7 +15,7 @@
 
 #include "utf8_to_unicode.h"
 
-#include <cstring>
+#include <cstdio>
 
 #include "src/utils/string.h"
 
@@ -78,12 +78,18 @@ static inline bool encode(std::string &value) {
                 unicode_len = 2;
                 count += 6;
                 if (count <= len) {
-                    int length = 0;
+                    size_t length = 0;
                     /* compute character number */
                     d = ((c & 0x1F) << 6) | (*(utf + 1) & 0x3F);
                     *data++ = '%';
                     *data++ = 'u';
-                    length = snprintf(unicode, sizeof(unicode), "%x", d);
+                    const int written = std::snprintf(unicode, sizeof(unicode),
+                        "%x", d);
+                    if (written < 0
+                        || static_cast<size_t>(written) >= sizeof(unicode)) {
+                        return changed;
+                    }
+                    length = static_cast<size_t>(written);
 
                     switch (length) {
                         case 1:
@@ -103,7 +109,7 @@ static inline bool encode(std::string &value) {
                             break;
                     }
 
-                    for (int j = 0; j < length; j++) {
+                    for (size_t j = 0; j < length; j++) {
                         *data++ = unicode[j];
                     }
 
@@ -125,14 +131,20 @@ static inline bool encode(std::string &value) {
                 unicode_len = 3;
                 count+=6;
                 if (count <= len) {
-                    int length = 0;
+                    size_t length = 0;
                     /* compute character number */
                     d = ((c & 0x0F) << 12)
                         | ((*(utf + 1) & 0x3F) << 6)
                         | (*(utf + 2) & 0x3F);
                     *data++ = '%';
                     *data++ = 'u';
-                    length = snprintf(unicode, sizeof(unicode), "%x", d);
+                    const int written = std::snprintf(unicode, sizeof(unicode),
+                        "%x", d);
+                    if (written < 0
+                        || static_cast<size_t>(written) >= sizeof(unicode)) {
+                        return changed;
+                    }
+                    length = static_cast<size_t>(written);
 
                     switch (length)  {
                         case 1:
@@ -152,7 +164,7 @@ static inline bool encode(std::string &value) {
                             break;
                     }
 
-                    for (int j = 0; j < length; j++) {
+                    for (size_t j = 0; j < length; j++) {
                         *data++ = unicode[j];
                     }
 
@@ -183,7 +195,7 @@ static inline bool encode(std::string &value) {
                 unicode_len = 4;
                 count+=7;
                 if (count <= len) {
-                    int length = 0;
+                    size_t length = 0;
                     /* compute character number */
                     d = ((c & 0x07) << 18)
                         | ((*(utf + 1) & 0x3F) << 12)
@@ -191,7 +203,13 @@ static inline bool encode(std::string &value) {
                         | (*(utf + 3) & 0x3F);
                     *data++ = '%';
                     *data++ = 'u';
-                    length = snprintf(unicode, sizeof(unicode), "%x", d);
+                    const int written = std::snprintf(unicode, sizeof(unicode),
+                        "%x", d);
+                    if (written < 0
+                        || static_cast<size_t>(written) >= sizeof(unicode)) {
+                        return changed;
+                    }
+                    length = static_cast<size_t>(written);
 
                     switch (length)  {
                         case 1:
@@ -211,7 +229,7 @@ static inline bool encode(std::string &value) {
                             break;
                     }
 
-                    for (int j = 0; j < length; j++) {
+                    for (size_t j = 0; j < length; j++) {
                         *data++ = unicode[j];
                     }
 

--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -270,6 +270,7 @@ int ModSecurity::processContentOffset(const char *content, size_t len,
 
         if (static_cast<size_t>(stoi(startingAt)) >= len) {
             *err = "Offset is out of the content limits.";
+            yajl_gen_free(g);
             return -1;
         }
 
@@ -349,6 +350,7 @@ int ModSecurity::processContentOffset(const char *content, size_t len,
 
         if (static_cast<size_t>(stoi(startingAt)) >= varValue.size()) {
             *err = "Offset is out of the variable limits.";
+            yajl_gen_free(g);
             return -1;
         }
         yajl_gen_string(g,

--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -268,7 +268,7 @@ int ModSecurity::processContentOffset(const char *content, size_t len,
             size.size());
         yajl_gen_map_close(g);
 
-        if (stoi(startingAt) >= len) {
+        if (static_cast<size_t>(stoi(startingAt)) >= len) {
             *err = "Offset is out of the content limits.";
             return -1;
         }
@@ -347,7 +347,7 @@ int ModSecurity::processContentOffset(const char *content, size_t len,
             size.size());
         yajl_gen_map_close(g);
 
-        if (stoi(startingAt) >= varValue.size()) {
+        if (static_cast<size_t>(stoi(startingAt)) >= varValue.size()) {
             *err = "Offset is out of the variable limits.";
             return -1;
         }

--- a/src/operators/pm_from_file.cc
+++ b/src/operators/pm_from_file.cc
@@ -33,7 +33,7 @@ bool PmFromFile::isComment(const std::string &s) {
     }
     size_t pos = s.find("#");
     if (pos != std::string::npos) {
-        for (int i = 0; i < pos; i++) {
+        for (size_t i = 0; i < pos; i++) {
 	    if (!std::isspace(s[i])) {
 		return false;
 	    }

--- a/src/operators/pm_from_file.cc
+++ b/src/operators/pm_from_file.cc
@@ -34,7 +34,7 @@ bool PmFromFile::isComment(const std::string &s) {
     size_t pos = s.find("#");
     if (pos != std::string::npos) {
         for (size_t i = 0; i < pos; i++) {
-	    if (!std::isspace(s[i])) {
+	    if (!std::isspace(static_cast<unsigned char>(s[i]))) {
 		return false;
 	    }
 	}

--- a/src/operators/rx.h
+++ b/src/operators/rx.h
@@ -37,8 +37,7 @@ class Rx : public Operator {
  public:
     /** @ingroup ModSecurity_Operator */
     explicit Rx(std::unique_ptr<RunTimeString> param)
-        : m_re(nullptr),
-        Operator("Rx", std::move(param)) {
+        : Operator("Rx", std::move(param)) {
             m_couldContainsMacro = true;
         }
 
@@ -59,7 +58,7 @@ class Rx : public Operator {
     bool init(const std::string &arg, std::string *error) override;
 
  private:
-    Regex *m_re;
+    Regex *m_re = nullptr;
 };
 
 

--- a/src/operators/rx_global.h
+++ b/src/operators/rx_global.h
@@ -37,8 +37,7 @@ class RxGlobal : public Operator {
  public:
     /** @ingroup ModSecurity_Operator */
     explicit RxGlobal(std::unique_ptr<RunTimeString> param)
-        : m_re(nullptr),
-        Operator("RxGlobal", std::move(param)) {
+        : Operator("RxGlobal", std::move(param)) {
             m_couldContainsMacro = true;
         }
 
@@ -59,7 +58,7 @@ class RxGlobal : public Operator {
     bool init(const std::string &arg, std::string *error) override;
 
  private:
-    Regex *m_re;
+    Regex *m_re = nullptr;
 };
 
 

--- a/src/operators/validate_url_encoding.cc
+++ b/src/operators/validate_url_encoding.cc
@@ -25,14 +25,13 @@ namespace operators {
 
 int ValidateUrlEncoding::validate_url_encoding(const char *input,
     uint64_t input_length, size_t *offset) {
-    int i;
+    uint64_t i = 0;
     *offset = 0;
 
     if ((input == NULL) || (input_length == 0)) {
         return -1;
     }
 
-    i = 0;
     while (i < input_length) {
         if (input[i] == '%') {
             if (i + 2 >= input_length) {

--- a/src/parser/driver.cc
+++ b/src/parser/driver.cc
@@ -108,7 +108,7 @@ int Driver::addSecRule(std::unique_ptr<RuleWithActions> r) {
 
     for (int i = 0; i < modsecurity::Phases::NUMBER_OF_PHASES; i++) {
         const Rules *rules = m_rulesSetPhases[i];
-        for (int j = 0; j < rules->size(); j++) {
+        for (size_t j = 0; j < rules->size(); j++) {
             const RuleWithOperator *lr = dynamic_cast<RuleWithOperator *>(rules->at(j).get());
             if (lr && lr->m_ruleId == rule->m_ruleId) {
                 m_parserError << "Rule id: " << std::to_string(rule->m_ruleId) \

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -2588,7 +2588,6 @@ var:
     | RUN_TIME_VAR_DUR
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         $$ = std::move(c);
       }
@@ -2596,84 +2595,72 @@ var:
     | RUN_TIME_VAR_BLD
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_HSV
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_REMOTE_USER
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_DAY
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_EPOCH
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_HOUR
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_MIN
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_MON
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_SEC
       {
         std::string name($1);
-        char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_WDAY
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         $$ = std::move(c);
       }
     | RUN_TIME_VAR_TIME_YEAR
       {
         std::string name($1);
-        char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         $$ = std::move(c);
       }

--- a/src/request_body_processor/multipart.cc
+++ b/src/request_body_processor/multipart.cc
@@ -558,7 +558,7 @@ int Multipart::process_part_data(std::string *error, size_t offset) {
 
         /* check if the file limit has been reached */
         if (extract && m_transaction->m_rules->m_uploadFileLimit.m_value
-            && (m_nfiles >=
+            && (static_cast<uint32_t>(m_nfiles) >=
                 m_transaction->m_rules->m_uploadFileLimit.m_value)) {
             if (m_flag_file_limit_exceeded == 0) {
                 ms_dbg_a(m_transaction, 1,

--- a/src/rules_set.cc
+++ b/src/rules_set.cc
@@ -144,7 +144,7 @@ int RulesSet::evaluate(int phase, Transaction *t) {
     t->m_allowType = actions::disruptive::NoneAllowType;
     //}
 
-    for (int i = 0; i < rules->size(); i++) {
+    for (size_t i = 0; i < rules->size(); i++) {
         // FIXME: This is not meant to be here. At the end of this refactoring,
         //        the shared pointer won't be used.
         auto rule = rules->at(i);

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -118,7 +118,8 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, const char *id, void 
 
 Transaction::Transaction(ModSecurity *ms, RulesSet *rules, const char *id,
     void *logCbData, const time_t timestamp)
-    : m_creationTimeStamp(utils::cpu_seconds()),
+    : TransactionAnchoredVariables(this),
+    m_creationTimeStamp(utils::cpu_seconds()),
     m_ARGScombinedSizeDouble(0),
     m_clientPort(0),
     m_highestSeverityAction(255),
@@ -149,8 +150,7 @@ Transaction::Transaction(ModSecurity *ms, RulesSet *rules, const char *id,
 #endif
     m_secRuleEngine(RulesSetProperties::PropertyNotSetRuleEngine),
     m_secXMLParseXmlIntoArgs(rules->m_secXMLParseXmlIntoArgs),
-    m_logCbData(logCbData),
-    TransactionAnchoredVariables(this) {
+    m_logCbData(logCbData) {
     m_variableUrlEncodedError.set("0", 0);
     m_variableMscPcreError.set("0", 0);
     m_variableMscPcreLimitsExceeded.set("0", 0);

--- a/src/transaction.cc
+++ b/src/transaction.cc
@@ -770,7 +770,7 @@ int Transaction::processRequestBody() {
     if (m_requestBodyType == MultiPartRequestBody) {
 #endif
         std::string error;
-        int reqbodyNoFilesLength = 0;
+        uint64_t reqbodyNoFilesLength = 0;
         if (a != NULL) {
             Multipart m(*a, this);
             if (m.init(&error) == true) {

--- a/src/utils/msc_tree.cc
+++ b/src/utils/msc_tree.cc
@@ -298,7 +298,7 @@ int InsertNetmask(TreeNode *node, TreeNode *parent, TreeNode *new_node,
 TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree *tree, unsigned char netmask)   {
     unsigned char *buffer = NULL;
     unsigned char bitlen = 0;
-    int bit_validation = 0, test_bit = 0;
+    unsigned int bit_validation = 0, test_bit = 0;
     size_t i = 0;
     unsigned int x, y;
     TreeNode *node = NULL, *new_node = NULL;
@@ -357,7 +357,7 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
     else
         bit_validation = bitlen;
 
-    for (i = 0; (i * NETMASK_8) < bit_validation; i++) {
+    for (i = 0; (i * NETMASK_8) < static_cast<size_t>(bit_validation); i++) {
         int net = 0, div = 0;
         int cnt = 0;
         int temp;
@@ -483,8 +483,8 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
 
         if (node->netmasks != NULL) {
             i = 0;
-            int j;
-            while(i < node->count) {
+            size_t j;
+            while (i < static_cast<size_t>(node->count)) {
                 if (node->netmasks[i] < test_bit + 1)
                     break;
                 i++;
@@ -501,7 +501,7 @@ TreeNode *CPTAddElement(unsigned char *ipdata, unsigned int ip_bitmask, CPTTree 
             }
 
             j = 0;
-            while (j < (node->count - i))   {
+            while (j < static_cast<size_t>(node->count) - i) {
                 i_node->netmasks[j] = node->netmasks[i + j];
                 j++;
             }
@@ -833,19 +833,22 @@ TreeNode *CPTIpMatch(unsigned char *ipdata, CPTTree *tree, int type)   {
 }
 
 TreeNode *TreeAddIP(const char *buffer, CPTTree *tree, int type) {
-    unsigned long ip;
     int ret;
     unsigned char netmask_v4 = NETMASK_32, netmask_v6 = NETMASK_128;
     char ip_strv4[NETMASK_32], ip_strv6[NETMASK_128];
     struct in_addr addr4;
     struct in6_addr addr6;
-    int pos = 0;
+    const char *slash = NULL;
+    size_t pos = 0;
     char *ptr = NULL;
 
     if(tree == NULL)
         return NULL;
 
-    pos = strchr(buffer, '/') - buffer;
+    slash = strchr(buffer, '/');
+    if (slash != NULL) {
+        pos = static_cast<size_t>(slash - buffer);
+    }
 
     switch(type)    {
 
@@ -871,7 +874,7 @@ TreeNode *TreeAddIP(const char *buffer, CPTTree *tree, int type) {
             if (netmask_v4 == 0) {
                 return NULL;
             }
-            else if (pos < strlen(ip_strv4)) {
+            else if (slash != NULL && pos < strlen(ip_strv4)) {
                 ip_strv4[pos] = '\0';
             }
 
@@ -908,7 +911,8 @@ TreeNode *TreeAddIP(const char *buffer, CPTTree *tree, int type) {
             if(netmask_v6 == 0) {
                 return NULL;
             }
-            else if (netmask_v6 != NETMASK_128 && pos < strlen(ip_strv6)) {
+            else if (slash != NULL && netmask_v6 != NETMASK_128 &&
+                pos < strlen(ip_strv6)) {
                 ip_strv6[pos] = '\0';
             }
 

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -89,7 +89,7 @@ inline std::string dash_if_empty(const std::string *str) {
 }
 
 
-inline std::string limitTo(int amount, const std::string &str) {
+inline std::string limitTo(std::string::size_type amount, const std::string &str) {
     std::string ret;
 
     if (str.length() > amount) {

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -634,7 +634,7 @@ class Variable : public VariableMonkeyResolution {
 class VariableDictElement : public Variable {
  public:
     VariableDictElement(const std::string &name, const std::string &dict_element)
-        :  m_dictElement(dict_element), Variable(name + ":" + dict_element) { }
+        : Variable(name + ":" + dict_element), m_dictElement(dict_element) { }
 
     std::string m_dictElement;
 };

--- a/src/variables/variable.h
+++ b/src/variables/variable.h
@@ -643,9 +643,9 @@ class VariableDictElement : public Variable {
 class VariableRegex : public Variable {
  public:
     VariableRegex(const std::string &name, const std::string &regex)
-        :  m_r(regex, true),
-        m_regex(regex),
-        Variable(name + ":" + "regex(" + regex + ")") { }
+        : Variable(name + ":" + "regex(" + regex + ")"),
+        m_r(regex, true),
+        m_regex(regex) { }
 
     Utils::Regex m_r;
     // FIXME: no need for that.


### PR DESCRIPTION
## what

- Fix compiler warnings reported when building with GCC and Fedora/RHEL-style flags (`-Wall`, hardening, ...).
- Each commit targets one warning class / location where practical.
- Build log warnings reduced from ~1270 to ~57 (same Fedora 45 / 3.0.15 build); remainder left for follow-up PRs.

## why

- Clean build logs are just better.
- Fewer noisy warnings makes real regressions easier to spot in CI/packaging builds.

## references

- Fedora 45 build log without the patches: https://kojipkgs.fedoraproject.org//packages/libmodsecurity/3.0.15/1.fc45/data/logs/x86_64/build.log
- Fedora 45 build log with these patches (temp logs): https://kojipkgs.fedoraproject.org//work/tasks/231/145490231/build.log
