### PR TITLE
fix(collections): Honour SecDataDir for LMDB, fix literal setvar writ…

### DIFF
--- a/headers/modsecurity/collection/collection.h
+++ b/headers/modsecurity/collection/collection.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <memory>
 #include <cstdint>
+#include <cctype>
 #endif
 
 
@@ -46,6 +47,23 @@ class Collection {
  public:
     explicit Collection(const std::string &a) : m_name(a) { }
     virtual ~Collection() { }
+
+    /*
+     * Collection variable names are case-insensitive in SecLang (e.g.
+     * `setvar:ip.counter` and `IP:COUNTER` refer to the same key). Normalise
+     * the variable-name term of the composite LMDB key to lowercase so that
+     * writes and reads performed with different casing hit the same entry.
+     * The compartment values (collection key, web app id) are intentionally
+     * left untouched since they may be opaque, case-sensitive identifiers.
+     */
+    static std::string normKey(const std::string &k) {
+        std::string out;
+        out.reserve(k.size());
+        for (char c : k) {
+            out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+        }
+        return out;
+    }
 
     virtual bool storeOrUpdateFirst(const std::string &key,
         const std::string &value) = 0;
@@ -73,7 +91,7 @@ class Collection {
     /* storeOrUpdateFirst */
     virtual bool storeOrUpdateFirst(const std::string &key,
         std::string compartment, const std::string &value) {
-        std::string nkey = compartment + "::" + key;
+        std::string nkey = compartment + "::" + normKey(key);
         return storeOrUpdateFirst(nkey, value);
     }
 
@@ -81,7 +99,7 @@ class Collection {
     virtual bool storeOrUpdateFirst(const std::string &key,
         std::string compartment, std::string compartment2,
         const std::string &value) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + key;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(key);
         return storeOrUpdateFirst(nkey, value);
     }
 
@@ -89,28 +107,28 @@ class Collection {
     /* updateFirst */
     virtual bool updateFirst(const std::string &key, std::string compartment,
         const std::string &value) {
-        std::string nkey = compartment + "::" + key;
+        std::string nkey = compartment + "::" + normKey(key);
         return updateFirst(nkey, value);
     }
 
 
     virtual bool updateFirst(const std::string &key, std::string compartment,
         std::string compartment2, const std::string &value) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + key;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(key);
         return updateFirst(nkey, value);
     }
 
 
     /* del */
     virtual void del(const std::string& key, std::string compartment) {
-        std::string nkey = compartment + "::" + key;
+        std::string nkey = compartment + "::" + normKey(key);
         del(nkey);
     }
 
 
     virtual void del(const std::string& key, std::string compartment,
         std::string compartment2) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + key;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(key);
         del(nkey);
     }
 
@@ -118,14 +136,14 @@ class Collection {
     /* setExpiry */
     virtual void setExpiry(const std::string& key, std::string compartment,
         int32_t expiry_seconds) {
-        std::string nkey = compartment + "::" + key;
+        std::string nkey = compartment + "::" + normKey(key);
         setExpiry(nkey, expiry_seconds);
     }
 
 
     virtual void setExpiry(const std::string& key, std::string compartment,
         std::string compartment2, int32_t expiry_seconds) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + key;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(key);
         setExpiry(nkey, expiry_seconds);
     }
 
@@ -133,14 +151,14 @@ class Collection {
     /* resolveFirst */
     virtual std::unique_ptr<std::string> resolveFirst(const std::string& var,
         std::string compartment) {
-        std::string nkey = compartment + "::" + var;
+        std::string nkey = compartment + "::" + normKey(var);
         return resolveFirst(nkey);
     }
 
 
     virtual std::unique_ptr<std::string> resolveFirst(const std::string& var,
         std::string compartment, std::string compartment2) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + var;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(var);
         return resolveFirst(nkey);
     }
 
@@ -148,7 +166,7 @@ class Collection {
     /* resolveSingleMatch */
     virtual void resolveSingleMatch(const std::string& var,
         std::string compartment, std::vector<const VariableValue *> *l) {
-        std::string nkey = compartment + "::" + var;
+        std::string nkey = compartment + "::" + normKey(var);
         resolveSingleMatch(nkey, l);
     }
 
@@ -156,7 +174,7 @@ class Collection {
     virtual void resolveSingleMatch(const std::string& var,
         std::string compartment, std::string compartment2,
         std::vector<const VariableValue *> *l) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + var;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(var);
         resolveSingleMatch(nkey, l);
     }
 
@@ -165,7 +183,7 @@ class Collection {
     virtual void resolveMultiMatches(const std::string& var,
         std::string compartment, std::vector<const VariableValue *> *l,
         variables::KeyExclusions &ke) {
-        std::string nkey = compartment + "::" + var;
+        std::string nkey = compartment + "::" + normKey(var);
         resolveMultiMatches(nkey, l, ke);
     }
 
@@ -174,7 +192,7 @@ class Collection {
         std::string compartment, std::string compartment2,
         std::vector<const VariableValue *> *l,
         variables::KeyExclusions &ke) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + var;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(var);
         resolveMultiMatches(nkey, l, ke);
     }
 
@@ -183,7 +201,7 @@ class Collection {
     virtual void resolveRegularExpression(const std::string& var,
         std::string compartment, std::vector<const VariableValue *> *l,
         variables::KeyExclusions &ke) {
-        std::string nkey = compartment + "::" + var;
+        std::string nkey = compartment + "::" + normKey(var);
         resolveRegularExpression(nkey, l, ke);
     }
 
@@ -191,7 +209,7 @@ class Collection {
     virtual void resolveRegularExpression(const std::string& var,
         std::string compartment, std::string compartment2,
         std::vector<const VariableValue *> *l, variables::KeyExclusions &ke) {
-        std::string nkey = compartment + "::" + compartment2 + "::" + var;
+        std::string nkey = compartment + "::" + compartment2 + "::" + normKey(var);
         resolveRegularExpression(nkey, l, ke);
     }
 

--- a/headers/modsecurity/rules_set_properties.h
+++ b/headers/modsecurity/rules_set_properties.h
@@ -522,6 +522,8 @@ class RulesSetProperties {
 
         to->m_secWebAppId.merge(&from->m_secWebAppId);
 
+        to->m_secDataDir.merge(&from->m_secDataDir);
+
         to->m_unicodeMapTable.merge(&from->m_unicodeMapTable);
 
         to->m_httpblKey.merge(&from->m_httpblKey);
@@ -620,6 +622,7 @@ class RulesSetProperties {
     ConfigString m_uploadTmpDirectory;
     ConfigString m_secArgumentSeparator;
     ConfigString m_secWebAppId;
+    ConfigString m_secDataDir;
     std::vector<std::shared_ptr<actions::Action> > \
         m_defaultActions[modsecurity::Phases::NUMBER_OF_PHASES];
     ConfigUnicodeMap m_unicodeMapTable;

--- a/src/actions/set_var.cc
+++ b/src/actions/set_var.cc
@@ -86,7 +86,30 @@ bool SetVar::evaluate(RuleWithActions *rule, Transaction *t) {
         } else if (user) {
             user->del(t, m_variableNameExpanded);
         } else {
-            // ?
+            const std::string &col = m_variable->m_collectionName;
+            if (col == "TX") {
+                t->m_collections.m_tx_collection->del(m_variableNameExpanded);
+            } else if (col == "IP") {
+                t->m_collections.m_ip_collection->del(m_variableNameExpanded,
+                    t->m_collections.m_ip_collection_key,
+                    t->m_rules->m_secWebAppId.m_value);
+            } else if (col == "SESSION") {
+                t->m_collections.m_session_collection->del(m_variableNameExpanded,
+                    t->m_collections.m_session_collection_key,
+                    t->m_collections.m_ip_collection_key);
+            } else if (col == "USER") {
+                t->m_collections.m_user_collection->del(m_variableNameExpanded,
+                    t->m_collections.m_user_collection_key,
+                    t->m_rules->m_secWebAppId.m_value);
+            } else if (col == "RESOURCE") {
+                t->m_collections.m_resource_collection->del(m_variableNameExpanded,
+                    t->m_collections.m_resource_collection_key,
+                    t->m_rules->m_secWebAppId.m_value);
+            } else if (col == "GLOBAL") {
+                t->m_collections.m_global_collection->del(m_variableNameExpanded,
+                    t->m_collections.m_global_collection_key,
+                    t->m_rules->m_secWebAppId.m_value);
+            }
         }
         goto end;
     } else {
@@ -138,7 +161,36 @@ bool SetVar::evaluate(RuleWithActions *rule, Transaction *t) {
     } else if (user) {
         user->storeOrUpdateFirst(t, m_variableNameExpanded, targetValue);
     } else {
-        // ?
+        const std::string &col = m_variable->m_collectionName;
+        if (col == "TX") {
+            t->m_collections.m_tx_collection->storeOrUpdateFirst(
+                m_variableNameExpanded, targetValue);
+        } else if (col == "IP") {
+            t->m_collections.m_ip_collection->storeOrUpdateFirst(
+                m_variableNameExpanded,
+                t->m_collections.m_ip_collection_key,
+                t->m_rules->m_secWebAppId.m_value, targetValue);
+        } else if (col == "SESSION") {
+            t->m_collections.m_session_collection->storeOrUpdateFirst(
+                m_variableNameExpanded,
+                t->m_collections.m_session_collection_key,
+                t->m_rules->m_secWebAppId.m_value, targetValue);
+        } else if (col == "USER") {
+            t->m_collections.m_user_collection->storeOrUpdateFirst(
+                m_variableNameExpanded,
+                t->m_collections.m_user_collection_key,
+                t->m_rules->m_secWebAppId.m_value, targetValue);
+        } else if (col == "RESOURCE") {
+            t->m_collections.m_resource_collection->storeOrUpdateFirst(
+                m_variableNameExpanded,
+                t->m_collections.m_resource_collection_key,
+                t->m_rules->m_secWebAppId.m_value, targetValue);
+        } else if (col == "GLOBAL") {
+            t->m_collections.m_global_collection->storeOrUpdateFirst(
+                m_variableNameExpanded,
+                t->m_collections.m_global_collection_key,
+                t->m_rules->m_secWebAppId.m_value, targetValue);
+        }
     }
 
     /*

--- a/src/collection/backend/lmdb.cc
+++ b/src/collection/backend/lmdb.cc
@@ -641,16 +641,40 @@ end_txn:
 MDBEnvProvider::MDBEnvProvider() : m_env(NULL), valid(false) {
     int rc;
     MDB_txn *txn;
+
+    std::string datadir = m_s_dataDir;
+    int openFlags = MDB_WRITEMAP;
+    mdb_mode_t openMode = 0664;
+
+    if (datadir.empty()) {
+        // Legacy fallback: single file in the current working directory.
+        datadir = "./modsec-shared-collections";
+        openFlags |= MDB_NOSUBDIR;
+    }
+
     mdb_env_create(&m_env);
-    rc = mdb_env_open(m_env, "./modsec-shared-collections",
-        MDB_WRITEMAP | MDB_NOSUBDIR, 0664);
+    rc = mdb_env_open(m_env, datadir.c_str(), openFlags, openMode);
 
     if (rc == 0) {
         valid = true;
         mdb_txn_begin(m_env, NULL, 0, &txn);
         mdb_dbi_open(txn, NULL, MDB_CREATE | MDB_DUPSORT, &m_dbi);
         mdb_txn_commit(txn);
+    } else {
+        std::cerr << "ModSecurity: failed to open LMDB environment '"
+            << datadir << "': " << mdb_strerror(rc)
+            << " (collections will not be persisted)." << std::endl;
     }
+}
+
+std::string MDBEnvProvider::m_s_dataDir = "";
+
+void MDBEnvProvider::SetDataDir(const std::string &dir) {
+    m_s_dataDir = dir;
+}
+
+const std::string& MDBEnvProvider::GetDataDir() {
+    return m_s_dataDir;
 }
 
 MDB_env* MDBEnvProvider::GetEnv() {

--- a/src/collection/backend/lmdb.h
+++ b/src/collection/backend/lmdb.h
@@ -83,6 +83,17 @@ class MDBEnvProvider {
     MDB_dbi* GetDBI();
     bool isValid() const;
 
+    /**
+     * Set the directory used to hold the LMDB environment. Must be called
+     * before the singleton is first instantiated (i.e. before the first
+     * collection transaction). When set, SecDataDir is used as the LMDB
+     * environment directory (data.mdb / lock.mdb are created inside it).
+     * When unset, the legacy behaviour is preserved: a single
+     * "./modsec-shared-collections" file in the current working directory.
+     */
+    static void SetDataDir(const std::string &dir);
+    static const std::string& GetDataDir();
+
     ~MDBEnvProvider();
  private:
     MDB_env *m_env;
@@ -90,6 +101,8 @@ class MDBEnvProvider {
     bool valid;
 
     MDBEnvProvider();
+
+    static std::string m_s_dataDir;
 };
 
 class LMDB :

--- a/src/parser/seclang-parser.cc
+++ b/src/parser/seclang-parser.cc
@@ -45,8 +45,19 @@
 #line 332 "seclang-parser.yy"
 
 #include "src/parser/driver.h"
+#include <cerrno>
+#include <cstring>
+#include <sys/types.h>
+#include <sys/stat.h>
+#if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+#ifndef WIN32
+#include <unistd.h>
+#endif
+#include "src/collection/backend/lmdb.h"
 
-#line 50 "seclang-parser.cc"
+#line 61 "seclang-parser.cc"
 
 
 #ifndef YY_
@@ -138,7 +149,7 @@
 #define YYRECOVERING()  (!!yyerrstatus_)
 
 namespace yy {
-#line 142 "seclang-parser.cc"
+#line 153 "seclang-parser.cc"
 
   /// Build a parser object.
   seclang_parser::seclang_parser (modsecurity::Parser::Driver& driver_yyarg)
@@ -1345,7 +1356,7 @@ namespace yy {
   yyla.location.begin.filename = yyla.location.end.filename = &(driver.m_filenames.back());
 }
 
-#line 1349 "seclang-parser.cc"
+#line 1360 "seclang-parser.cc"
 
 
     /* Initialize the stack.  The initial state will be set in
@@ -1716,170 +1727,170 @@ namespace yy {
           switch (yyn)
             {
   case 2: // input: "end of file"
-#line 737 "seclang-parser.yy"
+#line 748 "seclang-parser.yy"
       {
         return 0;
       }
-#line 1724 "seclang-parser.cc"
+#line 1735 "seclang-parser.cc"
     break;
 
   case 6: // audit_log: "CONFIG_DIR_AUDIT_DIR_MOD"
-#line 750 "seclang-parser.yy"
+#line 761 "seclang-parser.yy"
       {
         driver.m_auditLog->setStorageDirMode(strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 8));
       }
-#line 1732 "seclang-parser.cc"
+#line 1743 "seclang-parser.cc"
     break;
 
   case 7: // audit_log: "CONFIG_DIR_AUDIT_DIR"
-#line 756 "seclang-parser.yy"
+#line 767 "seclang-parser.yy"
       {
         driver.m_auditLog->setStorageDir(yystack_[0].value.as < std::string > ());
       }
-#line 1740 "seclang-parser.cc"
+#line 1751 "seclang-parser.cc"
     break;
 
   case 8: // audit_log: "CONFIG_DIR_AUDIT_ENG" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 762 "seclang-parser.yy"
+#line 773 "seclang-parser.yy"
       {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::RelevantOnlyAuditLogStatus);
       }
-#line 1748 "seclang-parser.cc"
+#line 1759 "seclang-parser.cc"
     break;
 
   case 9: // audit_log: "CONFIG_DIR_AUDIT_ENG" "CONFIG_VALUE_OFF"
-#line 766 "seclang-parser.yy"
+#line 777 "seclang-parser.yy"
       {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::OffAuditLogStatus);
       }
-#line 1756 "seclang-parser.cc"
+#line 1767 "seclang-parser.cc"
     break;
 
   case 10: // audit_log: "CONFIG_DIR_AUDIT_ENG" "CONFIG_VALUE_ON"
-#line 770 "seclang-parser.yy"
+#line 781 "seclang-parser.yy"
       {
         driver.m_auditLog->setStatus(modsecurity::audit_log::AuditLog::OnAuditLogStatus);
       }
-#line 1764 "seclang-parser.cc"
+#line 1775 "seclang-parser.cc"
     break;
 
   case 11: // audit_log: "CONFIG_DIR_AUDIT_FLE_MOD"
-#line 776 "seclang-parser.yy"
+#line 787 "seclang-parser.yy"
       {
         driver.m_auditLog->setFileMode(strtol(yystack_[0].value.as < std::string > ().c_str(), NULL, 8));
       }
-#line 1772 "seclang-parser.cc"
+#line 1783 "seclang-parser.cc"
     break;
 
   case 12: // audit_log: "CONFIG_DIR_AUDIT_LOG2"
-#line 782 "seclang-parser.yy"
+#line 793 "seclang-parser.yy"
       {
         driver.m_auditLog->setFilePath2(yystack_[0].value.as < std::string > ());
       }
-#line 1780 "seclang-parser.cc"
+#line 1791 "seclang-parser.cc"
     break;
 
   case 13: // audit_log: "CONFIG_DIR_AUDIT_LOG_P"
-#line 788 "seclang-parser.yy"
+#line 799 "seclang-parser.yy"
       {
         driver.m_auditLog->setParts(yystack_[0].value.as < std::string > ());
       }
-#line 1788 "seclang-parser.cc"
+#line 1799 "seclang-parser.cc"
     break;
 
   case 14: // audit_log: "CONFIG_DIR_AUDIT_LOG"
-#line 794 "seclang-parser.yy"
+#line 805 "seclang-parser.yy"
       {
         driver.m_auditLog->setFilePath1(yystack_[0].value.as < std::string > ());
       }
-#line 1796 "seclang-parser.cc"
+#line 1807 "seclang-parser.cc"
     break;
 
   case 15: // audit_log: CONFIG_DIR_AUDIT_LOG_FMT JSON
-#line 799 "seclang-parser.yy"
+#line 810 "seclang-parser.yy"
       {
         driver.m_auditLog->setFormat(modsecurity::audit_log::AuditLog::JSONAuditLogFormat);
       }
-#line 1804 "seclang-parser.cc"
+#line 1815 "seclang-parser.cc"
     break;
 
   case 16: // audit_log: CONFIG_DIR_AUDIT_LOG_FMT NATIVE
-#line 804 "seclang-parser.yy"
+#line 815 "seclang-parser.yy"
       {
         driver.m_auditLog->setFormat(modsecurity::audit_log::AuditLog::NativeAuditLogFormat);
       }
-#line 1812 "seclang-parser.cc"
+#line 1823 "seclang-parser.cc"
     break;
 
   case 17: // audit_log: "CONFIG_DIR_AUDIT_STS"
-#line 810 "seclang-parser.yy"
+#line 821 "seclang-parser.yy"
       {
         std::string relevant_status(yystack_[0].value.as < std::string > ());
         driver.m_auditLog->setRelevantStatus(relevant_status);
       }
-#line 1821 "seclang-parser.cc"
+#line 1832 "seclang-parser.cc"
     break;
 
   case 18: // audit_log: "CONFIG_DIR_AUDIT_PREFIX"
-#line 817 "seclang-parser.yy"
+#line 828 "seclang-parser.yy"
       {
         std::string prefix(yystack_[0].value.as < std::string > ());
         driver.m_auditLog->setPrefix(prefix);
       }
-#line 1830 "seclang-parser.cc"
+#line 1841 "seclang-parser.cc"
     break;
 
   case 19: // audit_log: "CONFIG_DIR_AUDIT_TPE" "CONFIG_VALUE_SERIAL"
-#line 824 "seclang-parser.yy"
+#line 835 "seclang-parser.yy"
       {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::SerialAuditLogType);
       }
-#line 1838 "seclang-parser.cc"
+#line 1849 "seclang-parser.cc"
     break;
 
   case 20: // audit_log: "CONFIG_DIR_AUDIT_TPE" "CONFIG_VALUE_PARALLEL"
-#line 828 "seclang-parser.yy"
+#line 839 "seclang-parser.yy"
       {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::ParallelAuditLogType);
       }
-#line 1846 "seclang-parser.cc"
+#line 1857 "seclang-parser.cc"
     break;
 
   case 21: // audit_log: "CONFIG_DIR_AUDIT_TPE" "CONFIG_VALUE_HTTPS"
-#line 832 "seclang-parser.yy"
+#line 843 "seclang-parser.yy"
       {
         driver.m_auditLog->setType(modsecurity::audit_log::AuditLog::HttpsAuditLogType);
       }
-#line 1854 "seclang-parser.cc"
+#line 1865 "seclang-parser.cc"
     break;
 
   case 22: // audit_log: "CONFIG_UPDLOAD_KEEP_FILES" "CONFIG_VALUE_ON"
-#line 838 "seclang-parser.yy"
+#line 849 "seclang-parser.yy"
       {
         driver.m_uploadKeepFiles = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 1862 "seclang-parser.cc"
+#line 1873 "seclang-parser.cc"
     break;
 
   case 23: // audit_log: "CONFIG_UPDLOAD_KEEP_FILES" "CONFIG_VALUE_OFF"
-#line 842 "seclang-parser.yy"
+#line 853 "seclang-parser.yy"
       {
         driver.m_uploadKeepFiles = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 1870 "seclang-parser.cc"
+#line 1881 "seclang-parser.cc"
     break;
 
   case 24: // audit_log: "CONFIG_UPDLOAD_KEEP_FILES" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 846 "seclang-parser.yy"
+#line 857 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecUploadKeepFiles RelevantOnly is not currently supported. Accepted values are On or Off");
         YYERROR;
       }
-#line 1879 "seclang-parser.cc"
+#line 1890 "seclang-parser.cc"
     break;
 
   case 25: // audit_log: "CONFIG_UPLOAD_FILE_LIMIT"
-#line 851 "seclang-parser.yy"
+#line 862 "seclang-parser.yy"
       {
         std::string errmsg = "";
         if (driver.m_uploadFileLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
@@ -1887,11 +1898,11 @@ namespace yy {
           YYERROR;
         }
       }
-#line 1891 "seclang-parser.cc"
+#line 1902 "seclang-parser.cc"
     break;
 
   case 26: // audit_log: "CONFIG_UPLOAD_FILE_MODE"
-#line 859 "seclang-parser.yy"
+#line 870 "seclang-parser.yy"
       {
         std::string errmsg = "";
         if (driver.m_uploadFileMode.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
@@ -1899,73 +1910,73 @@ namespace yy {
           YYERROR;
         }
       }
-#line 1903 "seclang-parser.cc"
+#line 1914 "seclang-parser.cc"
     break;
 
   case 27: // audit_log: "CONFIG_UPLOAD_DIR"
-#line 867 "seclang-parser.yy"
+#line 878 "seclang-parser.yy"
       {
         driver.m_uploadDirectory.m_set = true;
         driver.m_uploadDirectory.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 1912 "seclang-parser.cc"
+#line 1923 "seclang-parser.cc"
     break;
 
   case 28: // audit_log: "CONFIG_UPDLOAD_SAVE_TMP_FILES" "CONFIG_VALUE_ON"
-#line 872 "seclang-parser.yy"
+#line 883 "seclang-parser.yy"
       {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 1920 "seclang-parser.cc"
+#line 1931 "seclang-parser.cc"
     break;
 
   case 29: // audit_log: "CONFIG_UPDLOAD_SAVE_TMP_FILES" "CONFIG_VALUE_OFF"
-#line 876 "seclang-parser.yy"
+#line 887 "seclang-parser.yy"
       {
         driver.m_tmpSaveUploadedFiles = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 1928 "seclang-parser.cc"
+#line 1939 "seclang-parser.cc"
     break;
 
   case 30: // actions: "QUOTATION_MARK" actions_may_quoted "QUOTATION_MARK"
-#line 883 "seclang-parser.yy"
+#line 894 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1936 "seclang-parser.cc"
+#line 1947 "seclang-parser.cc"
     break;
 
   case 31: // actions: actions_may_quoted
-#line 887 "seclang-parser.yy"
+#line 898 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1944 "seclang-parser.cc"
+#line 1955 "seclang-parser.cc"
     break;
 
   case 32: // actions_may_quoted: actions_may_quoted "," act
-#line 894 "seclang-parser.yy"
+#line 905 "seclang-parser.yy"
       {
         ACTION_INIT(yystack_[0].value.as < std::unique_ptr<actions::Action> > (), yystack_[3].location)
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > ());
       }
-#line 1954 "seclang-parser.cc"
+#line 1965 "seclang-parser.cc"
     break;
 
   case 33: // actions_may_quoted: act
-#line 900 "seclang-parser.yy"
+#line 911 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<actions::Action>>> b(new std::vector<std::unique_ptr<actions::Action>>());
         ACTION_INIT(yystack_[0].value.as < std::unique_ptr<actions::Action> > (), yystack_[1].location)
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<actions::Action> > >  > () = std::move(b);
       }
-#line 1965 "seclang-parser.cc"
+#line 1976 "seclang-parser.cc"
     break;
 
   case 34: // op: op_before_init
-#line 910 "seclang-parser.yy"
+#line 921 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as < std::unique_ptr<Operator> > ());
         std::string error;
@@ -1974,11 +1985,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1978 "seclang-parser.cc"
+#line 1989 "seclang-parser.cc"
     break;
 
   case 35: // op: "NOT" op_before_init
-#line 919 "seclang-parser.yy"
+#line 930 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<Operator> > () = std::move(yystack_[0].value.as < std::unique_ptr<Operator> > ());
         yylhs.value.as < std::unique_ptr<Operator> > ()->m_negation = true;
@@ -1988,11 +1999,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 1992 "seclang-parser.cc"
+#line 2003 "seclang-parser.cc"
     break;
 
   case 36: // op: run_time_string
-#line 929 "seclang-parser.yy"
+#line 940 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
         std::string error;
@@ -2001,11 +2012,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2005 "seclang-parser.cc"
+#line 2016 "seclang-parser.cc"
     break;
 
   case 37: // op: "NOT" run_time_string
-#line 938 "seclang-parser.yy"
+#line 949 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
         yylhs.value.as < std::unique_ptr<Operator> > ()->m_negation = true;
@@ -2015,302 +2026,302 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2019 "seclang-parser.cc"
+#line 2030 "seclang-parser.cc"
     break;
 
   case 38: // op_before_init: "OPERATOR_UNCONDITIONAL_MATCH"
-#line 951 "seclang-parser.yy"
+#line 962 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::UnconditionalMatch());
       }
-#line 2027 "seclang-parser.cc"
+#line 2038 "seclang-parser.cc"
     break;
 
   case 39: // op_before_init: "OPERATOR_DETECT_SQLI"
-#line 955 "seclang-parser.yy"
+#line 966 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::DetectSQLi());
       }
-#line 2035 "seclang-parser.cc"
+#line 2046 "seclang-parser.cc"
     break;
 
   case 40: // op_before_init: "OPERATOR_DETECT_XSS"
-#line 959 "seclang-parser.yy"
+#line 970 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::DetectXSS());
       }
-#line 2043 "seclang-parser.cc"
+#line 2054 "seclang-parser.cc"
     break;
 
   case 41: // op_before_init: "OPERATOR_VALIDATE_URL_ENCODING"
-#line 963 "seclang-parser.yy"
+#line 974 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateUrlEncoding());
       }
-#line 2051 "seclang-parser.cc"
+#line 2062 "seclang-parser.cc"
     break;
 
   case 42: // op_before_init: "OPERATOR_VALIDATE_UTF8_ENCODING"
-#line 967 "seclang-parser.yy"
+#line 978 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateUtf8Encoding());
       }
-#line 2059 "seclang-parser.cc"
+#line 2070 "seclang-parser.cc"
     break;
 
   case 43: // op_before_init: "OPERATOR_INSPECT_FILE" run_time_string
-#line 971 "seclang-parser.yy"
+#line 982 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::InspectFile(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2067 "seclang-parser.cc"
+#line 2078 "seclang-parser.cc"
     break;
 
   case 44: // op_before_init: "OPERATOR_FUZZY_HASH" run_time_string
-#line 975 "seclang-parser.yy"
+#line 986 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::FuzzyHash(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2075 "seclang-parser.cc"
+#line 2086 "seclang-parser.cc"
     break;
 
   case 45: // op_before_init: "OPERATOR_VALIDATE_BYTE_RANGE" run_time_string
-#line 979 "seclang-parser.yy"
+#line 990 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateByteRange(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2083 "seclang-parser.cc"
+#line 2094 "seclang-parser.cc"
     break;
 
   case 46: // op_before_init: "OPERATOR_VALIDATE_DTD" run_time_string
-#line 983 "seclang-parser.yy"
+#line 994 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateDTD(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2091 "seclang-parser.cc"
+#line 2102 "seclang-parser.cc"
     break;
 
   case 47: // op_before_init: "OPERATOR_VALIDATE_HASH" run_time_string
-#line 987 "seclang-parser.yy"
+#line 998 "seclang-parser.yy"
       {
         /* $$ = new operators::ValidateHash($1); */
         OPERATOR_NOT_SUPPORTED("ValidateHash", yystack_[2].location);
       }
-#line 2100 "seclang-parser.cc"
+#line 2111 "seclang-parser.cc"
     break;
 
   case 48: // op_before_init: "OPERATOR_VALIDATE_SCHEMA" run_time_string
-#line 992 "seclang-parser.yy"
+#line 1003 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ValidateSchema(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2108 "seclang-parser.cc"
+#line 2119 "seclang-parser.cc"
     break;
 
   case 49: // op_before_init: "OPERATOR_VERIFY_CC" run_time_string
-#line 996 "seclang-parser.yy"
+#line 1007 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifyCC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2116 "seclang-parser.cc"
+#line 2127 "seclang-parser.cc"
     break;
 
   case 50: // op_before_init: "OPERATOR_VERIFY_CPF" run_time_string
-#line 1000 "seclang-parser.yy"
+#line 1011 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifyCPF(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2124 "seclang-parser.cc"
+#line 2135 "seclang-parser.cc"
     break;
 
   case 51: // op_before_init: "OPERATOR_VERIFY_SSN" run_time_string
-#line 1004 "seclang-parser.yy"
+#line 1015 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifySSN(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2132 "seclang-parser.cc"
+#line 2143 "seclang-parser.cc"
     break;
 
   case 52: // op_before_init: "OPERATOR_VERIFY_SVNR" run_time_string
-#line 1008 "seclang-parser.yy"
+#line 1019 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::VerifySVNR(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2140 "seclang-parser.cc"
+#line 2151 "seclang-parser.cc"
     break;
 
   case 53: // op_before_init: "OPERATOR_GSB_LOOKUP" run_time_string
-#line 1012 "seclang-parser.yy"
+#line 1023 "seclang-parser.yy"
       {
         /* $$ = new operators::GsbLookup($1); */
         OPERATOR_NOT_SUPPORTED("GsbLookup", yystack_[2].location);
       }
-#line 2149 "seclang-parser.cc"
+#line 2160 "seclang-parser.cc"
     break;
 
   case 54: // op_before_init: "OPERATOR_RSUB" run_time_string
-#line 1017 "seclang-parser.yy"
+#line 1028 "seclang-parser.yy"
       {
         /* $$ = new operators::Rsub($1); */
         OPERATOR_NOT_SUPPORTED("Rsub", yystack_[2].location);
       }
-#line 2158 "seclang-parser.cc"
+#line 2169 "seclang-parser.cc"
     break;
 
   case 55: // op_before_init: "OPERATOR_WITHIN" run_time_string
-#line 1022 "seclang-parser.yy"
+#line 1033 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Within(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2166 "seclang-parser.cc"
+#line 2177 "seclang-parser.cc"
     break;
 
   case 56: // op_before_init: "OPERATOR_CONTAINS_WORD" run_time_string
-#line 1026 "seclang-parser.yy"
+#line 1037 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::ContainsWord(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2174 "seclang-parser.cc"
+#line 2185 "seclang-parser.cc"
     break;
 
   case 57: // op_before_init: "OPERATOR_CONTAINS" run_time_string
-#line 1030 "seclang-parser.yy"
+#line 1041 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Contains(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2182 "seclang-parser.cc"
+#line 2193 "seclang-parser.cc"
     break;
 
   case 58: // op_before_init: "OPERATOR_ENDS_WITH" run_time_string
-#line 1034 "seclang-parser.yy"
+#line 1045 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::EndsWith(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2190 "seclang-parser.cc"
+#line 2201 "seclang-parser.cc"
     break;
 
   case 59: // op_before_init: "OPERATOR_EQ" run_time_string
-#line 1038 "seclang-parser.yy"
+#line 1049 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Eq(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2198 "seclang-parser.cc"
+#line 2209 "seclang-parser.cc"
     break;
 
   case 60: // op_before_init: "OPERATOR_GE" run_time_string
-#line 1042 "seclang-parser.yy"
+#line 1053 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Ge(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2206 "seclang-parser.cc"
+#line 2217 "seclang-parser.cc"
     break;
 
   case 61: // op_before_init: "OPERATOR_GT" run_time_string
-#line 1046 "seclang-parser.yy"
+#line 1057 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Gt(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2214 "seclang-parser.cc"
+#line 2225 "seclang-parser.cc"
     break;
 
   case 62: // op_before_init: "OPERATOR_IP_MATCH_FROM_FILE" run_time_string
-#line 1050 "seclang-parser.yy"
+#line 1061 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::IpMatchF(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2222 "seclang-parser.cc"
+#line 2233 "seclang-parser.cc"
     break;
 
   case 63: // op_before_init: "OPERATOR_IP_MATCH" run_time_string
-#line 1054 "seclang-parser.yy"
+#line 1065 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::IpMatch(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2230 "seclang-parser.cc"
+#line 2241 "seclang-parser.cc"
     break;
 
   case 64: // op_before_init: "OPERATOR_LE" run_time_string
-#line 1058 "seclang-parser.yy"
+#line 1069 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Le(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2238 "seclang-parser.cc"
+#line 2249 "seclang-parser.cc"
     break;
 
   case 65: // op_before_init: "OPERATOR_LT" run_time_string
-#line 1062 "seclang-parser.yy"
+#line 1073 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Lt(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2246 "seclang-parser.cc"
+#line 2257 "seclang-parser.cc"
     break;
 
   case 66: // op_before_init: "OPERATOR_PM_FROM_FILE" run_time_string
-#line 1066 "seclang-parser.yy"
+#line 1077 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::PmFromFile(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2254 "seclang-parser.cc"
+#line 2265 "seclang-parser.cc"
     break;
 
   case 67: // op_before_init: "OPERATOR_PM" run_time_string
-#line 1070 "seclang-parser.yy"
+#line 1081 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Pm(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2262 "seclang-parser.cc"
+#line 2273 "seclang-parser.cc"
     break;
 
   case 68: // op_before_init: "OPERATOR_RBL" run_time_string
-#line 1074 "seclang-parser.yy"
+#line 1085 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rbl(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2270 "seclang-parser.cc"
+#line 2281 "seclang-parser.cc"
     break;
 
   case 69: // op_before_init: "OPERATOR_RX" run_time_string
-#line 1078 "seclang-parser.yy"
+#line 1089 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::Rx(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2278 "seclang-parser.cc"
+#line 2289 "seclang-parser.cc"
     break;
 
   case 70: // op_before_init: "OPERATOR_RX_GLOBAL" run_time_string
-#line 1082 "seclang-parser.yy"
+#line 1093 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::RxGlobal(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2286 "seclang-parser.cc"
+#line 2297 "seclang-parser.cc"
     break;
 
   case 71: // op_before_init: "OPERATOR_STR_EQ" run_time_string
-#line 1086 "seclang-parser.yy"
+#line 1097 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::StrEq(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2294 "seclang-parser.cc"
+#line 2305 "seclang-parser.cc"
     break;
 
   case 72: // op_before_init: "OPERATOR_STR_MATCH" run_time_string
-#line 1090 "seclang-parser.yy"
+#line 1101 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::StrMatch(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2302 "seclang-parser.cc"
+#line 2313 "seclang-parser.cc"
     break;
 
   case 73: // op_before_init: "OPERATOR_BEGINS_WITH" run_time_string
-#line 1094 "seclang-parser.yy"
+#line 1105 "seclang-parser.yy"
       {
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::BeginsWith(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 2310 "seclang-parser.cc"
+#line 2321 "seclang-parser.cc"
     break;
 
   case 74: // op_before_init: "OPERATOR_GEOLOOKUP"
-#line 1098 "seclang-parser.yy"
+#line 1109 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         OPERATOR_CONTAINER(yylhs.value.as < std::unique_ptr<Operator> > (), new operators::GeoLookup());
@@ -2321,11 +2332,11 @@ namespace yy {
             YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 2325 "seclang-parser.cc"
+#line 2336 "seclang-parser.cc"
     break;
 
   case 76: // expression: "DIRECTIVE" variables op actions
-#line 1113 "seclang-parser.yy"
+#line 1124 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
@@ -2356,11 +2367,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2360 "seclang-parser.cc"
+#line 2371 "seclang-parser.cc"
     break;
 
   case 77: // expression: "DIRECTIVE" variables op
-#line 1144 "seclang-parser.yy"
+#line 1155 "seclang-parser.yy"
       {
         variables::Variables *v = new variables::Variables();
         for (auto &i : *yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ().get()) {
@@ -2379,11 +2390,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2383 "seclang-parser.cc"
+#line 2394 "seclang-parser.cc"
     break;
 
   case 78: // expression: "CONFIG_DIR_SEC_ACTION" actions
-#line 1163 "seclang-parser.yy"
+#line 1174 "seclang-parser.yy"
       {
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
         std::vector<actions::transformations::Transformation *> *t = new std::vector<actions::transformations::Transformation *>();
@@ -2403,11 +2414,11 @@ namespace yy {
             ));
         driver.addSecAction(std::move(rule));
       }
-#line 2407 "seclang-parser.cc"
+#line 2418 "seclang-parser.cc"
     break;
 
   case 79: // expression: "DIRECTIVE_SECRULESCRIPT" actions
-#line 1183 "seclang-parser.yy"
+#line 1194 "seclang-parser.yy"
       {
         std::string err;
         std::vector<actions::Action *> *a = new std::vector<actions::Action *>();
@@ -2436,11 +2447,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2440 "seclang-parser.cc"
+#line 2451 "seclang-parser.cc"
     break;
 
   case 80: // expression: "CONFIG_DIR_SEC_DEFAULT_ACTION" actions
-#line 1212 "seclang-parser.yy"
+#line 1223 "seclang-parser.yy"
       {
         bool hasDisruptive = false;
         std::vector<actions::Action *> *actions = new std::vector<actions::Action *>();
@@ -2497,78 +2508,78 @@ namespace yy {
 
         delete actions;
       }
-#line 2501 "seclang-parser.cc"
+#line 2512 "seclang-parser.cc"
     break;
 
   case 81: // expression: "CONFIG_DIR_SEC_MARKER"
-#line 1269 "seclang-parser.yy"
+#line 1280 "seclang-parser.yy"
       {
         driver.addSecMarker(modsecurity::utils::string::removeBracketsIfNeeded(yystack_[0].value.as < std::string > ()),
             /* file name */ std::string(*yystack_[0].location.end.filename),
             /* line number */ yystack_[0].location.end.line
         );
       }
-#line 2512 "seclang-parser.cc"
+#line 2523 "seclang-parser.cc"
     break;
 
   case 82: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_OFF"
-#line 1276 "seclang-parser.yy"
+#line 1287 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DisabledRuleEngine;
       }
-#line 2520 "seclang-parser.cc"
+#line 2531 "seclang-parser.cc"
     break;
 
   case 83: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_ON"
-#line 1280 "seclang-parser.yy"
+#line 1291 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::EnabledRuleEngine;
       }
-#line 2528 "seclang-parser.cc"
+#line 2539 "seclang-parser.cc"
     break;
 
   case 84: // expression: "CONFIG_DIR_RULE_ENG" "CONFIG_VALUE_DETC"
-#line 1284 "seclang-parser.yy"
+#line 1295 "seclang-parser.yy"
       {
         driver.m_secRuleEngine = modsecurity::RulesSet::DetectionOnlyRuleEngine;
       }
-#line 2536 "seclang-parser.cc"
+#line 2547 "seclang-parser.cc"
     break;
 
   case 85: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_ON"
-#line 1288 "seclang-parser.yy"
+#line 1299 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2544 "seclang-parser.cc"
+#line 2555 "seclang-parser.cc"
     break;
 
   case 86: // expression: "CONFIG_DIR_REQ_BODY" "CONFIG_VALUE_OFF"
-#line 1292 "seclang-parser.yy"
+#line 1303 "seclang-parser.yy"
       {
         driver.m_secRequestBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2552 "seclang-parser.cc"
+#line 2563 "seclang-parser.cc"
     break;
 
   case 87: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_ON"
-#line 1296 "seclang-parser.yy"
+#line 1307 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 2560 "seclang-parser.cc"
+#line 2571 "seclang-parser.cc"
     break;
 
   case 88: // expression: "CONFIG_DIR_RES_BODY" "CONFIG_VALUE_OFF"
-#line 1300 "seclang-parser.yy"
+#line 1311 "seclang-parser.yy"
       {
         driver.m_secResponseBodyAccess = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 2568 "seclang-parser.cc"
+#line 2579 "seclang-parser.cc"
     break;
 
   case 89: // expression: "CONFIG_SEC_ARGUMENT_SEPARATOR"
-#line 1304 "seclang-parser.yy"
+#line 1315 "seclang-parser.yy"
       {
         if (yystack_[0].value.as < std::string > ().length() != 1) {
           driver.error(yystack_[1].location, "Argument separator should be set to a single character.");
@@ -2577,259 +2588,259 @@ namespace yy {
         driver.m_secArgumentSeparator.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secArgumentSeparator.m_set = true;
       }
-#line 2581 "seclang-parser.cc"
+#line 2592 "seclang-parser.cc"
     break;
 
   case 90: // expression: "CONFIG_COMPONENT_SIG"
-#line 1313 "seclang-parser.yy"
+#line 1324 "seclang-parser.yy"
       {
         driver.m_components.push_back(yystack_[0].value.as < std::string > ());
       }
-#line 2589 "seclang-parser.cc"
+#line 2600 "seclang-parser.cc"
     break;
 
   case 91: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_ON"
-#line 1317 "seclang-parser.yy"
+#line 1328 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecConnEngine is not yet supported.");
         YYERROR;
       }
-#line 2598 "seclang-parser.cc"
+#line 2609 "seclang-parser.cc"
     break;
 
   case 92: // expression: "CONFIG_CONN_ENGINE" "CONFIG_VALUE_OFF"
-#line 1322 "seclang-parser.yy"
+#line 1333 "seclang-parser.yy"
       {
       }
-#line 2605 "seclang-parser.cc"
+#line 2616 "seclang-parser.cc"
     break;
 
   case 93: // expression: "CONFIG_SEC_WEB_APP_ID"
-#line 1325 "seclang-parser.yy"
+#line 1336 "seclang-parser.yy"
       {
         driver.m_secWebAppId.m_value = yystack_[0].value.as < std::string > ();
         driver.m_secWebAppId.m_set = true;
       }
-#line 2614 "seclang-parser.cc"
+#line 2625 "seclang-parser.cc"
     break;
 
   case 94: // expression: "CONFIG_SEC_SERVER_SIG"
-#line 1330 "seclang-parser.yy"
+#line 1341 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecServerSignature is not supported.");
         YYERROR;
       }
-#line 2623 "seclang-parser.cc"
+#line 2634 "seclang-parser.cc"
     break;
 
   case 95: // expression: "CONFIG_SEC_CACHE_TRANSFORMATIONS"
-#line 1335 "seclang-parser.yy"
+#line 1346 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCacheTransformations is not supported.");
         YYERROR;
       }
-#line 2632 "seclang-parser.cc"
+#line 2643 "seclang-parser.cc"
     break;
 
   case 96: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_ON"
-#line 1340 "seclang-parser.yy"
+#line 1351 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecDisableBackendCompression is not supported.");
         YYERROR;
       }
-#line 2641 "seclang-parser.cc"
+#line 2652 "seclang-parser.cc"
     break;
 
   case 97: // expression: "CONFIG_SEC_DISABLE_BACKEND_COMPRESS" "CONFIG_VALUE_OFF"
-#line 1345 "seclang-parser.yy"
+#line 1356 "seclang-parser.yy"
       {
       }
-#line 2648 "seclang-parser.cc"
+#line 2659 "seclang-parser.cc"
     break;
 
   case 98: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_ON"
-#line 1348 "seclang-parser.yy"
+#line 1359 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecContentInjection is not yet supported.");
         YYERROR;
       }
-#line 2657 "seclang-parser.cc"
+#line 2668 "seclang-parser.cc"
     break;
 
   case 99: // expression: "CONFIG_CONTENT_INJECTION" "CONFIG_VALUE_OFF"
-#line 1353 "seclang-parser.yy"
+#line 1364 "seclang-parser.yy"
       {
       }
-#line 2664 "seclang-parser.cc"
+#line 2675 "seclang-parser.cc"
     break;
 
   case 100: // expression: "CONFIG_SEC_CHROOT_DIR"
-#line 1356 "seclang-parser.yy"
+#line 1367 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecChrootDir is not supported.");
         YYERROR;
       }
-#line 2673 "seclang-parser.cc"
+#line 2684 "seclang-parser.cc"
     break;
 
   case 101: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_ON"
-#line 1361 "seclang-parser.yy"
+#line 1372 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecHashEngine is not yet supported.");
         YYERROR;
       }
-#line 2682 "seclang-parser.cc"
+#line 2693 "seclang-parser.cc"
     break;
 
   case 102: // expression: "CONFIG_SEC_HASH_ENGINE" "CONFIG_VALUE_OFF"
-#line 1366 "seclang-parser.yy"
+#line 1377 "seclang-parser.yy"
       {
       }
-#line 2689 "seclang-parser.cc"
+#line 2700 "seclang-parser.cc"
     break;
 
   case 103: // expression: "CONFIG_SEC_HASH_KEY"
-#line 1369 "seclang-parser.yy"
+#line 1380 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashKey is not yet supported.");
         YYERROR;
       }
-#line 2698 "seclang-parser.cc"
+#line 2709 "seclang-parser.cc"
     break;
 
   case 104: // expression: "CONFIG_SEC_HASH_PARAM"
-#line 1374 "seclang-parser.yy"
+#line 1385 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashParam is not yet supported.");
         YYERROR;
       }
-#line 2707 "seclang-parser.cc"
+#line 2718 "seclang-parser.cc"
     break;
 
   case 105: // expression: "CONFIG_SEC_HASH_METHOD_RX"
-#line 1379 "seclang-parser.yy"
+#line 1390 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodRx is not yet supported.");
         YYERROR;
       }
-#line 2716 "seclang-parser.cc"
+#line 2727 "seclang-parser.cc"
     break;
 
   case 106: // expression: "CONFIG_SEC_HASH_METHOD_PM"
-#line 1384 "seclang-parser.yy"
+#line 1395 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecHashMethodPm is not yet supported.");
         YYERROR;
       }
-#line 2725 "seclang-parser.cc"
+#line 2736 "seclang-parser.cc"
     break;
 
   case 107: // expression: "CONFIG_DIR_GSB_DB"
-#line 1389 "seclang-parser.yy"
+#line 1400 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGsbLookupDb is not supported.");
         YYERROR;
       }
-#line 2734 "seclang-parser.cc"
+#line 2745 "seclang-parser.cc"
     break;
 
   case 108: // expression: "CONFIG_SEC_GUARDIAN_LOG"
-#line 1394 "seclang-parser.yy"
+#line 1405 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecGuardianLog is not supported.");
         YYERROR;
       }
-#line 2743 "seclang-parser.cc"
+#line 2754 "seclang-parser.cc"
     break;
 
   case 109: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_ON"
-#line 1399 "seclang-parser.yy"
+#line 1410 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecInterceptOnError is not yet supported.");
         YYERROR;
       }
