### PR TITLE
chore: fix cppcheck issues with v2.21.0

### DIFF
--- a/standalone/filters.c
+++ b/standalone/filters.c
@@ -65,7 +65,7 @@ void init_filter_tables()
 
 
 AP_DECLARE(ap_filter_rec_t *) ap_register_input_filter(const char *name,
-                                          ap_in_filter_func filter_func, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                                          ap_in_filter_func filter_func,
                                           ap_init_filter_func filter_init, // cppcheck-suppress funcArgNamesDifferentUnnamed
                                           ap_filter_type ftype) // cppcheck-suppress funcArgNamesDifferentUnnamed
 {
@@ -86,7 +86,7 @@ AP_DECLARE(ap_filter_rec_t *) ap_register_input_filter(const char *name,
 }
 
 AP_DECLARE(ap_filter_rec_t *) ap_register_output_filter(const char *name,
-                                            ap_out_filter_func filter_func, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                                            ap_out_filter_func filter_func,
                                             ap_init_filter_func filter_init, // cppcheck-suppress funcArgNamesDifferentUnnamed
                                             ap_filter_type ftype) // cppcheck-suppress funcArgNamesDifferentUnnamed
 {

--- a/standalone/filters.c
+++ b/standalone/filters.c
@@ -63,10 +63,11 @@ void init_filter_tables()
 	}
 }
 
+
 AP_DECLARE(ap_filter_rec_t *) ap_register_input_filter(const char *name,
-                                          ap_in_filter_func filter_func,
-                                          ap_init_filter_func filter_init,
-                                          ap_filter_type ftype)
+                                          ap_in_filter_func filter_func, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                                          ap_init_filter_func filter_init, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                                          ap_filter_type ftype) // cppcheck-suppress funcArgNamesDifferentUnnamed
 {
 	ap_filter_rec_t *f;
 
@@ -85,9 +86,9 @@ AP_DECLARE(ap_filter_rec_t *) ap_register_input_filter(const char *name,
 }
 
 AP_DECLARE(ap_filter_rec_t *) ap_register_output_filter(const char *name,
-                                            ap_out_filter_func filter_func,
-                                            ap_init_filter_func filter_init,
-                                            ap_filter_type ftype)
+                                            ap_out_filter_func filter_func, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                                            ap_init_filter_func filter_init, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                                            ap_filter_type ftype) // cppcheck-suppress funcArgNamesDifferentUnnamed
 {
 	ap_filter_rec_t *f;
 	

--- a/standalone/hooks.c
+++ b/standalone/hooks.c
@@ -50,16 +50,16 @@ link##_DECLARE(void) ns##_hook_##name(ns##_HOOK_##name##_t *pf, \
 #define DECLARE_HOOK(ret,name,args) \
 	DECLARE_EXTERNAL_HOOK(ap,AP,ret,name,args)
 
-DECLARE_HOOK(int,pre_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp))
-DECLARE_HOOK(int,post_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp,server_rec *s))
-DECLARE_HOOK(void,child_init,(apr_pool_t *pchild, server_rec *s))
-DECLARE_HOOK(int,process_connection,(conn_rec *c))
-DECLARE_HOOK(int,post_read_request,(request_rec *r))
-DECLARE_HOOK(int,fixups,(request_rec *r))
-DECLARE_HOOK(void, error_log, (const char *file, int line, int level,
-                       apr_status_t status, const server_rec *s,
-                       const request_rec *r, apr_pool_t *pool,
-                       const char *errstr))
-DECLARE_HOOK(int,log_transaction,(request_rec *r))
-DECLARE_HOOK(void,insert_filter,(request_rec *r))
-DECLARE_HOOK(void,insert_error_filter,(request_rec *r))
+DECLARE_HOOK(int,pre_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(int,post_config,(apr_pool_t *pconf,apr_pool_t *plog, apr_pool_t *ptemp,server_rec *s)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(void,child_init,(apr_pool_t *pchild, server_rec *s)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(int,process_connection,(conn_rec *c)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(int,post_read_request,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(int,fixups,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(void, error_log, (const char *file, int line, int level, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                       apr_status_t status, const server_rec *s, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                       const request_rec *r, apr_pool_t *pool, // cppcheck-suppress funcArgNamesDifferentUnnamed
+                       const char *errstr)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(int,log_transaction,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(void,insert_filter,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+DECLARE_HOOK(void,insert_error_filter,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed

--- a/standalone/hooks.c
+++ b/standalone/hooks.c
@@ -57,9 +57,9 @@ DECLARE_HOOK(int,process_connection,(conn_rec *c)) // cppcheck-suppress funcArgN
 DECLARE_HOOK(int,post_read_request,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
 DECLARE_HOOK(int,fixups,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
 DECLARE_HOOK(void, error_log, (const char *file, int line, int level, // cppcheck-suppress funcArgNamesDifferentUnnamed
-                       apr_status_t status, const server_rec *s, // cppcheck-suppress funcArgNamesDifferentUnnamed
-                       const request_rec *r, apr_pool_t *pool, // cppcheck-suppress funcArgNamesDifferentUnnamed
-                       const char *errstr)) // cppcheck-suppress funcArgNamesDifferentUnnamed
+                       apr_status_t status, const server_rec *s,
+                       const request_rec *r, apr_pool_t *pool,
+                       const char *errstr))
 DECLARE_HOOK(int,log_transaction,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
 DECLARE_HOOK(void,insert_filter,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed
 DECLARE_HOOK(void,insert_error_filter,(request_rec *r)) // cppcheck-suppress funcArgNamesDifferentUnnamed


### PR DESCRIPTION
## what

Fix cppcheck issues with the newest cppcheck version (2.21.0).

I think this warning is a false positive, and caused some wrong macro expansion.

## why

Recent PRs' cppcheck were failed, eg. [this](https://github.com/owasp-modsecurity/ModSecurity/actions/runs/28531440008/job/84581708547?pr=3592).


