### PR TITLE
fix: cppcheck warnings with version 2.21.0

### DIFF
--- a/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
+++ b/examples/reading_logs_via_rule_message/reading_logs_via_rule_message.h
@@ -96,20 +96,20 @@ static void process_request(modsecurity::ModSecurity *modsec, modsecurity::Rules
 
 class ReadingLogsViaRuleMessage {
  public:
-    ReadingLogsViaRuleMessage(char *request_header,
-        char *request_uri,
-        char *request_body,
-        char *response_headers,
-        char *response_body,
-        char *ip,
-        const std::string &rules) :
-            m_request_header(request_header),
-            m_request_uri(request_uri),
-            m_request_body(request_body),
-            m_response_headers(response_headers),
-            m_response_body(response_body),
-            m_ip(ip),
-            m_rules(rules)
+    ReadingLogsViaRuleMessage(char *arg_request_header,
+        char *arg_request_uri,
+        char *arg_request_body,
+        char *arg_response_headers,
+        char *arg_response_body,
+        char *arg_ip,
+        const std::string &arg_rules) :
+            m_request_header(arg_request_header),
+            m_request_uri(arg_request_uri),
+            m_request_body(arg_request_body),
+            m_response_headers(arg_response_headers),
+            m_response_body(arg_response_body),
+            m_ip(arg_ip),
+            m_rules(arg_rules)
         { }
 
     int process() const {

--- a/headers/modsecurity/transaction.h
+++ b/headers/modsecurity/transaction.h
@@ -405,7 +405,7 @@ class Transaction : public TransactionAnchoredVariables, public TransactionSecMa
     size_t getRequestBodyLength();
 
 #ifndef NO_LOGS
-    void debug(int, const std::string &) const;
+    void debug(int level, const std::string& message) const;
 #endif
     void serverLog(const RuleMessage &rm);
 

--- a/src/modsecurity.cc
+++ b/src/modsecurity.cc
@@ -391,7 +391,7 @@ void ModSecurity::setServerLogCb(ModSecLogCb cb) {
 }
 
 
-void ModSecurity::setServerLogCb(ModSecLogCb cb, int properties) {
+void ModSecurity::setServerLogCb(ModSecLogCb cb, int properties) { // cppcheck-suppress funcArgNamesDifferentUnnamed - this is a false positive
     m_logCb = (ModSecLogCb) cb;
     m_logProperties = properties;
 }

--- a/src/request_body_processor/xml.h
+++ b/src/request_body_processor/xml.h
@@ -60,7 +60,7 @@ class XMLNodes {
         // need to stop parsing if the number of arguments reached the limit
         xmlParserCtxtPtr  parsing_ctx_arg;
 
-        explicit XMLNodes (Transaction *);
+        explicit XMLNodes (Transaction *transaction);
         ~XMLNodes();
 };
 
@@ -69,7 +69,7 @@ struct xml_data {
     xmlParserCtxtPtr parsing_ctx;
     xmlDocPtr doc;
 
-    unsigned int well_formed;
+    unsigned int well_formed = 0;
 
     /* error reporting and XML array flag */
     std::string               xml_error;

--- a/src/request_body_processor/xml.h
+++ b/src/request_body_processor/xml.h
@@ -60,7 +60,7 @@ class XMLNodes {
         // need to stop parsing if the number of arguments reached the limit
         xmlParserCtxtPtr  parsing_ctx_arg;
 
-        explicit XMLNodes (Transaction *transaction);
+        explicit XMLNodes(Transaction *transaction);
         ~XMLNodes();
 };
 

--- a/src/utils/shared_files.h
+++ b/src/utils/shared_files.h
@@ -55,11 +55,11 @@ private:
     void operator=(SharedFiles const&) = delete;
 
      struct handler_info {
-         FILE* fp;
+         FILE* fp = nullptr;
 #ifdef WIN32
-         HANDLE hMutex;
+         HANDLE hMutex = nullptr;
 #endif
-         unsigned int cnt;
+         unsigned int cnt = 0;
      };
 
     using handlers_map = std::unordered_map<std::string, handler_info>;

--- a/test/common/modsecurity_test.h
+++ b/test/common/modsecurity_test.h
@@ -34,7 +34,7 @@ template <class T> class ModSecurityTest :
     ModSecurityTest() = default;
 
     std::string header();
-    void cmd_options(int, char **);
+    void cmd_options(int argc, char** argv);
     void load_tests();
     void load_tests(const std::string &path);
     bool load_test_json(const std::string &file);

--- a/test/common/modsecurity_test_results.h
+++ b/test/common/modsecurity_test_results.h
@@ -25,7 +25,7 @@ namespace modsecurity_test {
 template <class T> class ModSecurityTestResults : public std::vector<T *> {
  public:
     std::string log_raw_debug_log;
-    int status;
+    int status = 0;
     std::string location;
 };
 

--- a/test/regression/regression_test.h
+++ b/test/regression/regression_test.h
@@ -32,7 +32,7 @@ namespace modsecurity_test {
 
 class RegressionTest {
  public:
-    static std::unique_ptr<RegressionTest> from_yajl_node(const yajl_val &);
+    static std::unique_ptr<RegressionTest> from_yajl_node(const yajl_val &node);
 
     static std::string print();
     std::string filename;
@@ -42,8 +42,8 @@ class RegressionTest {
     std::string rules;
 
     std::string url;
-    int enabled;
-    int version_min;
+    int enabled = 0;
+    int version_min = 0;
     std::optional<int> version_max;
     std::optional<int> github_issue;
 
@@ -60,8 +60,8 @@ class RegressionTest {
 
     std::string clientIp;
     std::string serverIp;
-    int clientPort;
-    int serverPort;
+    int clientPort = 0;
+    int serverPort = 0;
     std::string hostname;
 
     std::string method;
@@ -75,7 +75,7 @@ class RegressionTest {
     static inline std::vector<std::pair<std::string, std::string>>
         yajl_array_to_map(const yajl_val &node);
 
-    int http_code;
+    int http_code = 0;
     std::string redirect_url;
 
     // fields for formatting JSON
@@ -96,7 +96,7 @@ private:
 
 class RegressionTests {
  public:
-    static std::unique_ptr<RegressionTests> from_yajl_node(const yajl_val &);
+    static std::unique_ptr<RegressionTests> from_yajl_node(const yajl_val &node);
     void update_content_lengths();
     std::string toJSON() const;
 

--- a/test/unit/unit_test.h
+++ b/test/unit/unit_test.h
@@ -27,13 +27,13 @@ namespace modsecurity_test {
 
 class UnitTestResult {
  public:
-    int ret;
+    int ret = 0;
     std::string output;
 };
 
 class UnitTest {
  public:
-    static std::unique_ptr<UnitTest> from_yajl_node(const yajl_val &);
+    static std::unique_ptr<UnitTest> from_yajl_node(const yajl_val &node);
 
     std::string print() const;
 
@@ -45,9 +45,9 @@ class UnitTest {
     std::string filename;
     std::string output;
     std::string libinjection_override;
-    int ret;
-    int capture;
-    int skipped;
+    int ret = 0;
+    int capture = 0;
+    int skipped = 0;
     UnitTestResult result;
 };
 


### PR DESCRIPTION
## what

Fix newest cppcheck (2.21.0) warnings.

## why

Recently there were a few cppcheck warnings in our CI workflows.

## references

Eg.: [this](https://github.com/owasp-modsecurity/ModSecurity/actions/runs/27267337259/job/80574671957?pr=3573) one.