-#line 2752 "seclang-parser.cc"
+#line 2763 "seclang-parser.cc"
     break;
 
   case 110: // expression: "CONFIG_SEC_INTERCEPT_ON_ERROR" "CONFIG_VALUE_OFF"
-#line 1404 "seclang-parser.yy"
+#line 1415 "seclang-parser.yy"
       {
       }
-#line 2759 "seclang-parser.cc"
+#line 2770 "seclang-parser.cc"
     break;
 
   case 111: // expression: "CONFIG_SEC_CONN_R_STATE_LIMIT"
-#line 1407 "seclang-parser.yy"
+#line 1418 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnReadStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2768 "seclang-parser.cc"
+#line 2779 "seclang-parser.cc"
     break;
 
   case 112: // expression: "CONFIG_SEC_CONN_W_STATE_LIMIT"
-#line 1412 "seclang-parser.yy"
+#line 1423 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecConnWriteStateLimit is not yet supported.");
         YYERROR;
       }
-#line 2777 "seclang-parser.cc"
+#line 2788 "seclang-parser.cc"
     break;
 
   case 113: // expression: "CONFIG_SEC_SENSOR_ID"
-#line 1417 "seclang-parser.yy"
+#line 1428 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecSensorId is not yet supported.");
         YYERROR;
       }
