### PR TITLE
create fopen_modsec

### DIFF
--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -1,3 +1,4 @@
+
 #line 3 "seclang-scanner.cc"
 
 #define  YY_INT_ALIGNED short int
@@ -8400,7 +8401,7 @@ YY_RULE_SETUP
         driver.loc.push_back(new yy::location());
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
-        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) { // NOSONAR
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);
@@ -8431,8 +8432,7 @@ YY_RULE_SETUP
         driver.loc.push_back(new yy::location());
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
-
-        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) { // NOSONAR
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);

--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -1,4 +1,3 @@
-
 #line 3 "seclang-scanner.cc"
 
 #define  YY_INT_ALIGNED short int
@@ -4953,6 +4952,7 @@ char *yytext;
 #include "src/parser/seclang-parser.hh"
 #include "src/utils/https_client.h"
 #include "src/utils/string.h"
+#include "src/utils/system.h"
 
 using modsecurity::Parser::Driver;
 using modsecurity::Utils::HttpsClient;
@@ -8400,8 +8400,7 @@ YY_RULE_SETUP
         driver.loc.push_back(new yy::location());
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
-        yyin = fopen(f.c_str(), "r" );
-        if (!yyin) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) {
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);
@@ -8433,8 +8432,7 @@ YY_RULE_SETUP
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
 
-        yyin = fopen(f.c_str(), "r" );
-        if (!yyin) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) {
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);

