### PR TITLE
ci: pin Windows version in workflow

### DIFF
--- a/.github/workflows/ci_new.yml
+++ b/.github/workflows/ci_new.yml
@@ -172,7 +172,7 @@ jobs:
 
   build-windows:
     name: Windows (${{ matrix.platform.label }}, ${{ matrix.configure.label }})
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## what

This PR pins the Windows version in CI workflow.

## why

It seems like GH upgraded the machines and we need to align the workflow for the new environments. Until then, I just pinned the last stable version.