-#line 2786 "seclang-parser.cc"
+#line 2797 "seclang-parser.cc"
     break;
 
   case 114: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_ON"
-#line 1422 "seclang-parser.yy"
+#line 1433 "seclang-parser.yy"
       {
         driver.error(yystack_[2].location, "SecRuleInheritance is not yet supported.");
         YYERROR;
       }
-#line 2795 "seclang-parser.cc"
+#line 2806 "seclang-parser.cc"
     break;
 
   case 115: // expression: "CONFIG_SEC_RULE_INHERITANCE" "CONFIG_VALUE_OFF"
-#line 1427 "seclang-parser.yy"
+#line 1438 "seclang-parser.yy"
       {
       }
-#line 2802 "seclang-parser.cc"
+#line 2813 "seclang-parser.cc"
     break;
 
   case 116: // expression: "CONFIG_SEC_RULE_PERF_TIME"
-#line 1430 "seclang-parser.yy"
+#line 1441 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecRulePerfTime is not yet supported.");
         YYERROR;
       }
-#line 2811 "seclang-parser.cc"
+#line 2822 "seclang-parser.cc"
     break;
 
   case 117: // expression: "CONFIG_SEC_STREAM_IN_BODY_INSPECTION"
-#line 1435 "seclang-parser.yy"
+#line 1446 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamInBodyInspection is not supported.");
         YYERROR;
       }
-#line 2820 "seclang-parser.cc"
+#line 2831 "seclang-parser.cc"
     break;
 
   case 118: // expression: "CONFIG_SEC_STREAM_OUT_BODY_INSPECTION"
-#line 1440 "seclang-parser.yy"
+#line 1451 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecStreamOutBodyInspection is not supported.");
         YYERROR;
       }
-#line 2829 "seclang-parser.cc"
+#line 2840 "seclang-parser.cc"
     break;
 
   case 119: // expression: "CONFIG_SEC_RULE_REMOVE_BY_ID"
-#line 1445 "seclang-parser.yy"
+#line 1456 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.load(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2842,11 +2853,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2846 "seclang-parser.cc"
+#line 2857 "seclang-parser.cc"
     break;
 
   case 120: // expression: "CONFIG_SEC_RULE_REMOVE_BY_TAG"
-#line 1458 "seclang-parser.yy"
+#line 1469 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByTag(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2859,11 +2870,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2863 "seclang-parser.cc"
+#line 2874 "seclang-parser.cc"
     break;
 
   case 121: // expression: "CONFIG_SEC_RULE_REMOVE_BY_MSG"
-#line 1471 "seclang-parser.yy"
+#line 1482 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadRemoveRuleByMsg(yystack_[0].value.as < std::string > (), &error) == false) {
@@ -2876,11 +2887,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2880 "seclang-parser.cc"
+#line 2891 "seclang-parser.cc"
     break;
 
   case 122: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_TAG" variables_pre_process
-#line 1484 "seclang-parser.yy"
+#line 1495 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByTag(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2893,11 +2904,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2897 "seclang-parser.cc"
+#line 2908 "seclang-parser.cc"
     break;
 
   case 123: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_MSG" variables_pre_process