--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -8401,7 +8401,7 @@ YY_RULE_SETUP
         driver.loc.push_back(new yy::location());
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
-        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) { // NOSONAR
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r")) { // NOSONAR
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);
@@ -8432,7 +8432,7 @@ YY_RULE_SETUP
         driver.loc.push_back(new yy::location());
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
-        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) { // NOSONAR
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r")) { // NOSONAR
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -1,4 +1,4 @@
-/* -*- C++ -*- */
+%{ /* -*- C++ -*- */
 #include <cerrno>
 #include <climits>
 #include <cstdlib>

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -1303,7 +1303,7 @@ EQUALS_MINUS                            (?i:=\-)
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
 
-        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r")) {
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);

--- a/src/parser/seclang-scanner.ll
+++ b/src/parser/seclang-scanner.ll
@@ -1,4 +1,4 @@
-%{ /* -*- C++ -*- */
+/* -*- C++ -*- */
 #include <cerrno>
 #include <climits>
 #include <cstdlib>
@@ -8,6 +8,7 @@
 #include "src/parser/seclang-parser.hh"
 #include "src/utils/https_client.h"
 #include "src/utils/string.h"
+#include "src/utils/system.h"
 
 using modsecurity::Parser::Driver;
 using modsecurity::Utils::HttpsClient;
@@ -1273,8 +1274,7 @@ EQUALS_MINUS                            (?i:=\-)
         driver.loc.push_back(new yy::location());
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
-        yyin = fopen(f.c_str(), "r" );
-        if (!yyin) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r")) {
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);
@@ -1303,8 +1303,7 @@ EQUALS_MINUS                            (?i:=\-)
         driver.m_filenames.push_back(f);
         driver.loc.back()->begin.filename = driver.loc.back()->end.filename = &(driver.m_filenames.back());
 
-        yyin = fopen(f.c_str(), "r" );
-        if (!yyin) {
+        if (!modsecurity::utils::fopen_modsec(&yyin, f.c_str(), "r") != 0) {
             BEGIN(INITIAL);
             driver.loc.pop_back();
             driver.error (*driver.loc.back(), "", s + std::string(": Not able to open file. ") + err);

--- a/src/utils/shared_files.cc
+++ b/src/utils/shared_files.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/utils/shared_files.h"
+#include "src/utils/system.h"
 
 #include <fcntl.h>
 #ifdef WIN32
@@ -27,8 +28,8 @@ namespace utils {
 
 SharedFiles::handlers_map::iterator SharedFiles::add_new_handler(
     const std::string &fileName, std::string *error) {
-    FILE *fp = fopen(fileName.c_str(), "a");
-    if (fp == 0) {
+    FILE *fp;
+    if (!fopen_modsec(&fp, fileName.c_str(), "a")) {
         error->assign("Failed to open file: " + fileName);
         return m_handlers.end();
     }

--- a/src/utils/system.cc
+++ b/src/utils/system.cc
@@ -13,7 +13,6 @@
  *
  */
 
-#include <bits/types/FILE.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -228,11 +227,12 @@ bool fopen_modsec(FILE **v_fp, const char *filename, const char *mode) {
     if (v_fp == nullptr || filename == nullptr || mode == nullptr) {
         return false;
     }
-    *v_fp = fopen(filename, mode);
-    if (*v_fp == nullptr) {
-        return false;
-    }
-    return true;
+#if defined(_MSC_VER)
+     return fopen_s(v_fp, filename, mode) == 0 && *v_fp != nullptr;
+#else
+      *v_fp = fopen(filename, mode);
+      return *v_fp != nullptr;
+#endif
 }
 #if defined(_MSC_VER)
 #pragma warning(pop)

--- a/src/utils/system.cc
+++ b/src/utils/system.cc
@@ -220,15 +220,22 @@ bool isFile(const std::string& f) {
     return true;
 }
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
 bool fopen_modsec(FILE **v_fp, const char *filename, const char *mode) {
-    if (v_fp == NULL || filename == NULL || mode == NULL) {
+    if (v_fp == nullptr || filename == nullptr || mode == nullptr) {
         return false;
     }
     *v_fp = fopen(filename, mode);
-    if (*v_fp == NULL) {
+    if (*v_fp == nullptr) {
         return false;
     }
     return true;
 }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 }  // namespace utils
 }  // namespace modsecurity

--- a/src/utils/system.cc
+++ b/src/utils/system.cc
@@ -13,6 +13,7 @@
  *
  */
 
+#include <bits/types/FILE.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -205,8 +206,8 @@ bool createDir(const std::string& dir, int mode, std::string *error) {
 
 bool isFile(const std::string& f) {
     struct stat fileInfo;
-    FILE *fp = fopen(f.c_str(), "r");
-    if (fp == NULL) {
+    FILE *fp;
+    if (!fopen_modsec(&fp, f.c_str(), "r")) {
         return false;
     }
     fstat(fileno(fp), &fileInfo);
@@ -219,6 +220,15 @@ bool isFile(const std::string& f) {
     return true;
 }
 
-
+bool fopen_modsec(FILE **v_fp, const char *filename, const char *mode) {
+    if (v_fp == NULL || filename == NULL || mode == NULL) {
+        return false;
+    }
+    *v_fp = fopen(filename, mode);
+    if (*v_fp == NULL) {
+        return false;
+    }
+    return true;
+}
 }  // namespace utils
 }  // namespace modsecurity

--- a/src/utils/system.h
+++ b/src/utils/system.h
@@ -33,6 +33,7 @@ std::string get_path(const std::string& file);
 std::list<std::string> expandEnv(const std::string& var, int flags);
 bool createDir(const std::string& dir, int mode, std::string *error);
 bool isFile(const std::string& f);
+bool fopen_modsec(FILE **v_fp, const char *filename, const char *mode);
 
 }  // namespace utils
 }  // namespace modsecurity

--- a/src/utils/system.h
+++ b/src/utils/system.h
@@ -13,6 +13,8 @@
  *
  */
 
+#include <stdio.h>
+
 #include <string>
 #include <list>
 


### PR DESCRIPTION
## what
Since fopen_s, which is used in win32, is more secure, we defined and implemented it internally so that it can be used in other operating systems as well.
Since `fopen_s` can have name conflicts, we're creating it as `fopen_modsec`.

## why
SonarCloud Code Analysis has started causing errors with fopen.
```
'fopen' is deprecated: This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```
## references
The goal is to resolve this error.
https://github.com/owasp-modsecurity/ModSecurity/pull/3521/changes#diff-2f0c197bfdbe90b112359e18d7980ca2c8535fe1cbd47ce1029c27130812de2aR113