-#line 1497 "seclang-parser.yy"
+#line 1508 "seclang-parser.yy"
       {
         std::string error;
         if (driver.m_exceptions.loadUpdateTargetByMsg(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()), &error) == false) {
@@ -2910,11 +2921,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2914 "seclang-parser.cc"
+#line 2925 "seclang-parser.cc"
     break;
 
   case 124: // expression: "CONFIG_SEC_RULE_UPDATE_TARGET_BY_ID" variables_pre_process
-#line 1510 "seclang-parser.yy"
+#line 1521 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2940,11 +2951,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2944 "seclang-parser.cc"
+#line 2955 "seclang-parser.cc"
     break;
 
   case 125: // expression: "CONFIG_SEC_RULE_UPDATE_ACTION_BY_ID" actions
-#line 1536 "seclang-parser.yy"
+#line 1547 "seclang-parser.yy"
       {
         std::string error;
         double ruleId;
@@ -2971,11 +2982,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2975 "seclang-parser.cc"
+#line 2986 "seclang-parser.cc"
     break;
 
   case 126: // expression: "CONFIG_DIR_DEBUG_LVL"
-#line 1564 "seclang-parser.yy"
+#line 1575 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
           driver.m_debugLog->setDebugLogLevel(atoi(yystack_[0].value.as < std::string > ().c_str()));
@@ -2987,11 +2998,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 2991 "seclang-parser.cc"
+#line 3002 "seclang-parser.cc"
     break;
 
   case 127: // expression: "CONFIG_DIR_DEBUG_LOG"
-#line 1576 "seclang-parser.yy"
+#line 1587 "seclang-parser.yy"
       {
         if (driver.m_debugLog != NULL) {
             std::string error;
@@ -3010,11 +3021,11 @@ namespace yy {
             YYERROR;
         }
       }
-#line 3014 "seclang-parser.cc"
+#line 3025 "seclang-parser.cc"
     break;
 
   case 128: // expression: "CONFIG_DIR_GEO_DB"
-#line 1596 "seclang-parser.yy"
+#line 1607 "seclang-parser.yy"
       {
 #if defined(WITH_GEOIP) or defined(WITH_MAXMIND)
         std::string err;
@@ -3041,29 +3052,29 @@ namespace yy {
         YYERROR;
 #endif  // WITH_GEOIP
       }
-#line 3045 "seclang-parser.cc"
+#line 3056 "seclang-parser.cc"
     break;
 
   case 129: // expression: "CONFIG_DIR_ARGS_LIMIT"
-#line 1623 "seclang-parser.yy"
+#line 1634 "seclang-parser.yy"
       {
         driver.m_argumentsLimit.m_set = true;
         driver.m_argumentsLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3054 "seclang-parser.cc"
+#line 3065 "seclang-parser.cc"
     break;
 
   case 130: // expression: "CONFIG_DIR_REQ_BODY_JSON_DEPTH_LIMIT"
-#line 1628 "seclang-parser.yy"
+#line 1639 "seclang-parser.yy"
       {
         driver.m_requestBodyJsonDepthLimit.m_set = true;
         driver.m_requestBodyJsonDepthLimit.m_value = atoi(yystack_[0].value.as < std::string > ().c_str());
       }
-#line 3063 "seclang-parser.cc"
+#line 3074 "seclang-parser.cc"
     break;
 
   case 131: // expression: "CONFIG_DIR_REQ_BODY_LIMIT"
-#line 1634 "seclang-parser.yy"
+#line 1645 "seclang-parser.yy"
       {
         std::string errmsg = "";
         if (driver.m_requestBodyLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
@@ -3071,11 +3082,11 @@ namespace yy {
           YYERROR;
         }
       }
-#line 3075 "seclang-parser.cc"
+#line 3086 "seclang-parser.cc"
     break;
 
   case 132: // expression: "CONFIG_DIR_REQ_BODY_NO_FILES_LIMIT"
-#line 1642 "seclang-parser.yy"
+#line 1653 "seclang-parser.yy"
       {
         std::string errmsg = "";
         if (driver.m_requestBodyNoFilesLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
@@ -3083,11 +3094,11 @@ namespace yy {
           YYERROR;
         }
       }
-#line 3087 "seclang-parser.cc"
+#line 3098 "seclang-parser.cc"
     break;
 
   case 133: // expression: "CONFIG_DIR_REQ_BODY_IN_MEMORY_LIMIT"
-#line 1650 "seclang-parser.yy"
+#line 1661 "seclang-parser.yy"
       {
         std::stringstream ss;
         ss << "As of ModSecurity version 3.0, SecRequestBodyInMemoryLimit is no longer ";
@@ -3096,11 +3107,11 @@ namespace yy {
         driver.error(yystack_[1].location, ss.str());
         YYERROR;
       }
-#line 3100 "seclang-parser.cc"
+#line 3111 "seclang-parser.cc"
     break;
 
   case 134: // expression: "CONFIG_DIR_RES_BODY_LIMIT"
-#line 1659 "seclang-parser.yy"
+#line 1670 "seclang-parser.yy"
       {
         std::string errmsg = "";
         if (driver.m_responseBodyLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
@@ -3108,59 +3119,59 @@ namespace yy {
           YYERROR;
         }
       }
-#line 3112 "seclang-parser.cc"
+#line 3123 "seclang-parser.cc"
     break;
 
   case 135: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1667 "seclang-parser.yy"
+#line 1678 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3120 "seclang-parser.cc"
+#line 3131 "seclang-parser.cc"
     break;
 
   case 136: // expression: "CONFIG_DIR_REQ_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1671 "seclang-parser.yy"
+#line 1682 "seclang-parser.yy"
       {
         driver.m_requestBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3128 "seclang-parser.cc"
+#line 3139 "seclang-parser.cc"
     break;
 
   case 137: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_PROCESS_PARTIAL"
-#line 1675 "seclang-parser.yy"
+#line 1686 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::ProcessPartialBodyLimitAction;
       }
-#line 3136 "seclang-parser.cc"
+#line 3147 "seclang-parser.cc"
     break;
 
   case 138: // expression: "CONFIG_DIR_RES_BODY_LIMIT_ACTION" "CONFIG_VALUE_REJECT"
-#line 1679 "seclang-parser.yy"
+#line 1690 "seclang-parser.yy"
       {
         driver.m_responseBodyLimitAction = modsecurity::RulesSet::BodyLimitAction::RejectBodyLimitAction;
       }
-#line 3144 "seclang-parser.cc"
+#line 3155 "seclang-parser.cc"
     break;
 
   case 139: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_ABORT"
-#line 1683 "seclang-parser.yy"
+#line 1694 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::AbortOnFailedRemoteRulesAction;
       }
-#line 3152 "seclang-parser.cc"
+#line 3163 "seclang-parser.cc"
     break;
 
   case 140: // expression: "CONFIG_SEC_REMOTE_RULES_FAIL_ACTION" "CONFIG_VALUE_WARN"
-#line 1687 "seclang-parser.yy"
+#line 1698 "seclang-parser.yy"
       {
         driver.m_remoteRulesActionOnFailed = RulesSet::OnFailedRemoteRulesAction::WarnOnFailedRemoteRulesAction;
       }
-#line 3160 "seclang-parser.cc"
+#line 3171 "seclang-parser.cc"
     break;
 
   case 142: // expression: "CONFIG_DIR_PCRE_MATCH_LIMIT"
-#line 1696 "seclang-parser.yy"
+#line 1707 "seclang-parser.yy"
       {
         std::string errmsg = "";
         if (driver.m_pcreMatchLimit.parse(std::string(yystack_[0].value.as < std::string > ()), &errmsg) != true) {
@@ -3168,11 +3179,11 @@ namespace yy {
           YYERROR;
         }
       }
-#line 3172 "seclang-parser.cc"
+#line 3183 "seclang-parser.cc"
     break;
 
   case 143: // expression: "CONGIG_DIR_RESPONSE_BODY_MP"
-#line 1704 "seclang-parser.yy"
+#line 1715 "seclang-parser.yy"
       {
         std::istringstream buf(yystack_[0].value.as < std::string > ());
         std::istream_iterator<std::string> beg(buf), end;
@@ -3184,61 +3195,61 @@ namespace yy {
             driver.m_responseBodyTypeToBeInspected.m_value.insert(*it);
         }
       }
-#line 3188 "seclang-parser.cc"
+#line 3199 "seclang-parser.cc"
     break;
 
   case 144: // expression: "CONGIG_DIR_RESPONSE_BODY_MP_CLEAR"
-#line 1716 "seclang-parser.yy"
+#line 1727 "seclang-parser.yy"
       {
         driver.m_responseBodyTypeToBeInspected.m_set = true;
         driver.m_responseBodyTypeToBeInspected.m_clear = true;
         driver.m_responseBodyTypeToBeInspected.m_value.clear();
       }
-#line 3198 "seclang-parser.cc"
+#line 3209 "seclang-parser.cc"
     break;
 
   case 145: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_OFF"
-#line 1722 "seclang-parser.yy"
+#line 1733 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::FalseConfigBoolean;
       }
-#line 3206 "seclang-parser.cc"
+#line 3217 "seclang-parser.cc"
     break;
 
   case 146: // expression: "CONFIG_XML_EXTERNAL_ENTITY" "CONFIG_VALUE_ON"
-#line 1726 "seclang-parser.yy"
+#line 1737 "seclang-parser.yy"
       {
         driver.m_secXMLExternalEntity = modsecurity::RulesSetProperties::TrueConfigBoolean;
       }
-#line 3214 "seclang-parser.cc"
+#line 3225 "seclang-parser.cc"
     break;
 
   case 147: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
-#line 1730 "seclang-parser.yy"
+#line 1741 "seclang-parser.yy"
       {
         driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::OnlyArgsConfigXMLParseXmlIntoArgs;
       }
-#line 3222 "seclang-parser.cc"
+#line 3233 "seclang-parser.cc"
     break;
 
   case 148: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
-#line 1734 "seclang-parser.yy"
+#line 1745 "seclang-parser.yy"
       {
         driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::FalseConfigXMLParseXmlIntoArgs;
       }
-#line 3230 "seclang-parser.cc"
+#line 3241 "seclang-parser.cc"
     break;
 
   case 149: // expression: "CONFIG_XML_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
-#line 1738 "seclang-parser.yy"
+#line 1749 "seclang-parser.yy"
       {
         driver.m_secXMLParseXmlIntoArgs = modsecurity::RulesSetProperties::TrueConfigXMLParseXmlIntoArgs;
       }
-#line 3238 "seclang-parser.cc"
+#line 3249 "seclang-parser.cc"
     break;
 
   case 150: // expression: "CONGIG_DIR_SEC_TMP_DIR"
-#line 1742 "seclang-parser.yy"
+#line 1753 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
         std::stringstream ss;
@@ -3249,31 +3260,64 @@ namespace yy {
         YYERROR;
 */
       }
-#line 3253 "seclang-parser.cc"
+#line 3264 "seclang-parser.cc"
+    break;
+
+  case 151: // expression: "CONGIG_DIR_SEC_DATA_DIR"
+#line 1764 "seclang-parser.yy"
+      {
+        driver.m_secDataDir.m_set = true;
+        driver.m_secDataDir.m_value = yystack_[0].value.as < std::string > ();
+#ifdef WITH_LMDB
+        struct stat dstat;
+        if (stat(yystack_[0].value.as < std::string > ().c_str(), &dstat) != 0) {
+            std::stringstream ss;
+            ss << "SecDataDir '" << yystack_[0].value.as < std::string > () << "' does not exist: " << strerror(errno);
+            driver.error(yystack_[1].location, ss.str());
+            YYERROR;
+        }
+        if (!S_ISDIR(dstat.st_mode)) {
+            std::stringstream ss;
+            ss << "SecDataDir '" << yystack_[0].value.as < std::string > () << "' is not a directory.";
+            driver.error(yystack_[1].location, ss.str());
+            YYERROR;
+        }
+#ifndef WIN32
+        if (access(yystack_[0].value.as < std::string > ().c_str(), W_OK | X_OK) != 0) {
+            std::stringstream ss;
+            ss << "SecDataDir '" << yystack_[0].value.as < std::string > () << "' is not writable: " << strerror(errno);
+            driver.error(yystack_[1].location, ss.str());
+            YYERROR;
+        }
+#endif
+        collection::backend::MDBEnvProvider::SetDataDir(yystack_[0].value.as < std::string > ());
+#endif
+      }
+#line 3297 "seclang-parser.cc"
     break;
 
   case 153: // expression: "CONGIG_DIR_SEC_COOKIE_FORMAT"
-#line 1763 "seclang-parser.yy"
+#line 1794 "seclang-parser.yy"
       {
         if (atoi(yystack_[0].value.as < std::string > ().c_str()) == 1) {
           driver.error(yystack_[1].location, "SecCookieFormat 1 is not yet supported.");
           YYERROR;
         }
       }
-#line 3264 "seclang-parser.cc"
+#line 3308 "seclang-parser.cc"
     break;
 
   case 154: // expression: "CONFIG_SEC_COOKIEV0_SEPARATOR"
-#line 1770 "seclang-parser.yy"
+#line 1801 "seclang-parser.yy"
       {
         driver.error(yystack_[1].location, "SecCookieV0Separator is not yet supported.");
         YYERROR;
       }
-#line 3273 "seclang-parser.cc"
+#line 3317 "seclang-parser.cc"
     break;
 
   case 156: // expression: "CONFIG_DIR_UNICODE_MAP_FILE"
-#line 1780 "seclang-parser.yy"
+#line 1811 "seclang-parser.yy"
       {
         std::string error;
         std::vector<std::string> param;
@@ -3327,31 +3371,31 @@ namespace yy {
         }
 
       }
-#line 3331 "seclang-parser.cc"
+#line 3375 "seclang-parser.cc"
     break;
 
   case 157: // expression: "CONFIG_SEC_COLLECTION_TIMEOUT"
-#line 1834 "seclang-parser.yy"
+#line 1865 "seclang-parser.yy"
       {
 /* Parser error disabled to avoid breaking default CRS installations with crs-setup.conf-recommended
         driver.error(@0, "SecCollectionTimeout is not yet supported.");
         YYERROR;
 */
       }
-#line 3342 "seclang-parser.cc"
+#line 3386 "seclang-parser.cc"
     break;
 
   case 158: // expression: "CONFIG_SEC_HTTP_BLKEY"
-#line 1841 "seclang-parser.yy"
+#line 1872 "seclang-parser.yy"
       {
         driver.m_httpblKey.m_set = true;
         driver.m_httpblKey.m_value = yystack_[0].value.as < std::string > ();
       }
-#line 3351 "seclang-parser.cc"
+#line 3395 "seclang-parser.cc"
     break;
 
   case 159: // variables: variables_pre_process
-#line 1849 "seclang-parser.yy"
+#line 1880 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable> > > originalList = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> newList(new std::vector<std::unique_ptr<Variable>>());
@@ -3385,2425 +3429,2425 @@ namespace yy {
         }
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(newNewList);
       }
-#line 3389 "seclang-parser.cc"
+#line 3433 "seclang-parser.cc"
     break;
 
   case 160: // variables_pre_process: variables_may_be_quoted
-#line 1886 "seclang-parser.yy"
+#line 1917 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[0].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3397 "seclang-parser.cc"
+#line 3441 "seclang-parser.cc"
     break;
 
   case 161: // variables_pre_process: "QUOTATION_MARK" variables_may_be_quoted "QUOTATION_MARK"
-#line 1890 "seclang-parser.yy"
+#line 1921 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[1].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3405 "seclang-parser.cc"
+#line 3449 "seclang-parser.cc"
     break;
 
   case 162: // variables_may_be_quoted: variables_may_be_quoted PIPE var
-#line 1897 "seclang-parser.yy"
+#line 1928 "seclang-parser.yy"
       {
         yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[2].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3414 "seclang-parser.cc"
+#line 3458 "seclang-parser.cc"
     break;
 
   case 163: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_EXCLUSION var
-#line 1902 "seclang-parser.yy"
+#line 1933 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3424 "seclang-parser.cc"
+#line 3468 "seclang-parser.cc"
     break;
 
   case 164: // variables_may_be_quoted: variables_may_be_quoted PIPE VAR_COUNT var
-#line 1908 "seclang-parser.yy"
+#line 1939 "seclang-parser.yy"
       {
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ()->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(yystack_[3].value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > ());
       }
-#line 3434 "seclang-parser.cc"
+#line 3478 "seclang-parser.cc"
     break;
 
   case 165: // variables_may_be_quoted: var
-#line 1914 "seclang-parser.yy"
+#line 1945 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         b->push_back(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3444 "seclang-parser.cc"
+#line 3488 "seclang-parser.cc"
     break;
 
   case 166: // variables_may_be_quoted: VAR_EXCLUSION var
-#line 1920 "seclang-parser.yy"
+#line 1951 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorExclusion(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3455 "seclang-parser.cc"
+#line 3499 "seclang-parser.cc"
     break;
 
   case 167: // variables_may_be_quoted: VAR_COUNT var
-#line 1927 "seclang-parser.yy"
+#line 1958 "seclang-parser.yy"
       {
         std::unique_ptr<std::vector<std::unique_ptr<Variable>>> b(new std::vector<std::unique_ptr<Variable>>());
         std::unique_ptr<Variable> c(new VariableModificatorCount(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
         b->push_back(std::move(c));
         yylhs.value.as < std::unique_ptr<std::vector<std::unique_ptr<Variable> > >  > () = std::move(b);
       }
-#line 3466 "seclang-parser.cc"
+#line 3510 "seclang-parser.cc"
     break;
 
   case 168: // var: VARIABLE_ARGS "Dictionary element"
-#line 1937 "seclang-parser.yy"
+#line 1968 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3474 "seclang-parser.cc"
+#line 3518 "seclang-parser.cc"
     break;
 
   case 169: // var: VARIABLE_ARGS "Dictionary element, selected by regexp"
-#line 1941 "seclang-parser.yy"
+#line 1972 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3482 "seclang-parser.cc"
+#line 3526 "seclang-parser.cc"
     break;
 
   case 170: // var: VARIABLE_ARGS
-#line 1945 "seclang-parser.yy"
+#line 1976 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Args_NoDictElement());
       }
-#line 3490 "seclang-parser.cc"
+#line 3534 "seclang-parser.cc"
     break;
 
   case 171: // var: VARIABLE_ARGS_POST "Dictionary element"
-#line 1949 "seclang-parser.yy"
+#line 1980 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3498 "seclang-parser.cc"
+#line 3542 "seclang-parser.cc"
     break;
 
   case 172: // var: VARIABLE_ARGS_POST "Dictionary element, selected by regexp"
-#line 1953 "seclang-parser.yy"
+#line 1984 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3506 "seclang-parser.cc"
+#line 3550 "seclang-parser.cc"
     break;
 
   case 173: // var: VARIABLE_ARGS_POST
-#line 1957 "seclang-parser.yy"
+#line 1988 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPost_NoDictElement());
       }
-#line 3514 "seclang-parser.cc"
+#line 3558 "seclang-parser.cc"
     break;
 
   case 174: // var: VARIABLE_ARGS_GET "Dictionary element"
-#line 1961 "seclang-parser.yy"
+#line 1992 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3522 "seclang-parser.cc"
+#line 3566 "seclang-parser.cc"
     break;
 
   case 175: // var: VARIABLE_ARGS_GET "Dictionary element, selected by regexp"
-#line 1965 "seclang-parser.yy"
+#line 1996 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3530 "seclang-parser.cc"
+#line 3574 "seclang-parser.cc"
     break;
 
   case 176: // var: VARIABLE_ARGS_GET
-#line 1969 "seclang-parser.yy"
+#line 2000 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGet_NoDictElement());
       }
-#line 3538 "seclang-parser.cc"
+#line 3582 "seclang-parser.cc"
     break;
 
   case 177: // var: VARIABLE_FILES_SIZES "Dictionary element"
-#line 1973 "seclang-parser.yy"
+#line 2004 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3546 "seclang-parser.cc"
+#line 3590 "seclang-parser.cc"
     break;
 
   case 178: // var: VARIABLE_FILES_SIZES "Dictionary element, selected by regexp"
-#line 1977 "seclang-parser.yy"
+#line 2008 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3554 "seclang-parser.cc"
+#line 3598 "seclang-parser.cc"
     break;
 
   case 179: // var: VARIABLE_FILES_SIZES
-#line 1981 "seclang-parser.yy"
+#line 2012 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesSizes_NoDictElement());
       }
-#line 3562 "seclang-parser.cc"
+#line 3606 "seclang-parser.cc"
     break;
 
   case 180: // var: VARIABLE_FILES_NAMES "Dictionary element"
-#line 1985 "seclang-parser.yy"
+#line 2016 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3570 "seclang-parser.cc"
+#line 3614 "seclang-parser.cc"
     break;
 
   case 181: // var: VARIABLE_FILES_NAMES "Dictionary element, selected by regexp"
-#line 1989 "seclang-parser.yy"
+#line 2020 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3578 "seclang-parser.cc"
+#line 3622 "seclang-parser.cc"
     break;
 
   case 182: // var: VARIABLE_FILES_NAMES
-#line 1993 "seclang-parser.yy"
+#line 2024 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesNames_NoDictElement());
       }
-#line 3586 "seclang-parser.cc"
+#line 3630 "seclang-parser.cc"
     break;
 
   case 183: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element"
-#line 1997 "seclang-parser.yy"
+#line 2028 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3594 "seclang-parser.cc"
+#line 3638 "seclang-parser.cc"
     break;
 
   case 184: // var: VARIABLE_FILES_TMP_CONTENT "Dictionary element, selected by regexp"
-#line 2001 "seclang-parser.yy"
+#line 2032 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3602 "seclang-parser.cc"
+#line 3646 "seclang-parser.cc"
     break;
 
   case 185: // var: VARIABLE_FILES_TMP_CONTENT
-#line 2005 "seclang-parser.yy"
+#line 2036 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpContent_NoDictElement());
       }
-#line 3610 "seclang-parser.cc"
+#line 3654 "seclang-parser.cc"
     break;
 
   case 186: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element"
-#line 2009 "seclang-parser.yy"
+#line 2040 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3618 "seclang-parser.cc"
+#line 3662 "seclang-parser.cc"
     break;
 
   case 187: // var: VARIABLE_MULTIPART_FILENAME "Dictionary element, selected by regexp"
-#line 2013 "seclang-parser.yy"
+#line 2044 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3626 "seclang-parser.cc"
+#line 3670 "seclang-parser.cc"
     break;
 
   case 188: // var: VARIABLE_MULTIPART_FILENAME
-#line 2017 "seclang-parser.yy"
+#line 2048 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartFileName_NoDictElement());
       }
-#line 3634 "seclang-parser.cc"
+#line 3678 "seclang-parser.cc"
     break;
 
   case 189: // var: VARIABLE_MULTIPART_NAME "Dictionary element"
-#line 2021 "seclang-parser.yy"
+#line 2052 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3642 "seclang-parser.cc"
+#line 3686 "seclang-parser.cc"
     break;
 
   case 190: // var: VARIABLE_MULTIPART_NAME "Dictionary element, selected by regexp"
-#line 2025 "seclang-parser.yy"
+#line 2056 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3650 "seclang-parser.cc"
+#line 3694 "seclang-parser.cc"
     break;
 
   case 191: // var: VARIABLE_MULTIPART_NAME
-#line 2029 "seclang-parser.yy"
+#line 2060 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultiPartName_NoDictElement());
       }
-#line 3658 "seclang-parser.cc"
+#line 3702 "seclang-parser.cc"
     break;
 
   case 192: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element"
-#line 2033 "seclang-parser.yy"
+#line 2064 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3666 "seclang-parser.cc"
+#line 3710 "seclang-parser.cc"
     break;
 
   case 193: // var: VARIABLE_MATCHED_VARS_NAMES "Dictionary element, selected by regexp"
-#line 2037 "seclang-parser.yy"
+#line 2068 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3674 "seclang-parser.cc"
+#line 3718 "seclang-parser.cc"
     break;
 
   case 194: // var: VARIABLE_MATCHED_VARS_NAMES
-#line 2041 "seclang-parser.yy"
+#line 2072 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarsNames_NoDictElement());
       }
-#line 3682 "seclang-parser.cc"
+#line 3726 "seclang-parser.cc"
     break;
 
   case 195: // var: VARIABLE_MATCHED_VARS "Dictionary element"
-#line 2045 "seclang-parser.yy"
+#line 2076 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3690 "seclang-parser.cc"
+#line 3734 "seclang-parser.cc"
     break;
 
   case 196: // var: VARIABLE_MATCHED_VARS "Dictionary element, selected by regexp"
-#line 2049 "seclang-parser.yy"
+#line 2080 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3698 "seclang-parser.cc"
+#line 3742 "seclang-parser.cc"
     break;
 
   case 197: // var: VARIABLE_MATCHED_VARS
-#line 2053 "seclang-parser.yy"
+#line 2084 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVars_NoDictElement());
       }
-#line 3706 "seclang-parser.cc"
+#line 3750 "seclang-parser.cc"
     break;
 
   case 198: // var: VARIABLE_FILES "Dictionary element"
-#line 2057 "seclang-parser.yy"
+#line 2088 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3714 "seclang-parser.cc"
+#line 3758 "seclang-parser.cc"
     break;
 
   case 199: // var: VARIABLE_FILES "Dictionary element, selected by regexp"
-#line 2061 "seclang-parser.yy"
+#line 2092 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3722 "seclang-parser.cc"
+#line 3766 "seclang-parser.cc"
     break;
 
   case 200: // var: VARIABLE_FILES
-#line 2065 "seclang-parser.yy"
+#line 2096 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Files_NoDictElement());
       }
-#line 3730 "seclang-parser.cc"
+#line 3774 "seclang-parser.cc"
     break;
 
   case 201: // var: VARIABLE_REQUEST_COOKIES "Dictionary element"
-#line 2069 "seclang-parser.yy"
+#line 2100 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3738 "seclang-parser.cc"
+#line 3782 "seclang-parser.cc"
     break;
 
   case 202: // var: VARIABLE_REQUEST_COOKIES "Dictionary element, selected by regexp"
-#line 2073 "seclang-parser.yy"
+#line 2104 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3746 "seclang-parser.cc"
+#line 3790 "seclang-parser.cc"
     break;
 
   case 203: // var: VARIABLE_REQUEST_COOKIES
-#line 2077 "seclang-parser.yy"
+#line 2108 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookies_NoDictElement());
       }
-#line 3754 "seclang-parser.cc"
+#line 3798 "seclang-parser.cc"
     break;
 
   case 204: // var: VARIABLE_REQUEST_HEADERS "Dictionary element"
-#line 2081 "seclang-parser.yy"
+#line 2112 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3762 "seclang-parser.cc"
+#line 3806 "seclang-parser.cc"
     break;
 
   case 205: // var: VARIABLE_REQUEST_HEADERS "Dictionary element, selected by regexp"
-#line 2085 "seclang-parser.yy"
+#line 2116 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3770 "seclang-parser.cc"
+#line 3814 "seclang-parser.cc"
     break;
 
   case 206: // var: VARIABLE_REQUEST_HEADERS
-#line 2089 "seclang-parser.yy"
+#line 2120 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeaders_NoDictElement());
       }
-#line 3778 "seclang-parser.cc"
+#line 3822 "seclang-parser.cc"
     break;
 
   case 207: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element"
-#line 2093 "seclang-parser.yy"
+#line 2124 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3786 "seclang-parser.cc"
+#line 3830 "seclang-parser.cc"
     break;
 
   case 208: // var: VARIABLE_RESPONSE_HEADERS "Dictionary element, selected by regexp"
-#line 2097 "seclang-parser.yy"
+#line 2128 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3794 "seclang-parser.cc"
+#line 3838 "seclang-parser.cc"
     break;
 
   case 209: // var: VARIABLE_RESPONSE_HEADERS
-#line 2101 "seclang-parser.yy"
+#line 2132 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeaders_NoDictElement());
       }
-#line 3802 "seclang-parser.cc"
+#line 3846 "seclang-parser.cc"
     break;
 
   case 210: // var: VARIABLE_GEO "Dictionary element"
-#line 2105 "seclang-parser.yy"
+#line 2136 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3810 "seclang-parser.cc"
+#line 3854 "seclang-parser.cc"
     break;
 
   case 211: // var: VARIABLE_GEO "Dictionary element, selected by regexp"
-#line 2109 "seclang-parser.yy"
+#line 2140 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3818 "seclang-parser.cc"
+#line 3862 "seclang-parser.cc"
     break;
 
   case 212: // var: VARIABLE_GEO
-#line 2113 "seclang-parser.yy"
+#line 2144 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Geo_NoDictElement());
       }
-#line 3826 "seclang-parser.cc"
+#line 3870 "seclang-parser.cc"
     break;
 
   case 213: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element"
-#line 2117 "seclang-parser.yy"
+#line 2148 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3834 "seclang-parser.cc"
+#line 3878 "seclang-parser.cc"
     break;
 
   case 214: // var: VARIABLE_REQUEST_COOKIES_NAMES "Dictionary element, selected by regexp"
-#line 2121 "seclang-parser.yy"
+#line 2152 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3842 "seclang-parser.cc"
+#line 3886 "seclang-parser.cc"
     break;
 
   case 215: // var: VARIABLE_REQUEST_COOKIES_NAMES
-#line 2125 "seclang-parser.yy"
+#line 2156 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestCookiesNames_NoDictElement());
       }
-#line 3850 "seclang-parser.cc"
+#line 3894 "seclang-parser.cc"
     break;
 
   case 216: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element"
-#line 2129 "seclang-parser.yy"
+#line 2160 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3858 "seclang-parser.cc"
+#line 3902 "seclang-parser.cc"
     break;
 
   case 217: // var: VARIABLE_MULTIPART_PART_HEADERS "Dictionary element, selected by regexp"
-#line 2133 "seclang-parser.yy"
+#line 2164 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3866 "seclang-parser.cc"
+#line 3910 "seclang-parser.cc"
     break;
 
   case 218: // var: VARIABLE_MULTIPART_PART_HEADERS
-#line 2137 "seclang-parser.yy"
+#line 2168 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartPartHeaders_NoDictElement());
       }
-#line 3874 "seclang-parser.cc"
+#line 3918 "seclang-parser.cc"
     break;
 
   case 219: // var: VARIABLE_RULE "Dictionary element"
-#line 2141 "seclang-parser.yy"
+#line 2172 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3882 "seclang-parser.cc"
+#line 3926 "seclang-parser.cc"
     break;
 
   case 220: // var: VARIABLE_RULE "Dictionary element, selected by regexp"
-#line 2145 "seclang-parser.yy"
+#line 2176 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3890 "seclang-parser.cc"
+#line 3934 "seclang-parser.cc"
     break;
 
   case 221: // var: VARIABLE_RULE
-#line 2149 "seclang-parser.yy"
+#line 2180 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Rule_NoDictElement());
       }
-#line 3898 "seclang-parser.cc"
+#line 3942 "seclang-parser.cc"
     break;
 
   case 222: // var: "RUN_TIME_VAR_ENV" "Dictionary element"
-#line 2153 "seclang-parser.yy"
+#line 2184 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3906 "seclang-parser.cc"
+#line 3950 "seclang-parser.cc"
     break;
 
   case 223: // var: "RUN_TIME_VAR_ENV" "Dictionary element, selected by regexp"
-#line 2157 "seclang-parser.yy"
+#line 2188 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3914 "seclang-parser.cc"
+#line 3958 "seclang-parser.cc"
     break;
 
   case 224: // var: "RUN_TIME_VAR_ENV"
-#line 2161 "seclang-parser.yy"
+#line 2192 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Env("ENV"));
       }
-#line 3922 "seclang-parser.cc"
+#line 3966 "seclang-parser.cc"
     break;
 
   case 225: // var: "RUN_TIME_VAR_XML" "Dictionary element"
-#line 2165 "seclang-parser.yy"
+#line 2196 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3930 "seclang-parser.cc"
+#line 3974 "seclang-parser.cc"
     break;
 
   case 226: // var: "RUN_TIME_VAR_XML" "Dictionary element, selected by regexp"
-#line 2169 "seclang-parser.yy"
+#line 2200 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML("XML:" + yystack_[0].value.as < std::string > ()));
       }
-#line 3938 "seclang-parser.cc"
+#line 3982 "seclang-parser.cc"
     break;
 
   case 227: // var: "RUN_TIME_VAR_XML"
-#line 2173 "seclang-parser.yy"
+#line 2204 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::XML_NoDictElement());
       }
-#line 3946 "seclang-parser.cc"
+#line 3990 "seclang-parser.cc"
     break;
 
   case 228: // var: "FILES_TMPNAMES" "Dictionary element"
-#line 2177 "seclang-parser.yy"
+#line 2208 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3954 "seclang-parser.cc"
+#line 3998 "seclang-parser.cc"
     break;
 
   case 229: // var: "FILES_TMPNAMES" "Dictionary element, selected by regexp"
-#line 2181 "seclang-parser.yy"
+#line 2212 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3962 "seclang-parser.cc"
+#line 4006 "seclang-parser.cc"
     break;
 
   case 230: // var: "FILES_TMPNAMES"
-#line 2185 "seclang-parser.yy"
+#line 2216 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesTmpNames_NoDictElement());
       }
-#line 3970 "seclang-parser.cc"
+#line 4014 "seclang-parser.cc"
     break;
 
   case 231: // var: "RESOURCE" run_time_string
-#line 2189 "seclang-parser.yy"
+#line 2220 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 3978 "seclang-parser.cc"
+#line 4022 "seclang-parser.cc"
     break;
 
   case 232: // var: "RESOURCE" "Dictionary element"
-#line 2193 "seclang-parser.yy"
+#line 2224 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 3986 "seclang-parser.cc"
+#line 4030 "seclang-parser.cc"
     break;
 
   case 233: // var: "RESOURCE" "Dictionary element, selected by regexp"
-#line 2197 "seclang-parser.yy"
+#line 2228 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 3994 "seclang-parser.cc"
+#line 4038 "seclang-parser.cc"
     break;
 
   case 234: // var: "RESOURCE"
-#line 2201 "seclang-parser.yy"
+#line 2232 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Resource_NoDictElement());
       }
-#line 4002 "seclang-parser.cc"
+#line 4046 "seclang-parser.cc"
     break;
 
   case 235: // var: "VARIABLE_IP" run_time_string
-#line 2205 "seclang-parser.yy"
+#line 2236 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4010 "seclang-parser.cc"
+#line 4054 "seclang-parser.cc"
     break;
 
   case 236: // var: "VARIABLE_IP" "Dictionary element"
-#line 2209 "seclang-parser.yy"
+#line 2240 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4018 "seclang-parser.cc"
+#line 4062 "seclang-parser.cc"
     break;
 
   case 237: // var: "VARIABLE_IP" "Dictionary element, selected by regexp"
-#line 2213 "seclang-parser.yy"
+#line 2244 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4026 "seclang-parser.cc"
+#line 4070 "seclang-parser.cc"
     break;
 
   case 238: // var: "VARIABLE_IP"
-#line 2217 "seclang-parser.yy"
+#line 2248 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Ip_NoDictElement());
       }
-#line 4034 "seclang-parser.cc"
+#line 4078 "seclang-parser.cc"
     break;
 
   case 239: // var: "VARIABLE_GLOBAL" run_time_string
-#line 2221 "seclang-parser.yy"
+#line 2252 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4042 "seclang-parser.cc"
+#line 4086 "seclang-parser.cc"
     break;
 
   case 240: // var: "VARIABLE_GLOBAL" "Dictionary element"
-#line 2225 "seclang-parser.yy"
+#line 2256 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4050 "seclang-parser.cc"
+#line 4094 "seclang-parser.cc"
     break;
 
   case 241: // var: "VARIABLE_GLOBAL" "Dictionary element, selected by regexp"
-#line 2229 "seclang-parser.yy"
+#line 2260 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4058 "seclang-parser.cc"
+#line 4102 "seclang-parser.cc"
     break;
 
   case 242: // var: "VARIABLE_GLOBAL"
-#line 2233 "seclang-parser.yy"
+#line 2264 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Global_NoDictElement());
       }
-#line 4066 "seclang-parser.cc"
+#line 4110 "seclang-parser.cc"
     break;
 
   case 243: // var: "VARIABLE_USER" run_time_string
-#line 2237 "seclang-parser.yy"
+#line 2268 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4074 "seclang-parser.cc"
+#line 4118 "seclang-parser.cc"
     break;
 
   case 244: // var: "VARIABLE_USER" "Dictionary element"
-#line 2241 "seclang-parser.yy"
+#line 2272 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4082 "seclang-parser.cc"
+#line 4126 "seclang-parser.cc"
     break;
 
   case 245: // var: "VARIABLE_USER" "Dictionary element, selected by regexp"
-#line 2245 "seclang-parser.yy"
+#line 2276 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4090 "seclang-parser.cc"
+#line 4134 "seclang-parser.cc"
     break;
 
   case 246: // var: "VARIABLE_USER"
-#line 2249 "seclang-parser.yy"
+#line 2280 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::User_NoDictElement());
       }
-#line 4098 "seclang-parser.cc"
+#line 4142 "seclang-parser.cc"
     break;
 
   case 247: // var: "VARIABLE_TX" run_time_string
-#line 2253 "seclang-parser.yy"
+#line 2284 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4106 "seclang-parser.cc"
+#line 4150 "seclang-parser.cc"
     break;
 
   case 248: // var: "VARIABLE_TX" "Dictionary element"
-#line 2257 "seclang-parser.yy"
+#line 2288 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4114 "seclang-parser.cc"
+#line 4158 "seclang-parser.cc"
     break;
 
   case 249: // var: "VARIABLE_TX" "Dictionary element, selected by regexp"
-#line 2261 "seclang-parser.yy"
+#line 2292 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4122 "seclang-parser.cc"
+#line 4166 "seclang-parser.cc"
     break;
 
   case 250: // var: "VARIABLE_TX"
-#line 2265 "seclang-parser.yy"
+#line 2296 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Tx_NoDictElement());
       }
-#line 4130 "seclang-parser.cc"
+#line 4174 "seclang-parser.cc"
     break;
 
   case 251: // var: "VARIABLE_SESSION" run_time_string
-#line 2269 "seclang-parser.yy"
+#line 2300 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DynamicElement(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 4138 "seclang-parser.cc"
+#line 4182 "seclang-parser.cc"
     break;
 
   case 252: // var: "VARIABLE_SESSION" "Dictionary element"
-#line 2273 "seclang-parser.yy"
+#line 2304 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4146 "seclang-parser.cc"
+#line 4190 "seclang-parser.cc"
     break;
 
   case 253: // var: "VARIABLE_SESSION" "Dictionary element, selected by regexp"
-#line 2277 "seclang-parser.yy"
+#line 2308 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4154 "seclang-parser.cc"
+#line 4198 "seclang-parser.cc"
     break;
 
   case 254: // var: "VARIABLE_SESSION"
-#line 2281 "seclang-parser.yy"
+#line 2312 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Session_NoDictElement());
       }
-#line 4162 "seclang-parser.cc"
+#line 4206 "seclang-parser.cc"
     break;
 
   case 255: // var: "Variable ARGS_NAMES" "Dictionary element"
-#line 2285 "seclang-parser.yy"
+#line 2316 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4170 "seclang-parser.cc"
+#line 4214 "seclang-parser.cc"
     break;
 
   case 256: // var: "Variable ARGS_NAMES" "Dictionary element, selected by regexp"
-#line 2289 "seclang-parser.yy"
+#line 2320 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4178 "seclang-parser.cc"
+#line 4222 "seclang-parser.cc"
     break;
 
   case 257: // var: "Variable ARGS_NAMES"
-#line 2293 "seclang-parser.yy"
+#line 2324 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsNames_NoDictElement());
       }
-#line 4186 "seclang-parser.cc"
+#line 4230 "seclang-parser.cc"
     break;
 
   case 258: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element"
-#line 2297 "seclang-parser.yy"
+#line 2328 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4194 "seclang-parser.cc"
+#line 4238 "seclang-parser.cc"
     break;
 
   case 259: // var: VARIABLE_ARGS_GET_NAMES "Dictionary element, selected by regexp"
-#line 2301 "seclang-parser.yy"
+#line 2332 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4202 "seclang-parser.cc"
+#line 4246 "seclang-parser.cc"
     break;
 
   case 260: // var: VARIABLE_ARGS_GET_NAMES
-#line 2305 "seclang-parser.yy"
+#line 2336 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsGetNames_NoDictElement());
       }
-#line 4210 "seclang-parser.cc"
+#line 4254 "seclang-parser.cc"
     break;
 
   case 261: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element"
-#line 2310 "seclang-parser.yy"
+#line 2341 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4218 "seclang-parser.cc"
+#line 4262 "seclang-parser.cc"
     break;
 
   case 262: // var: VARIABLE_ARGS_POST_NAMES "Dictionary element, selected by regexp"
-#line 2314 "seclang-parser.yy"
+#line 2345 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4226 "seclang-parser.cc"
+#line 4270 "seclang-parser.cc"
     break;
 
   case 263: // var: VARIABLE_ARGS_POST_NAMES
-#line 2318 "seclang-parser.yy"
+#line 2349 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsPostNames_NoDictElement());
       }
-#line 4234 "seclang-parser.cc"
+#line 4278 "seclang-parser.cc"
     break;
 
   case 264: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element"
-#line 2323 "seclang-parser.yy"
+#line 2354 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4242 "seclang-parser.cc"
+#line 4286 "seclang-parser.cc"
     break;
 
   case 265: // var: VARIABLE_REQUEST_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2327 "seclang-parser.yy"
+#line 2358 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4250 "seclang-parser.cc"
+#line 4294 "seclang-parser.cc"
     break;
 
   case 266: // var: VARIABLE_REQUEST_HEADERS_NAMES
-#line 2331 "seclang-parser.yy"
+#line 2362 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestHeadersNames_NoDictElement());
       }
-#line 4258 "seclang-parser.cc"
+#line 4302 "seclang-parser.cc"
     break;
 
   case 267: // var: VARIABLE_RESPONSE_CONTENT_TYPE
-#line 2336 "seclang-parser.yy"
+#line 2367 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentType());
       }
-#line 4266 "seclang-parser.cc"
+#line 4310 "seclang-parser.cc"
     break;
 
   case 268: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element"
-#line 2341 "seclang-parser.yy"
+#line 2372 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElement(yystack_[0].value.as < std::string > ()));
       }
-#line 4274 "seclang-parser.cc"
+#line 4318 "seclang-parser.cc"
     break;
 
   case 269: // var: VARIABLE_RESPONSE_HEADERS_NAMES "Dictionary element, selected by regexp"
-#line 2345 "seclang-parser.yy"
+#line 2376 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_DictElementRegexp(yystack_[0].value.as < std::string > ()));
       }
-#line 4282 "seclang-parser.cc"
+#line 4326 "seclang-parser.cc"
     break;
 
   case 270: // var: VARIABLE_RESPONSE_HEADERS_NAMES
-#line 2349 "seclang-parser.yy"
+#line 2380 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseHeadersNames_NoDictElement());
       }
-#line 4290 "seclang-parser.cc"
+#line 4334 "seclang-parser.cc"
     break;
 
   case 271: // var: VARIABLE_ARGS_COMBINED_SIZE
-#line 2353 "seclang-parser.yy"
+#line 2384 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ArgsCombinedSize());
       }
-#line 4298 "seclang-parser.cc"
+#line 4342 "seclang-parser.cc"
     break;
 
   case 272: // var: "AUTH_TYPE"
-#line 2357 "seclang-parser.yy"
+#line 2388 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::AuthType());
       }
-#line 4306 "seclang-parser.cc"
+#line 4350 "seclang-parser.cc"
     break;
 
   case 273: // var: "FILES_COMBINED_SIZE"
-#line 2361 "seclang-parser.yy"
+#line 2392 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FilesCombinedSize());
       }
-#line 4314 "seclang-parser.cc"
+#line 4358 "seclang-parser.cc"
     break;
 
   case 274: // var: "FULL_REQUEST"
-#line 2365 "seclang-parser.yy"
+#line 2396 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequest());
       }
-#line 4322 "seclang-parser.cc"
+#line 4366 "seclang-parser.cc"
     break;
 
   case 275: // var: "FULL_REQUEST_LENGTH"
-#line 2369 "seclang-parser.yy"
+#line 2400 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::FullRequestLength());
       }
-#line 4330 "seclang-parser.cc"
+#line 4374 "seclang-parser.cc"
     break;
 
   case 276: // var: "INBOUND_DATA_ERROR"
-#line 2373 "seclang-parser.yy"
+#line 2404 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::InboundDataError());
       }
-#line 4338 "seclang-parser.cc"
+#line 4382 "seclang-parser.cc"
     break;
 
   case 277: // var: "MATCHED_VAR"
-#line 2377 "seclang-parser.yy"
+#line 2408 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVar());
       }
-#line 4346 "seclang-parser.cc"
+#line 4390 "seclang-parser.cc"
     break;
 
   case 278: // var: "MATCHED_VAR_NAME"
-#line 2381 "seclang-parser.yy"
+#line 2412 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MatchedVarName());
       }
-#line 4354 "seclang-parser.cc"
+#line 4398 "seclang-parser.cc"
     break;
 
   case 279: // var: "MSC_PCRE_ERROR"
-#line 2385 "seclang-parser.yy"
+#line 2416 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreError());
       }
-#line 4362 "seclang-parser.cc"
+#line 4406 "seclang-parser.cc"
     break;
 
   case 280: // var: "MSC_PCRE_LIMITS_EXCEEDED"
-#line 2389 "seclang-parser.yy"
+#line 2420 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MscPcreLimitsExceeded());
       }
-#line 4370 "seclang-parser.cc"
+#line 4414 "seclang-parser.cc"
     break;
 
   case 281: // var: VARIABLE_MULTIPART_BOUNDARY_QUOTED
-#line 2393 "seclang-parser.yy"
+#line 2424 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryQuoted());
       }
-#line 4378 "seclang-parser.cc"
+#line 4422 "seclang-parser.cc"
     break;
 
   case 282: // var: VARIABLE_MULTIPART_BOUNDARY_WHITESPACE
-#line 2397 "seclang-parser.yy"
+#line 2428 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartBoundaryWhiteSpace());
       }
-#line 4386 "seclang-parser.cc"
+#line 4430 "seclang-parser.cc"
     break;
 
   case 283: // var: "MULTIPART_CRLF_LF_LINES"
-#line 2401 "seclang-parser.yy"
+#line 2432 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartCrlfLFLines());
       }
-#line 4394 "seclang-parser.cc"
+#line 4438 "seclang-parser.cc"
     break;
 
   case 284: // var: "MULTIPART_DATA_AFTER"
-#line 2405 "seclang-parser.yy"
+#line 2436 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateAfter());
       }
-#line 4402 "seclang-parser.cc"
+#line 4446 "seclang-parser.cc"
     break;
 
   case 285: // var: VARIABLE_MULTIPART_DATA_BEFORE
-#line 2409 "seclang-parser.yy"
+#line 2440 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartDateBefore());
       }
-#line 4410 "seclang-parser.cc"
+#line 4454 "seclang-parser.cc"
     break;
 
   case 286: // var: "MULTIPART_FILE_LIMIT_EXCEEDED"
-#line 2413 "seclang-parser.yy"
+#line 2444 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartFileLimitExceeded());
       }
-#line 4418 "seclang-parser.cc"
+#line 4462 "seclang-parser.cc"
     break;
 
   case 287: // var: "MULTIPART_HEADER_FOLDING"
-#line 2417 "seclang-parser.yy"
+#line 2448 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartHeaderFolding());
       }
-#line 4426 "seclang-parser.cc"
+#line 4470 "seclang-parser.cc"
     break;
 
   case 288: // var: "MULTIPART_INVALID_HEADER_FOLDING"
-#line 2421 "seclang-parser.yy"
+#line 2452 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidHeaderFolding());
       }
-#line 4434 "seclang-parser.cc"
+#line 4478 "seclang-parser.cc"
     break;
 
   case 289: // var: VARIABLE_MULTIPART_INVALID_PART
-#line 2425 "seclang-parser.yy"
+#line 2456 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidPart());
       }
-#line 4442 "seclang-parser.cc"
+#line 4486 "seclang-parser.cc"
     break;
 
   case 290: // var: "MULTIPART_INVALID_QUOTING"
-#line 2429 "seclang-parser.yy"
+#line 2460 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartInvalidQuoting());
       }
-#line 4450 "seclang-parser.cc"
+#line 4494 "seclang-parser.cc"
     break;
 
   case 291: // var: VARIABLE_MULTIPART_LF_LINE
-#line 2433 "seclang-parser.yy"
+#line 2464 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartLFLine());
       }
-#line 4458 "seclang-parser.cc"
+#line 4502 "seclang-parser.cc"
     break;
 
   case 292: // var: VARIABLE_MULTIPART_MISSING_SEMICOLON
-#line 2437 "seclang-parser.yy"
+#line 2468 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4466 "seclang-parser.cc"
+#line 4510 "seclang-parser.cc"
     break;
 
   case 293: // var: VARIABLE_MULTIPART_SEMICOLON_MISSING
-#line 2441 "seclang-parser.yy"
+#line 2472 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartMissingSemicolon());
       }
-#line 4474 "seclang-parser.cc"
+#line 4518 "seclang-parser.cc"
     break;
 
   case 294: // var: "MULTIPART_STRICT_ERROR"
-#line 2445 "seclang-parser.yy"
+#line 2476 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartStrictError());
       }
-#line 4482 "seclang-parser.cc"
+#line 4526 "seclang-parser.cc"
     break;
 
   case 295: // var: "MULTIPART_UNMATCHED_BOUNDARY"
-#line 2449 "seclang-parser.yy"
+#line 2480 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::MultipartUnmatchedBoundary());
       }
-#line 4490 "seclang-parser.cc"
+#line 4534 "seclang-parser.cc"
     break;
 
   case 296: // var: "OUTBOUND_DATA_ERROR"
-#line 2453 "seclang-parser.yy"
+#line 2484 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::OutboundDataError());
       }
-#line 4498 "seclang-parser.cc"
+#line 4542 "seclang-parser.cc"
     break;
 
   case 297: // var: "PATH_INFO"
-#line 2457 "seclang-parser.yy"
+#line 2488 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::PathInfo());
       }
-#line 4506 "seclang-parser.cc"
+#line 4550 "seclang-parser.cc"
     break;
 
   case 298: // var: "QUERY_STRING"
-#line 2461 "seclang-parser.yy"
+#line 2492 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::QueryString());
       }
-#line 4514 "seclang-parser.cc"
+#line 4558 "seclang-parser.cc"
     break;
 
   case 299: // var: "REMOTE_ADDR"
-#line 2465 "seclang-parser.yy"
+#line 2496 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteAddr());
       }
-#line 4522 "seclang-parser.cc"
+#line 4566 "seclang-parser.cc"
     break;
 
   case 300: // var: "REMOTE_HOST"
-#line 2469 "seclang-parser.yy"
+#line 2500 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemoteHost());
       }
-#line 4530 "seclang-parser.cc"
+#line 4574 "seclang-parser.cc"
     break;
 
   case 301: // var: "REMOTE_PORT"
-#line 2473 "seclang-parser.yy"
+#line 2504 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RemotePort());
       }
-#line 4538 "seclang-parser.cc"
+#line 4582 "seclang-parser.cc"
     break;
 
   case 302: // var: "REQBODY_ERROR"
-#line 2477 "seclang-parser.yy"
+#line 2508 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyError());
       }
-#line 4546 "seclang-parser.cc"
+#line 4590 "seclang-parser.cc"
     break;
 
   case 303: // var: "REQBODY_ERROR_MSG"
-#line 2481 "seclang-parser.yy"
+#line 2512 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyErrorMsg());
       }
-#line 4554 "seclang-parser.cc"
+#line 4598 "seclang-parser.cc"
     break;
 
   case 304: // var: "REQBODY_PROCESSOR"
-#line 2485 "seclang-parser.yy"
+#line 2516 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessor());
       }
-#line 4562 "seclang-parser.cc"
+#line 4606 "seclang-parser.cc"
     break;
 
   case 305: // var: "REQBODY_PROCESSOR_ERROR"
-#line 2489 "seclang-parser.yy"
+#line 2520 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorError());
       }
-#line 4570 "seclang-parser.cc"
+#line 4614 "seclang-parser.cc"
     break;
 
   case 306: // var: "REQBODY_PROCESSOR_ERROR_MSG"
-#line 2493 "seclang-parser.yy"
+#line 2524 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ReqbodyProcessorErrorMsg());
       }
-#line 4578 "seclang-parser.cc"
+#line 4622 "seclang-parser.cc"
     break;
 
   case 307: // var: "REQUEST_BASENAME"
-#line 2497 "seclang-parser.yy"
+#line 2528 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBasename());
       }
-#line 4586 "seclang-parser.cc"
+#line 4630 "seclang-parser.cc"
     break;
 
   case 308: // var: "REQUEST_BODY"
-#line 2501 "seclang-parser.yy"
+#line 2532 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBody());
       }
-#line 4594 "seclang-parser.cc"
+#line 4638 "seclang-parser.cc"
     break;
 
   case 309: // var: "REQUEST_BODY_LENGTH"
-#line 2505 "seclang-parser.yy"
+#line 2536 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestBodyLength());
       }
-#line 4602 "seclang-parser.cc"
+#line 4646 "seclang-parser.cc"
     break;
 
   case 310: // var: "REQUEST_FILENAME"
-#line 2509 "seclang-parser.yy"
+#line 2540 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestFilename());
       }
-#line 4610 "seclang-parser.cc"
+#line 4654 "seclang-parser.cc"
     break;
 
   case 311: // var: "REQUEST_LINE"
-#line 2513 "seclang-parser.yy"
+#line 2544 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestLine());
       }
-#line 4618 "seclang-parser.cc"
+#line 4662 "seclang-parser.cc"
     break;
 
   case 312: // var: "REQUEST_METHOD"
-#line 2517 "seclang-parser.yy"
+#line 2548 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestMethod());
       }
-#line 4626 "seclang-parser.cc"
+#line 4670 "seclang-parser.cc"
     break;
 
   case 313: // var: "REQUEST_PROTOCOL"
-#line 2521 "seclang-parser.yy"
+#line 2552 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestProtocol());
       }
-#line 4634 "seclang-parser.cc"
+#line 4678 "seclang-parser.cc"
     break;
 
   case 314: // var: "REQUEST_URI"
-#line 2525 "seclang-parser.yy"
+#line 2556 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURI());
       }
-#line 4642 "seclang-parser.cc"
+#line 4686 "seclang-parser.cc"
     break;
 
   case 315: // var: "REQUEST_URI_RAW"
-#line 2529 "seclang-parser.yy"
+#line 2560 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::RequestURIRaw());
       }
-#line 4650 "seclang-parser.cc"
+#line 4694 "seclang-parser.cc"
     break;
 
   case 316: // var: "RESPONSE_BODY"
-#line 2533 "seclang-parser.yy"
+#line 2564 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseBody());
       }
-#line 4658 "seclang-parser.cc"
+#line 4702 "seclang-parser.cc"
     break;
 
   case 317: // var: "RESPONSE_CONTENT_LENGTH"
-#line 2537 "seclang-parser.yy"
+#line 2568 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseContentLength());
       }
-#line 4666 "seclang-parser.cc"
+#line 4710 "seclang-parser.cc"
     break;
 
   case 318: // var: "RESPONSE_PROTOCOL"
-#line 2541 "seclang-parser.yy"
+#line 2572 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseProtocol());
       }
-#line 4674 "seclang-parser.cc"
+#line 4718 "seclang-parser.cc"
     break;
 
   case 319: // var: "RESPONSE_STATUS"
-#line 2545 "seclang-parser.yy"
+#line 2576 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ResponseStatus());
       }
-#line 4682 "seclang-parser.cc"
+#line 4726 "seclang-parser.cc"
     break;
 
   case 320: // var: "SERVER_ADDR"
-#line 2549 "seclang-parser.yy"
+#line 2580 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerAddr());
       }
-#line 4690 "seclang-parser.cc"
+#line 4734 "seclang-parser.cc"
     break;
 
   case 321: // var: "SERVER_NAME"
-#line 2553 "seclang-parser.yy"
+#line 2584 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerName());
       }
-#line 4698 "seclang-parser.cc"
+#line 4742 "seclang-parser.cc"
     break;
 
   case 322: // var: "SERVER_PORT"
-#line 2557 "seclang-parser.yy"
+#line 2588 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::ServerPort());
       }
-#line 4706 "seclang-parser.cc"
+#line 4750 "seclang-parser.cc"
     break;
 
   case 323: // var: "SESSIONID"
-#line 2561 "seclang-parser.yy"
+#line 2592 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::SessionID());
       }
-#line 4714 "seclang-parser.cc"
+#line 4758 "seclang-parser.cc"
     break;
 
   case 324: // var: "UNIQUE_ID"
-#line 2565 "seclang-parser.yy"
+#line 2596 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UniqueID());
       }
-#line 4722 "seclang-parser.cc"
+#line 4766 "seclang-parser.cc"
     break;
 
   case 325: // var: "URLENCODED_ERROR"
-#line 2569 "seclang-parser.yy"
+#line 2600 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UrlEncodedError());
       }
-#line 4730 "seclang-parser.cc"
+#line 4774 "seclang-parser.cc"
     break;
 
   case 326: // var: "USERID"
-#line 2573 "seclang-parser.yy"
+#line 2604 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::UserID());
       }
-#line 4738 "seclang-parser.cc"
+#line 4782 "seclang-parser.cc"
     break;
 
   case 327: // var: "VARIABLE_STATUS"
-#line 2577 "seclang-parser.yy"
+#line 2608 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4746 "seclang-parser.cc"
+#line 4790 "seclang-parser.cc"
     break;
 
   case 328: // var: "VARIABLE_STATUS_LINE"
-#line 2581 "seclang-parser.yy"
+#line 2612 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::Status());
       }
-#line 4754 "seclang-parser.cc"
+#line 4798 "seclang-parser.cc"
     break;
 
   case 329: // var: "WEBAPPID"
-#line 2585 "seclang-parser.yy"
+#line 2616 "seclang-parser.yy"
       {
         VARIABLE_CONTAINER(yylhs.value.as < std::unique_ptr<Variable> > (), new variables::WebAppId());
       }
-#line 4762 "seclang-parser.cc"
+#line 4806 "seclang-parser.cc"
     break;
 
   case 330: // var: "RUN_TIME_VAR_DUR"
-#line 2589 "seclang-parser.yy"
+#line 2620 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Duration(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4773 "seclang-parser.cc"
+#line 4817 "seclang-parser.cc"
     break;
 
   case 331: // var: "RUN_TIME_VAR_BLD"
-#line 2597 "seclang-parser.yy"
+#line 2628 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new ModsecBuild(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4784 "seclang-parser.cc"
+#line 4828 "seclang-parser.cc"
     break;
 
   case 332: // var: "RUN_TIME_VAR_HSV"
-#line 2604 "seclang-parser.yy"
+#line 2635 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new HighestSeverity(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4795 "seclang-parser.cc"
+#line 4839 "seclang-parser.cc"
     break;
 
   case 333: // var: "RUN_TIME_VAR_REMOTE_USER"
-#line 2611 "seclang-parser.yy"
+#line 2642 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new RemoteUser(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4806 "seclang-parser.cc"
+#line 4850 "seclang-parser.cc"
     break;
 
   case 334: // var: "RUN_TIME_VAR_TIME"
-#line 2618 "seclang-parser.yy"
+#line 2649 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new Time(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4817 "seclang-parser.cc"
+#line 4861 "seclang-parser.cc"
     break;
 
   case 335: // var: "RUN_TIME_VAR_TIME_DAY"
-#line 2625 "seclang-parser.yy"
+#line 2656 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4828 "seclang-parser.cc"
+#line 4872 "seclang-parser.cc"
     break;
 
   case 336: // var: "RUN_TIME_VAR_TIME_EPOCH"
-#line 2632 "seclang-parser.yy"
+#line 2663 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeEpoch(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4839 "seclang-parser.cc"
+#line 4883 "seclang-parser.cc"
     break;
 
   case 337: // var: "RUN_TIME_VAR_TIME_HOUR"
-#line 2639 "seclang-parser.yy"
+#line 2670 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeHour(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4850 "seclang-parser.cc"
+#line 4894 "seclang-parser.cc"
     break;
 
   case 338: // var: "RUN_TIME_VAR_TIME_MIN"
-#line 2646 "seclang-parser.yy"
+#line 2677 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMin(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4861 "seclang-parser.cc"
+#line 4905 "seclang-parser.cc"
     break;
 
   case 339: // var: "RUN_TIME_VAR_TIME_MON"
-#line 2653 "seclang-parser.yy"
+#line 2684 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeMon(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4872 "seclang-parser.cc"
+#line 4916 "seclang-parser.cc"
     break;
 
   case 340: // var: "RUN_TIME_VAR_TIME_SEC"
-#line 2660 "seclang-parser.yy"
+#line 2691 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
             std::unique_ptr<Variable> c(new TimeSec(name));
             yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4883 "seclang-parser.cc"
+#line 4927 "seclang-parser.cc"
     break;
 
   case 341: // var: "RUN_TIME_VAR_TIME_WDAY"
-#line 2667 "seclang-parser.yy"
+#line 2698 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeWDay(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4894 "seclang-parser.cc"
+#line 4938 "seclang-parser.cc"
     break;
 
   case 342: // var: "RUN_TIME_VAR_TIME_YEAR"
-#line 2674 "seclang-parser.yy"
+#line 2705 "seclang-parser.yy"
       {
         std::string name(yystack_[0].value.as < std::string > ());
         char z = name.at(0);
         std::unique_ptr<Variable> c(new TimeYear(name));
         yylhs.value.as < std::unique_ptr<Variable> > () = std::move(c);
       }
-#line 4905 "seclang-parser.cc"
+#line 4949 "seclang-parser.cc"
     break;
 
   case 343: // act: "Accuracy"
-#line 2684 "seclang-parser.yy"
+#line 2715 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Accuracy(yystack_[0].value.as < std::string > ()));
       }
-#line 4913 "seclang-parser.cc"
+#line 4957 "seclang-parser.cc"
     break;
 
   case 344: // act: "Allow"
-#line 2688 "seclang-parser.yy"
+#line 2719 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Allow(yystack_[0].value.as < std::string > ()));
       }
-#line 4921 "seclang-parser.cc"
+#line 4965 "seclang-parser.cc"
     break;
 
   case 345: // act: "Append"
-#line 2692 "seclang-parser.yy"
+#line 2723 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Append", yystack_[1].location);
       }
-#line 4929 "seclang-parser.cc"
+#line 4973 "seclang-parser.cc"
     break;
 
   case 346: // act: "AuditLog"
-#line 2696 "seclang-parser.yy"
+#line 2727 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::AuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 4937 "seclang-parser.cc"
+#line 4981 "seclang-parser.cc"
     break;
 
   case 347: // act: "Block"
-#line 2700 "seclang-parser.yy"
+#line 2731 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Block(yystack_[0].value.as < std::string > ()));
       }
-#line 4945 "seclang-parser.cc"
+#line 4989 "seclang-parser.cc"
     break;
 
   case 348: // act: "Capture"
-#line 2704 "seclang-parser.yy"
+#line 2735 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Capture(yystack_[0].value.as < std::string > ()));
       }
-#line 4953 "seclang-parser.cc"
+#line 4997 "seclang-parser.cc"
     break;
 
   case 349: // act: "Chain"
-#line 2708 "seclang-parser.yy"
+#line 2739 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Chain(yystack_[0].value.as < std::string > ()));
       }
-#line 4961 "seclang-parser.cc"
+#line 5005 "seclang-parser.cc"
     break;
 
   case 350: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_ON"
-#line 2712 "seclang-parser.yy"
+#line 2743 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=on"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4970 "seclang-parser.cc"
+#line 5014 "seclang-parser.cc"
     break;
 
   case 351: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_OFF"
-#line 2717 "seclang-parser.yy"
+#line 2748 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=off"));
       }
-#line 4978 "seclang-parser.cc"
+#line 5022 "seclang-parser.cc"
     break;
 
   case 352: // act: "ACTION_CTL_AUDIT_ENGINE" "CONFIG_VALUE_RELEVANT_ONLY"
-#line 2721 "seclang-parser.yy"
+#line 2752 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditEngine("ctl:auditengine=relevantonly"));
         driver.m_auditLog->setCtlAuditEngineActive();
       }
-#line 4987 "seclang-parser.cc"
+#line 5031 "seclang-parser.cc"
     break;
 
   case 353: // act: "ACTION_CTL_AUDIT_LOG_PARTS"
-#line 2726 "seclang-parser.yy"
+#line 2757 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::AuditLogParts(yystack_[0].value.as < std::string > ()));
       }
-#line 4995 "seclang-parser.cc"
+#line 5039 "seclang-parser.cc"
     break;
 
   case 354: // act: "ACTION_CTL_BDY_JSON"
-#line 2730 "seclang-parser.yy"
+#line 2761 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorJSON(yystack_[0].value.as < std::string > ()));
       }
-#line 5003 "seclang-parser.cc"
+#line 5047 "seclang-parser.cc"
     break;
 
   case 355: // act: "ACTION_CTL_BDY_XML"
-#line 2734 "seclang-parser.yy"
+#line 2765 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorXML(yystack_[0].value.as < std::string > ()));
       }
-#line 5011 "seclang-parser.cc"
+#line 5055 "seclang-parser.cc"
     break;
 
   case 356: // act: "ACTION_CTL_BDY_URLENCODED"
-#line 2738 "seclang-parser.yy"
+#line 2769 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyProcessorURLENCODED(yystack_[0].value.as < std::string > ()));
       }
-#line 5019 "seclang-parser.cc"
+#line 5063 "seclang-parser.cc"
     break;
 
   case 357: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_ON"
-#line 2742 "seclang-parser.yy"
+#line 2773 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 5028 "seclang-parser.cc"
+#line 5072 "seclang-parser.cc"
     break;
 
   case 358: // act: "ACTION_CTL_FORCE_REQ_BODY_VAR" "CONFIG_VALUE_OFF"
-#line 2747 "seclang-parser.yy"
+#line 2778 "seclang-parser.yy"
       {
         //ACTION_NOT_SUPPORTED("CtlForceReequestBody", @0);
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Action(yystack_[1].value.as < std::string > ()));
       }
-#line 5037 "seclang-parser.cc"
+#line 5081 "seclang-parser.cc"
     break;
 
   case 359: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ON"
-#line 2752 "seclang-parser.yy"
+#line 2783 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=on"));
       }
-#line 5045 "seclang-parser.cc"
+#line 5089 "seclang-parser.cc"
     break;
 
   case 360: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_OFF"
-#line 2756 "seclang-parser.yy"
+#line 2787 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=off"));
       }
-#line 5053 "seclang-parser.cc"
+#line 5097 "seclang-parser.cc"
     break;
 
   case 361: // act: "ACTION_CTL_PARSE_XML_INTO_ARGS" "CONFIG_VALUE_ONLYARGS"
-#line 2760 "seclang-parser.yy"
+#line 2791 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::ParseXmlIntoArgs("ctl:parseXmlIntoArgs=onlyargs"));
       }
-#line 5061 "seclang-parser.cc"
+#line 5105 "seclang-parser.cc"
     break;
 
   case 362: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_ON"
-#line 2764 "seclang-parser.yy"
+#line 2795 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "true"));
       }
-#line 5069 "seclang-parser.cc"
+#line 5113 "seclang-parser.cc"
     break;
 
   case 363: // act: "ACTION_CTL_REQUEST_BODY_ACCESS" "CONFIG_VALUE_OFF"
-#line 2768 "seclang-parser.yy"
+#line 2799 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RequestBodyAccess(yystack_[1].value.as < std::string > () + "false"));
       }
-#line 5077 "seclang-parser.cc"
+#line 5121 "seclang-parser.cc"
     break;
 
   case 364: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_ON"
-#line 2772 "seclang-parser.yy"
+#line 2803 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=on"));
       }
-#line 5085 "seclang-parser.cc"
+#line 5129 "seclang-parser.cc"
     break;
 
   case 365: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_OFF"
-#line 2776 "seclang-parser.yy"
+#line 2807 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=off"));
       }
-#line 5093 "seclang-parser.cc"
+#line 5137 "seclang-parser.cc"
     break;
 
   case 366: // act: "ACTION_CTL_RULE_ENGINE" "CONFIG_VALUE_DETC"
-#line 2780 "seclang-parser.yy"
+#line 2811 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleEngine("ctl:RuleEngine=detectiononly"));
       }
-#line 5101 "seclang-parser.cc"
+#line 5145 "seclang-parser.cc"
     break;
 
   case 367: // act: "ACTION_CTL_RULE_REMOVE_BY_ID"
-#line 2784 "seclang-parser.yy"
+#line 2815 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveById(yystack_[0].value.as < std::string > ()));
       }
-#line 5109 "seclang-parser.cc"
+#line 5153 "seclang-parser.cc"
     break;
 
   case 368: // act: "ACTION_CTL_RULE_REMOVE_BY_TAG"
-#line 2788 "seclang-parser.yy"
+#line 2819 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5117 "seclang-parser.cc"
+#line 5161 "seclang-parser.cc"
     break;
 
   case 369: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_ID"
-#line 2792 "seclang-parser.yy"
+#line 2823 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetById(yystack_[0].value.as < std::string > ()));
       }
-#line 5125 "seclang-parser.cc"
+#line 5169 "seclang-parser.cc"
     break;
 
   case 370: // act: "ACTION_CTL_RULE_REMOVE_TARGET_BY_TAG"
-#line 2796 "seclang-parser.yy"
+#line 2827 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ctl::RuleRemoveTargetByTag(yystack_[0].value.as < std::string > ()));
       }
-#line 5133 "seclang-parser.cc"
+#line 5177 "seclang-parser.cc"
     break;
 
   case 371: // act: "Deny"
-#line 2800 "seclang-parser.yy"
+#line 2831 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Deny(yystack_[0].value.as < std::string > ()));
       }
-#line 5141 "seclang-parser.cc"
+#line 5185 "seclang-parser.cc"
     break;
 
   case 372: // act: "DeprecateVar"
-#line 2804 "seclang-parser.yy"
+#line 2835 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("DeprecateVar", yystack_[1].location);
       }
-#line 5149 "seclang-parser.cc"
+#line 5193 "seclang-parser.cc"
     break;
 
   case 373: // act: "Drop"
-#line 2808 "seclang-parser.yy"
+#line 2839 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Drop(yystack_[0].value.as < std::string > ()));
       }
-#line 5157 "seclang-parser.cc"
+#line 5201 "seclang-parser.cc"
     break;
 
   case 374: // act: "Exec"
-#line 2812 "seclang-parser.yy"
+#line 2843 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Exec(yystack_[0].value.as < std::string > ()));
       }
-#line 5165 "seclang-parser.cc"
+#line 5209 "seclang-parser.cc"
     break;
 
   case 375: // act: "ExpireVar" run_time_string
-#line 2816 "seclang-parser.yy"
+#line 2847 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::ExpireVar(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5173 "seclang-parser.cc"
+#line 5217 "seclang-parser.cc"
     break;
 
   case 376: // act: "Id"
-#line 2820 "seclang-parser.yy"
+#line 2851 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::RuleId(yystack_[0].value.as < std::string > ()));
       }
-#line 5181 "seclang-parser.cc"
+#line 5225 "seclang-parser.cc"
     break;
 
   case 377: // act: "InitCol" run_time_string
-#line 2824 "seclang-parser.yy"
+#line 2855 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::InitCol(yystack_[1].value.as < std::string > (), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5189 "seclang-parser.cc"
+#line 5233 "seclang-parser.cc"
     break;
 
   case 378: // act: "LogData" run_time_string
-#line 2828 "seclang-parser.yy"
+#line 2859 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::LogData(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5197 "seclang-parser.cc"
+#line 5241 "seclang-parser.cc"
     break;
 
   case 379: // act: "Log"
-#line 2832 "seclang-parser.yy"
+#line 2863 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Log(yystack_[0].value.as < std::string > ()));
       }
-#line 5205 "seclang-parser.cc"
+#line 5249 "seclang-parser.cc"
     break;
 
   case 380: // act: "Maturity"
-#line 2836 "seclang-parser.yy"
+#line 2867 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Maturity(yystack_[0].value.as < std::string > ()));
       }
-#line 5213 "seclang-parser.cc"
+#line 5257 "seclang-parser.cc"
     break;
 
   case 381: // act: "Msg" run_time_string
-#line 2840 "seclang-parser.yy"
+#line 2871 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Msg(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5221 "seclang-parser.cc"
+#line 5265 "seclang-parser.cc"
     break;
 
   case 382: // act: "MultiMatch"
-#line 2844 "seclang-parser.yy"
+#line 2875 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::MultiMatch(yystack_[0].value.as < std::string > ()));
       }
-#line 5229 "seclang-parser.cc"
+#line 5273 "seclang-parser.cc"
     break;
 
   case 383: // act: "NoAuditLog"
-#line 2848 "seclang-parser.yy"
+#line 2879 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoAuditLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5237 "seclang-parser.cc"
+#line 5281 "seclang-parser.cc"
     break;
 
   case 384: // act: "NoLog"
-#line 2852 "seclang-parser.yy"
+#line 2883 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::NoLog(yystack_[0].value.as < std::string > ()));
       }
-#line 5245 "seclang-parser.cc"
+#line 5289 "seclang-parser.cc"
     break;
 
   case 385: // act: "Pass"
-#line 2856 "seclang-parser.yy"
+#line 2887 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Pass(yystack_[0].value.as < std::string > ()));
       }
-#line 5253 "seclang-parser.cc"
+#line 5297 "seclang-parser.cc"
     break;
 
   case 386: // act: "Pause"
-#line 2860 "seclang-parser.yy"
+#line 2891 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Pause", yystack_[1].location);
       }
-#line 5261 "seclang-parser.cc"
+#line 5305 "seclang-parser.cc"
     break;
 
   case 387: // act: "Phase"
-#line 2864 "seclang-parser.yy"
+#line 2895 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Phase(yystack_[0].value.as < std::string > ()));
       }
-#line 5269 "seclang-parser.cc"
+#line 5313 "seclang-parser.cc"
     break;
 
   case 388: // act: "Prepend"
-#line 2868 "seclang-parser.yy"
+#line 2899 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Prepend", yystack_[1].location);
       }
-#line 5277 "seclang-parser.cc"
+#line 5321 "seclang-parser.cc"
     break;
 
   case 389: // act: "Proxy"
-#line 2872 "seclang-parser.yy"
+#line 2903 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("Proxy", yystack_[1].location);
       }
-#line 5285 "seclang-parser.cc"
+#line 5329 "seclang-parser.cc"
     break;
 
   case 390: // act: "Redirect" run_time_string
-#line 2876 "seclang-parser.yy"
+#line 2907 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::disruptive::Redirect(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5293 "seclang-parser.cc"
+#line 5337 "seclang-parser.cc"
     break;
 
   case 391: // act: "Rev"
-#line 2880 "seclang-parser.yy"
+#line 2911 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Rev(yystack_[0].value.as < std::string > ()));
       }
-#line 5301 "seclang-parser.cc"
+#line 5345 "seclang-parser.cc"
     break;
 
   case 392: // act: "SanitiseArg"
-#line 2884 "seclang-parser.yy"
+#line 2915 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseArg", yystack_[1].location);
       }
-#line 5309 "seclang-parser.cc"
+#line 5353 "seclang-parser.cc"
     break;
 
   case 393: // act: "SanitiseMatched"
-#line 2888 "seclang-parser.yy"
+#line 2919 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatched", yystack_[1].location);
       }
-#line 5317 "seclang-parser.cc"
+#line 5361 "seclang-parser.cc"
     break;
 
   case 394: // act: "SanitiseMatchedBytes"
-#line 2892 "seclang-parser.yy"
+#line 2923 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseMatchedBytes", yystack_[1].location);
       }
-#line 5325 "seclang-parser.cc"
+#line 5369 "seclang-parser.cc"
     break;
 
   case 395: // act: "SanitiseRequestHeader"
-#line 2896 "seclang-parser.yy"
+#line 2927 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseRequestHeader", yystack_[1].location);
       }
-#line 5333 "seclang-parser.cc"
+#line 5377 "seclang-parser.cc"
     break;
 
   case 396: // act: "SanitiseResponseHeader"
-#line 2900 "seclang-parser.yy"
+#line 2931 "seclang-parser.yy"
       {
         ACTION_NOT_SUPPORTED("SanitiseResponseHeader", yystack_[1].location);
       }
-#line 5341 "seclang-parser.cc"
+#line 5385 "seclang-parser.cc"
     break;
 
   case 397: // act: "SetEnv" run_time_string
-#line 2904 "seclang-parser.yy"
+#line 2935 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetENV(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5349 "seclang-parser.cc"
+#line 5393 "seclang-parser.cc"
     break;
 
   case 398: // act: "SetRsc" run_time_string
-#line 2908 "seclang-parser.yy"
+#line 2939 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetRSC(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5357 "seclang-parser.cc"
+#line 5401 "seclang-parser.cc"
     break;
 
   case 399: // act: "SetSid" run_time_string
-#line 2912 "seclang-parser.yy"
+#line 2943 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetSID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5365 "seclang-parser.cc"
+#line 5409 "seclang-parser.cc"
     break;
 
   case 400: // act: "SetUID" run_time_string
-#line 2916 "seclang-parser.yy"
+#line 2947 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetUID(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5373 "seclang-parser.cc"
+#line 5417 "seclang-parser.cc"
     break;
 
   case 401: // act: "SetVar" setvar_action
-#line 2920 "seclang-parser.yy"
+#line 2951 "seclang-parser.yy"
       {
         yylhs.value.as < std::unique_ptr<actions::Action> > () = std::move(yystack_[0].value.as < std::unique_ptr<actions::Action> > ());
       }
-#line 5381 "seclang-parser.cc"
+#line 5425 "seclang-parser.cc"
     break;
 
   case 402: // act: "Severity"
-#line 2924 "seclang-parser.yy"
+#line 2955 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Severity(yystack_[0].value.as < std::string > ()));
       }
-#line 5389 "seclang-parser.cc"
+#line 5433 "seclang-parser.cc"
     break;
 
   case 403: // act: "Skip"
-#line 2928 "seclang-parser.yy"
+#line 2959 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Skip(yystack_[0].value.as < std::string > ()));
       }
-#line 5397 "seclang-parser.cc"
+#line 5441 "seclang-parser.cc"
     break;
 
   case 404: // act: "SkipAfter"
-#line 2932 "seclang-parser.yy"
+#line 2963 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SkipAfter(yystack_[0].value.as < std::string > ()));
       }
-#line 5405 "seclang-parser.cc"
+#line 5449 "seclang-parser.cc"
     break;
 
   case 405: // act: "Status"
-#line 2936 "seclang-parser.yy"
+#line 2967 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::data::Status(yystack_[0].value.as < std::string > ()));
       }
-#line 5413 "seclang-parser.cc"
+#line 5457 "seclang-parser.cc"
     break;
 
   case 406: // act: "Tag" run_time_string
-#line 2940 "seclang-parser.yy"
+#line 2971 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Tag(std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5421 "seclang-parser.cc"
+#line 5465 "seclang-parser.cc"
     break;
 
   case 407: // act: "Ver"
-#line 2944 "seclang-parser.yy"
+#line 2975 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::Ver(yystack_[0].value.as < std::string > ()));
       }
-#line 5429 "seclang-parser.cc"
+#line 5473 "seclang-parser.cc"
     break;
 
   case 408: // act: "xmlns"
-#line 2948 "seclang-parser.yy"
+#line 2979 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::XmlNS(yystack_[0].value.as < std::string > ()));
       }
-#line 5437 "seclang-parser.cc"
+#line 5481 "seclang-parser.cc"
     break;
 
   case 409: // act: "ACTION_TRANSFORMATION_PARITY_ZERO_7_BIT"
-#line 2952 "seclang-parser.yy"
+#line 2983 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityZero7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5445 "seclang-parser.cc"
+#line 5489 "seclang-parser.cc"
     break;
 
   case 410: // act: "ACTION_TRANSFORMATION_PARITY_ODD_7_BIT"
-#line 2956 "seclang-parser.yy"
+#line 2987 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityOdd7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5453 "seclang-parser.cc"
+#line 5497 "seclang-parser.cc"
     break;
 
   case 411: // act: "ACTION_TRANSFORMATION_PARITY_EVEN_7_BIT"
-#line 2960 "seclang-parser.yy"
+#line 2991 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ParityEven7bit(yystack_[0].value.as < std::string > ()));
       }
-#line 5461 "seclang-parser.cc"
+#line 5505 "seclang-parser.cc"
     break;
 
   case 412: // act: "ACTION_TRANSFORMATION_SQL_HEX_DECODE"
-#line 2964 "seclang-parser.yy"
+#line 2995 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::SqlHexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5469 "seclang-parser.cc"
+#line 5513 "seclang-parser.cc"
     break;
 
   case 413: // act: "ACTION_TRANSFORMATION_BASE_64_ENCODE"
-#line 2968 "seclang-parser.yy"
+#line 2999 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Encode(yystack_[0].value.as < std::string > ()));
       }
-#line 5477 "seclang-parser.cc"
+#line 5521 "seclang-parser.cc"
     break;
 
   case 414: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE"
-#line 2972 "seclang-parser.yy"
+#line 3003 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64Decode(yystack_[0].value.as < std::string > ()));
       }
-#line 5485 "seclang-parser.cc"
+#line 5529 "seclang-parser.cc"
     break;
 
   case 415: // act: "ACTION_TRANSFORMATION_BASE_64_DECODE_EXT"
-#line 2976 "seclang-parser.yy"
+#line 3007 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Base64DecodeExt(yystack_[0].value.as < std::string > ()));
       }
-#line 5493 "seclang-parser.cc"
+#line 5537 "seclang-parser.cc"
     break;
 
   case 416: // act: "ACTION_TRANSFORMATION_CMD_LINE"
-#line 2980 "seclang-parser.yy"
+#line 3011 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CmdLine(yystack_[0].value.as < std::string > ()));
       }
-#line 5501 "seclang-parser.cc"
+#line 5545 "seclang-parser.cc"
     break;
 
   case 417: // act: "ACTION_TRANSFORMATION_SHA1"
-#line 2984 "seclang-parser.yy"
+#line 3015 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Sha1(yystack_[0].value.as < std::string > ()));
       }
-#line 5509 "seclang-parser.cc"
+#line 5553 "seclang-parser.cc"
     break;
 
   case 418: // act: "ACTION_TRANSFORMATION_MD5"
-#line 2988 "seclang-parser.yy"
+#line 3019 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Md5(yystack_[0].value.as < std::string > ()));
       }
-#line 5517 "seclang-parser.cc"
+#line 5561 "seclang-parser.cc"
     break;
 
   case 419: // act: "ACTION_TRANSFORMATION_ESCAPE_SEQ_DECODE"
-#line 2992 "seclang-parser.yy"
+#line 3023 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::EscapeSeqDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5525 "seclang-parser.cc"
+#line 5569 "seclang-parser.cc"
     break;
 
   case 420: // act: "ACTION_TRANSFORMATION_HEX_ENCODE"
-#line 2996 "seclang-parser.yy"
+#line 3027 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5533 "seclang-parser.cc"
+#line 5577 "seclang-parser.cc"
     break;
 
   case 421: // act: "ACTION_TRANSFORMATION_HEX_DECODE"
-#line 3000 "seclang-parser.yy"
+#line 3031 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HexDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5541 "seclang-parser.cc"
+#line 5585 "seclang-parser.cc"
     break;
 
   case 422: // act: "ACTION_TRANSFORMATION_LOWERCASE"
-#line 3004 "seclang-parser.yy"
+#line 3035 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::LowerCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5549 "seclang-parser.cc"
+#line 5593 "seclang-parser.cc"
     break;
 
   case 423: // act: "ACTION_TRANSFORMATION_UPPERCASE"
-#line 3008 "seclang-parser.yy"
+#line 3039 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UpperCase(yystack_[0].value.as < std::string > ()));
       }
-#line 5557 "seclang-parser.cc"
+#line 5601 "seclang-parser.cc"
     break;
 
   case 424: // act: "ACTION_TRANSFORMATION_URL_DECODE_UNI"
-#line 3012 "seclang-parser.yy"
+#line 3043 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecodeUni(yystack_[0].value.as < std::string > ()));
       }
-#line 5565 "seclang-parser.cc"
+#line 5609 "seclang-parser.cc"
     break;
 
   case 425: // act: "ACTION_TRANSFORMATION_URL_DECODE"
-#line 3016 "seclang-parser.yy"
+#line 3047 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5573 "seclang-parser.cc"
+#line 5617 "seclang-parser.cc"
     break;
 
   case 426: // act: "ACTION_TRANSFORMATION_URL_ENCODE"
-#line 3020 "seclang-parser.yy"
+#line 3051 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::UrlEncode(yystack_[0].value.as < std::string > ()));
       }
-#line 5581 "seclang-parser.cc"
+#line 5625 "seclang-parser.cc"
     break;
 
   case 427: // act: "ACTION_TRANSFORMATION_NONE"
-#line 3024 "seclang-parser.yy"
+#line 3055 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::None(yystack_[0].value.as < std::string > ()));
       }
-#line 5589 "seclang-parser.cc"
+#line 5633 "seclang-parser.cc"
     break;
 
   case 428: // act: "ACTION_TRANSFORMATION_COMPRESS_WHITESPACE"
-#line 3028 "seclang-parser.yy"
+#line 3059 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CompressWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5597 "seclang-parser.cc"
+#line 5641 "seclang-parser.cc"
     break;
 
   case 429: // act: "ACTION_TRANSFORMATION_REMOVE_WHITESPACE"
-#line 3032 "seclang-parser.yy"
+#line 3063 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveWhitespace(yystack_[0].value.as < std::string > ()));
       }
-#line 5605 "seclang-parser.cc"
+#line 5649 "seclang-parser.cc"
     break;
 
   case 430: // act: "ACTION_TRANSFORMATION_REPLACE_NULLS"
-#line 3036 "seclang-parser.yy"
+#line 3067 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5613 "seclang-parser.cc"
+#line 5657 "seclang-parser.cc"
     break;
 
   case 431: // act: "ACTION_TRANSFORMATION_REMOVE_NULLS"
-#line 3040 "seclang-parser.yy"
+#line 3071 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveNulls(yystack_[0].value.as < std::string > ()));
       }
-#line 5621 "seclang-parser.cc"
+#line 5665 "seclang-parser.cc"
     break;
 
   case 432: // act: "ACTION_TRANSFORMATION_HTML_ENTITY_DECODE"
-#line 3044 "seclang-parser.yy"
+#line 3075 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::HtmlEntityDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5629 "seclang-parser.cc"
+#line 5673 "seclang-parser.cc"
     break;
 
   case 433: // act: "ACTION_TRANSFORMATION_JS_DECODE"
-#line 3048 "seclang-parser.yy"
+#line 3079 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::JsDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5637 "seclang-parser.cc"
+#line 5681 "seclang-parser.cc"
     break;
 
   case 434: // act: "ACTION_TRANSFORMATION_CSS_DECODE"
-#line 3052 "seclang-parser.yy"
+#line 3083 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::CssDecode(yystack_[0].value.as < std::string > ()));
       }
-#line 5645 "seclang-parser.cc"
+#line 5689 "seclang-parser.cc"
     break;
 
   case 435: // act: "ACTION_TRANSFORMATION_TRIM"
-#line 3056 "seclang-parser.yy"
+#line 3087 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Trim(yystack_[0].value.as < std::string > ()));
       }
-#line 5653 "seclang-parser.cc"
+#line 5697 "seclang-parser.cc"
     break;
 
   case 436: // act: "ACTION_TRANSFORMATION_TRIM_LEFT"
-#line 3060 "seclang-parser.yy"
+#line 3091 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimLeft(yystack_[0].value.as < std::string > ()));
       }
-#line 5661 "seclang-parser.cc"
+#line 5705 "seclang-parser.cc"
     break;
 
   case 437: // act: "ACTION_TRANSFORMATION_TRIM_RIGHT"
-#line 3064 "seclang-parser.yy"
+#line 3095 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::TrimRight(yystack_[0].value.as < std::string > ()));
       }
-#line 5669 "seclang-parser.cc"
+#line 5713 "seclang-parser.cc"
     break;
 
   case 438: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH_WIN"
-#line 3068 "seclang-parser.yy"
+#line 3099 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePathWin(yystack_[0].value.as < std::string > ()));
       }
-#line 5677 "seclang-parser.cc"
+#line 5721 "seclang-parser.cc"
     break;
 
   case 439: // act: "ACTION_TRANSFORMATION_NORMALISE_PATH"
-#line 3072 "seclang-parser.yy"
+#line 3103 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::NormalisePath(yystack_[0].value.as < std::string > ()));
       }
-#line 5685 "seclang-parser.cc"
+#line 5729 "seclang-parser.cc"
     break;
 
   case 440: // act: "ACTION_TRANSFORMATION_LENGTH"
-#line 3076 "seclang-parser.yy"
+#line 3107 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Length(yystack_[0].value.as < std::string > ()));
       }
-#line 5693 "seclang-parser.cc"
+#line 5737 "seclang-parser.cc"
     break;
 
   case 441: // act: "ACTION_TRANSFORMATION_UTF8_TO_UNICODE"
-#line 3080 "seclang-parser.yy"
+#line 3111 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::Utf8ToUnicode(yystack_[0].value.as < std::string > ()));
       }
-#line 5701 "seclang-parser.cc"
+#line 5745 "seclang-parser.cc"
     break;
 
   case 442: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS_CHAR"
-#line 3084 "seclang-parser.yy"
+#line 3115 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveCommentsChar(yystack_[0].value.as < std::string > ()));
       }
-#line 5709 "seclang-parser.cc"
+#line 5753 "seclang-parser.cc"
     break;
 
   case 443: // act: "ACTION_TRANSFORMATION_REMOVE_COMMENTS"
-#line 3088 "seclang-parser.yy"
+#line 3119 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::RemoveComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5717 "seclang-parser.cc"
+#line 5761 "seclang-parser.cc"
     break;
 
   case 444: // act: "ACTION_TRANSFORMATION_REPLACE_COMMENTS"
-#line 3092 "seclang-parser.yy"
+#line 3123 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::transformations::ReplaceComments(yystack_[0].value.as < std::string > ()));
       }
-#line 5725 "seclang-parser.cc"
+#line 5769 "seclang-parser.cc"
     break;
 
   case 445: // setvar_action: "NOT" var
-#line 3099 "seclang-parser.yy"
+#line 3130 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::unsetOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5733 "seclang-parser.cc"
+#line 5777 "seclang-parser.cc"
     break;
 
   case 446: // setvar_action: var
-#line 3103 "seclang-parser.yy"
+#line 3134 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setToOneOperation, std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ())));
       }
-#line 5741 "seclang-parser.cc"
+#line 5785 "seclang-parser.cc"
     break;
 
   case 447: // setvar_action: var SETVAR_OPERATION_EQUALS run_time_string
-#line 3107 "seclang-parser.yy"
+#line 3138 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::setOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5749 "seclang-parser.cc"
+#line 5793 "seclang-parser.cc"
     break;
 
   case 448: // setvar_action: var SETVAR_OPERATION_EQUALS_PLUS run_time_string
-#line 3111 "seclang-parser.yy"
+#line 3142 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::sumAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5757 "seclang-parser.cc"
+#line 5801 "seclang-parser.cc"
     break;
 
   case 449: // setvar_action: var SETVAR_OPERATION_EQUALS_MINUS run_time_string
-#line 3115 "seclang-parser.yy"
+#line 3146 "seclang-parser.yy"
       {
         ACTION_CONTAINER(yylhs.value.as < std::unique_ptr<actions::Action> > (), new actions::SetVar(actions::SetVarOperation::substractAndSetOperation, std::move(yystack_[2].value.as < std::unique_ptr<Variable> > ()), std::move(yystack_[0].value.as < std::unique_ptr<RunTimeString> > ())));
       }
-#line 5765 "seclang-parser.cc"
+#line 5809 "seclang-parser.cc"
     break;
 
   case 450: // run_time_string: run_time_string "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3122 "seclang-parser.yy"
+#line 3153 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5774 "seclang-parser.cc"
+#line 5818 "seclang-parser.cc"
     break;
 
   case 451: // run_time_string: run_time_string var
-#line 3127 "seclang-parser.yy"
+#line 3158 "seclang-parser.yy"
       {
         yystack_[1].value.as < std::unique_ptr<RunTimeString> > ()->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(yystack_[1].value.as < std::unique_ptr<RunTimeString> > ());
       }
-#line 5783 "seclang-parser.cc"
+#line 5827 "seclang-parser.cc"
     break;
 
   case 452: // run_time_string: "FREE_TEXT_QUOTE_MACRO_EXPANSION"
-#line 3132 "seclang-parser.yy"
+#line 3163 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendText(yystack_[0].value.as < std::string > ());
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5793 "seclang-parser.cc"
+#line 5837 "seclang-parser.cc"
     break;
 
   case 453: // run_time_string: var
-#line 3138 "seclang-parser.yy"
+#line 3169 "seclang-parser.yy"
       {
         std::unique_ptr<RunTimeString> r(new RunTimeString());
         r->appendVar(std::move(yystack_[0].value.as < std::unique_ptr<Variable> > ()));
         yylhs.value.as < std::unique_ptr<RunTimeString> > () = std::move(r);
       }
-#line 5803 "seclang-parser.cc"
+#line 5847 "seclang-parser.cc"
     break;
 
 
-#line 5807 "seclang-parser.cc"
+#line 5851 "seclang-parser.cc"
 
             default:
               break;
@@ -7340,52 +7384,52 @@ namespace yy {
   const short
   seclang_parser::yyrline_[] =
   {
-       0,   736,   736,   740,   741,   744,   749,   755,   761,   765,
-     769,   775,   781,   787,   793,   798,   803,   809,   816,   823,
-     827,   831,   837,   841,   845,   850,   858,   866,   871,   875,
-     882,   886,   893,   899,   909,   918,   928,   937,   950,   954,
-     958,   962,   966,   970,   974,   978,   982,   986,   991,   995,
-     999,  1003,  1007,  1011,  1016,  1021,  1025,  1029,  1033,  1037,
-    1041,  1045,  1049,  1053,  1057,  1061,  1065,  1069,  1073,  1077,
-    1081,  1085,  1089,  1093,  1097,  1111,  1112,  1143,  1162,  1182,
-    1211,  1268,  1275,  1279,  1283,  1287,  1291,  1295,  1299,  1303,
-    1312,  1316,  1321,  1324,  1329,  1334,  1339,  1344,  1347,  1352,
-    1355,  1360,  1365,  1368,  1373,  1378,  1383,  1388,  1393,  1398,
-    1403,  1406,  1411,  1416,  1421,  1426,  1429,  1434,  1439,  1444,
-    1457,  1470,  1483,  1496,  1509,  1535,  1563,  1575,  1595,  1622,
-    1627,  1633,  1641,  1649,  1658,  1666,  1670,  1674,  1678,  1682,
-    1686,  1690,  1695,  1703,  1715,  1721,  1725,  1729,  1733,  1737,
-    1741,  1752,  1761,  1762,  1769,  1774,  1779,  1833,  1840,  1848,
-    1885,  1889,  1896,  1901,  1907,  1913,  1919,  1926,  1936,  1940,
-    1944,  1948,  1952,  1956,  1960,  1964,  1968,  1972,  1976,  1980,
-    1984,  1988,  1992,  1996,  2000,  2004,  2008,  2012,  2016,  2020,
-    2024,  2028,  2032,  2036,  2040,  2044,  2048,  2052,  2056,  2060,
-    2064,  2068,  2072,  2076,  2080,  2084,  2088,  2092,  2096,  2100,
-    2104,  2108,  2112,  2116,  2120,  2124,  2128,  2132,  2136,  2140,
-    2144,  2148,  2152,  2156,  2160,  2164,  2168,  2172,  2176,  2180,
-    2184,  2188,  2192,  2196,  2200,  2204,  2208,  2212,  2216,  2220,
-    2224,  2228,  2232,  2236,  2240,  2244,  2248,  2252,  2256,  2260,
-    2264,  2268,  2272,  2276,  2280,  2284,  2288,  2292,  2296,  2300,
-    2304,  2309,  2313,  2317,  2322,  2326,  2330,  2335,  2340,  2344,
-    2348,  2352,  2356,  2360,  2364,  2368,  2372,  2376,  2380,  2384,
-    2388,  2392,  2396,  2400,  2404,  2408,  2412,  2416,  2420,  2424,
-    2428,  2432,  2436,  2440,  2444,  2448,  2452,  2456,  2460,  2464,
-    2468,  2472,  2476,  2480,  2484,  2488,  2492,  2496,  2500,  2504,
-    2508,  2512,  2516,  2520,  2524,  2528,  2532,  2536,  2540,  2544,
-    2548,  2552,  2556,  2560,  2564,  2568,  2572,  2576,  2580,  2584,
-    2588,  2596,  2603,  2610,  2617,  2624,  2631,  2638,  2645,  2652,
-    2659,  2666,  2673,  2683,  2687,  2691,  2695,  2699,  2703,  2707,
-    2711,  2716,  2720,  2725,  2729,  2733,  2737,  2741,  2746,  2751,
-    2755,  2759,  2763,  2767,  2771,  2775,  2779,  2783,  2787,  2791,
-    2795,  2799,  2803,  2807,  2811,  2815,  2819,  2823,  2827,  2831,
-    2835,  2839,  2843,  2847,  2851,  2855,  2859,  2863,  2867,  2871,
-    2875,  2879,  2883,  2887,  2891,  2895,  2899,  2903,  2907,  2911,
-    2915,  2919,  2923,  2927,  2931,  2935,  2939,  2943,  2947,  2951,
-    2955,  2959,  2963,  2967,  2971,  2975,  2979,  2983,  2987,  2991,
-    2995,  2999,  3003,  3007,  3011,  3015,  3019,  3023,  3027,  3031,
-    3035,  3039,  3043,  3047,  3051,  3055,  3059,  3063,  3067,  3071,
-    3075,  3079,  3083,  3087,  3091,  3098,  3102,  3106,  3110,  3114,
-    3121,  3126,  3131,  3137
+       0,   747,   747,   751,   752,   755,   760,   766,   772,   776,
+     780,   786,   792,   798,   804,   809,   814,   820,   827,   834,
+     838,   842,   848,   852,   856,   861,   869,   877,   882,   886,
+     893,   897,   904,   910,   920,   929,   939,   948,   961,   965,
+     969,   973,   977,   981,   985,   989,   993,   997,  1002,  1006,
+    1010,  1014,  1018,  1022,  1027,  1032,  1036,  1040,  1044,  1048,
+    1052,  1056,  1060,  1064,  1068,  1072,  1076,  1080,  1084,  1088,
+    1092,  1096,  1100,  1104,  1108,  1122,  1123,  1154,  1173,  1193,
+    1222,  1279,  1286,  1290,  1294,  1298,  1302,  1306,  1310,  1314,
+    1323,  1327,  1332,  1335,  1340,  1345,  1350,  1355,  1358,  1363,
+    1366,  1371,  1376,  1379,  1384,  1389,  1394,  1399,  1404,  1409,
+    1414,  1417,  1422,  1427,  1432,  1437,  1440,  1445,  1450,  1455,
+    1468,  1481,  1494,  1507,  1520,  1546,  1574,  1586,  1606,  1633,
+    1638,  1644,  1652,  1660,  1669,  1677,  1681,  1685,  1689,  1693,
+    1697,  1701,  1706,  1714,  1726,  1732,  1736,  1740,  1744,  1748,
+    1752,  1763,  1792,  1793,  1800,  1805,  1810,  1864,  1871,  1879,
+    1916,  1920,  1927,  1932,  1938,  1944,  1950,  1957,  1967,  1971,
+    1975,  1979,  1983,  1987,  1991,  1995,  1999,  2003,  2007,  2011,
+    2015,  2019,  2023,  2027,  2031,  2035,  2039,  2043,  2047,  2051,
+    2055,  2059,  2063,  2067,  2071,  2075,  2079,  2083,  2087,  2091,
+    2095,  2099,  2103,  2107,  2111,  2115,  2119,  2123,  2127,  2131,
+    2135,  2139,  2143,  2147,  2151,  2155,  2159,  2163,  2167,  2171,
+    2175,  2179,  2183,  2187,  2191,  2195,  2199,  2203,  2207,  2211,
+    2215,  2219,  2223,  2227,  2231,  2235,  2239,  2243,  2247,  2251,
+    2255,  2259,  2263,  2267,  2271,  2275,  2279,  2283,  2287,  2291,
+    2295,  2299,  2303,  2307,  2311,  2315,  2319,  2323,  2327,  2331,
+    2335,  2340,  2344,  2348,  2353,  2357,  2361,  2366,  2371,  2375,
+    2379,  2383,  2387,  2391,  2395,  2399,  2403,  2407,  2411,  2415,
+    2419,  2423,  2427,  2431,  2435,  2439,  2443,  2447,  2451,  2455,
+    2459,  2463,  2467,  2471,  2475,  2479,  2483,  2487,  2491,  2495,
+    2499,  2503,  2507,  2511,  2515,  2519,  2523,  2527,  2531,  2535,
+    2539,  2543,  2547,  2551,  2555,  2559,  2563,  2567,  2571,  2575,
+    2579,  2583,  2587,  2591,  2595,  2599,  2603,  2607,  2611,  2615,
+    2619,  2627,  2634,  2641,  2648,  2655,  2662,  2669,  2676,  2683,
+    2690,  2697,  2704,  2714,  2718,  2722,  2726,  2730,  2734,  2738,
+    2742,  2747,  2751,  2756,  2760,  2764,  2768,  2772,  2777,  2782,
+    2786,  2790,  2794,  2798,  2802,  2806,  2810,  2814,  2818,  2822,
+    2826,  2830,  2834,  2838,  2842,  2846,  2850,  2854,  2858,  2862,
+    2866,  2870,  2874,  2878,  2882,  2886,  2890,  2894,  2898,  2902,
+    2906,  2910,  2914,  2918,  2922,  2926,  2930,  2934,  2938,  2942,
+    2946,  2950,  2954,  2958,  2962,  2966,  2970,  2974,  2978,  2982,
+    2986,  2990,  2994,  2998,  3002,  3006,  3010,  3014,  3018,  3022,
+    3026,  3030,  3034,  3038,  3042,  3046,  3050,  3054,  3058,  3062,
+    3066,  3070,  3074,  3078,  3082,  3086,  3090,  3094,  3098,  3102,
+    3106,  3110,  3114,  3118,  3122,  3129,  3133,  3137,  3141,  3145,
+    3152,  3157,  3162,  3168
   };
 
   void
@@ -7417,9 +7461,9 @@ namespace yy {
 
 
 } // yy
-#line 7421 "seclang-parser.cc"
+#line 7465 "seclang-parser.cc"
 
-#line 3144 "seclang-parser.yy"
+#line 3175 "seclang-parser.yy"
 
 
 void yy::seclang_parser::error (const location_type& l, const std::string& m) {

--- a/src/parser/seclang-parser.hh
+++ b/src/parser/seclang-parser.hh
@@ -32,7 +32,7 @@
 
 
 /**
- ** \file y.tab.h
+ ** \file seclang-parser.hh
  ** Define the yy::parser class.
  */
 
@@ -2139,67 +2139,67 @@ namespace yy {
         switch (yykind)
         {
       case symbol_kind::S_actions: // actions
-#line 724 "seclang-parser.yy"
+#line 735 "seclang-parser.yy"
                     { }
 #line 2145 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_actions_may_quoted: // actions_may_quoted
-#line 724 "seclang-parser.yy"
+#line 735 "seclang-parser.yy"
                     { }
 #line 2151 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_op: // op
-#line 725 "seclang-parser.yy"
+#line 736 "seclang-parser.yy"
                     { }
 #line 2157 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_op_before_init: // op_before_init
-#line 725 "seclang-parser.yy"
+#line 736 "seclang-parser.yy"
                     { }
 #line 2163 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_variables: // variables
-#line 727 "seclang-parser.yy"
+#line 738 "seclang-parser.yy"
                     { }
 #line 2169 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_variables_pre_process: // variables_pre_process
-#line 727 "seclang-parser.yy"
+#line 738 "seclang-parser.yy"
                     { }
 #line 2175 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_variables_may_be_quoted: // variables_may_be_quoted
-#line 727 "seclang-parser.yy"
+#line 738 "seclang-parser.yy"
                     { }
 #line 2181 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_var: // var
-#line 726 "seclang-parser.yy"
+#line 737 "seclang-parser.yy"
                     { }
 #line 2187 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_act: // act
-#line 722 "seclang-parser.yy"
+#line 733 "seclang-parser.yy"
                     { }
 #line 2193 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_setvar_action: // setvar_action
-#line 722 "seclang-parser.yy"
+#line 733 "seclang-parser.yy"
                     { }
 #line 2199 "seclang-parser.hh"
         break;
 
       case symbol_kind::S_run_time_string: // run_time_string
-#line 723 "seclang-parser.yy"
+#line 734 "seclang-parser.yy"
                     { }
 #line 2205 "seclang-parser.hh"
         break;

--- a/src/parser/seclang-parser.yy
+++ b/src/parser/seclang-parser.yy
@@ -331,6 +331,17 @@ using namespace modsecurity::operators;
 %code
 {
 #include "src/parser/driver.h"
+#include <cerrno>
+#include <cstring>
+#include <sys/types.h>
+#include <sys/stat.h>
+#if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+#ifndef WIN32
+#include <unistd.h>
+#endif
+#include "src/collection/backend/lmdb.h"
 }
 %define api.token.prefix {TOK_}
 %token
@@ -1750,14 +1761,34 @@ expression:
 */
       }
     | CONGIG_DIR_SEC_DATA_DIR
-/* Parser error disabled to avoid breaking default installations with modsecurity.conf-recommended
-        std::stringstream ss;
-        ss << "SecDataDir is not currently supported.";
-        ss << " Collections are kept in memory (in_memory-per_process) for now.";
-        ss << " When using a backend such as LMDB, temp data path is currently defined by the backend.";
-        driver.error(@0, ss.str());
-        YYERROR;
-*/
+      {
+        driver.m_secDataDir.m_set = true;
+        driver.m_secDataDir.m_value = $1;
+#ifdef WITH_LMDB
+        struct stat dstat;
+        if (stat($1.c_str(), &dstat) != 0) {
+            std::stringstream ss;
+            ss << "SecDataDir '" << $1 << "' does not exist: " << strerror(errno);
+            driver.error(@0, ss.str());
+            YYERROR;
+        }
+        if (!S_ISDIR(dstat.st_mode)) {
+            std::stringstream ss;
+            ss << "SecDataDir '" << $1 << "' is not a directory.";
+            driver.error(@0, ss.str());
+            YYERROR;
+        }
+#ifndef WIN32
+        if (access($1.c_str(), W_OK | X_OK) != 0) {
+            std::stringstream ss;
+            ss << "SecDataDir '" << $1 << "' is not writable: " << strerror(errno);
+            driver.error(@0, ss.str());
+            YYERROR;
+        }
+#endif
+        collection::backend::MDBEnvProvider::SetDataDir($1);
+#endif
+      }
     | CONGIG_DIR_SEC_ARG_SEP
     | CONGIG_DIR_SEC_COOKIE_FORMAT
       {

--- a/src/parser/seclang-scanner.cc
+++ b/src/parser/seclang-scanner.cc
@@ -1,5 +1,6 @@
+#line 2 "seclang-scanner.cc"
 
-#line 3 "seclang-scanner.cc"
+#line 4 "seclang-scanner.cc"
 
 #define  YY_INT_ALIGNED short int
 
@@ -5010,7 +5011,7 @@ static const char* find_separator(const char *s) {
 #define BEGIN_PREVIOUS() { BEGIN(YY_PREVIOUS_STATE.top()); YY_PREVIOUS_STATE.pop(); }
 
 // The location of the current token.
-#line 5014 "seclang-scanner.cc"
+#line 5015 "seclang-scanner.cc"
 #define YY_NO_INPUT 1
 #define YY_NO_UNISTD_H 1
 
@@ -5018,8 +5019,8 @@ static const char* find_separator(const char *s) {
   // Code run each time a pattern is matched.
   # define YY_USER_ACTION  driver.loc.back()->columns (yyleng);
 
-#line 5022 "seclang-scanner.cc"
 #line 5023 "seclang-scanner.cc"
+#line 5024 "seclang-scanner.cc"
 
 #define INITIAL 0
 #define EXPECTING_ACTION_PREDICATE_VARIABLE 1
@@ -5341,7 +5342,7 @@ YY_DECL
   // Code run each time yylex is called.
   driver.loc.back()->step();
 
-#line 5345 "seclang-scanner.cc"
+#line 5346 "seclang-scanner.cc"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -8477,7 +8478,7 @@ YY_RULE_SETUP
 #line 1355 "seclang-scanner.ll"
 ECHO;
 	YY_BREAK
-#line 8481 "seclang-scanner.cc"
+#line 8482 "seclang-scanner.cc"
 
 	case YY_END_OF_BUFFER:
 		{


### PR DESCRIPTION
## what

- SecDataDir is now honoured by the LMDB backend. The path is stored in
  RulesSetProperties and used by the MDBEnvProvider singleton to open the LMDB
  environment (data.mdb/lock.mdb) inside that directory. Falls back to the
  legacy "./modsec-shared-collections" file when SecDataDir is unset.

- SecDataDir misconfiguration is now loud. The parser validates the path
  (exists, is a directory, writable) and fails configuration load on error,
  surfacing the message through getParserError to the connector error log.

- LMDB open failures are now logged to stderr instead of being silently
  swallowed.

- Literal setvar targets now persist. set_var.cc only dispatched writes to
  the dynamic variable subclasses. Variables parsed as literal dict elements
  fell through an empty else branch and were never stored. This adds name
  based dispatch for the literal case.

- Collection variable names are now case-insensitive. The composite key
  compared variable names case-sensitively, so setvar:ip.counter and
  IP:COUNTER resolved to different entries. All Collection wrapper methods now
  lowercase the variable name term.

- Bison and flex outputs regenerated from the edited grammar.


## why

- SecDataDir is a documented directive shipped in modsecurity.conf-recommended.
  Users expect it to control where persistent collection data lives. In v3
  with LMDB it was a no-op: the value was discarded and the file always
  appeared in the worker current working directory, with no error in the log.

- The silent setvar no-op was a data loss bug. Any rule writing a literal
  collection variable lost the value with no error. The 2018 RunTimeString
  refactor replaced the original generic dispatcher with per type dynamic
  casts that omitted the literal case by oversight, not by design.

- Case insensitive variable names are a SecLang property: the scanner matches
  collection prefixes case insensitively. The case sensitive key broke the
  natural pattern of a lowercase write and uppercase read, silently producing
  empty match values. Fixing it at the Collection wrapper boundary covers both
  LMDB and in memory backends.


## references

- Hardcoded LMDB path: lmdb.cc mdb_env_open of "./modsec-shared-collections".
- setvar literal no-op: set_var.cc dynamic cast dispatch, introduced in
  commit f17af957 "Using RunTimeString on setvar action".
- Case sensitive keys: collection.h composite key wrappers, lmdb.cc strncmp.
- modsecurity.conf-recommended line 203 ships "SecDataDir /tmp/".
- Tests that informed the fix: action-expirevar.json (lowercase write plus
  uppercase read asserted the value), collection-regular_expression_selection
  .json (uppercase setvar only asserted the debug log line, masking the no-op).

## related issue
[#3394](https://github.com/owasp-modsecurity/ModSecurity/issues/3394)


## changed files

Hand edited:
- headers/modsecurity/rules_set_properties.h
- headers/modsecurity/collection/collection.h
- src/parser/seclang-parser.yy
- src/collection/backend/lmdb.h
- src/collection/backend/lmdb.cc
- src/actions/set_var.cc

Regenerated:
- src/parser/seclang-parser.cc
- src/parser/seclang-parser.hh
- src/parser/seclang-scanner.cc