### PR TITLE
fix(iis): correct InstallModule32/64 CustomAction ID naming swap

### DIFF
--- a/iis/installer.wxs
+++ b/iis/installer.wxs
@@ -361,9 +361,9 @@
             <Custom Action="Cleanup4" Before="Cleanup3"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
             <Custom Action="Cleanup5" Before="Cleanup4"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
             <?if $(var.Win64) = "yes" ?>
-            <Custom Action="InstallModule64" Before="InstallFinalize"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
-            <Custom Action="InstallModule32" After="InstallModule64"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
-            <Custom Action="InstallConf" After="InstallModule32"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
+            <Custom Action="InstallModule32" Before="InstallFinalize"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
+            <Custom Action="InstallModule64" After="InstallModule32"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
+            <Custom Action="InstallConf" After="InstallModule64"><![CDATA[NOT Installed AND IIS_SETUP]]></Custom>
             <Custom Action="UninstallConf" Before="RemoveFiles"><![CDATA[Installed AND IIS_SETUP]]></Custom>
             <Custom Action="UninstallModule32" Before="UninstallConf"><![CDATA[Installed AND IIS_SETUP]]></Custom>
             <Custom Action="UninstallModule64" Before="UninstallModule32"><![CDATA[Installed AND IIS_SETUP]]></Custom>
@@ -390,8 +390,8 @@
         <CustomAction Id="Cleanup5" Execute="deferred" Impersonate="no" Return="ignore" Directory="INSTALLFOLDER" ExeCommand="&quot;[SystemFolder]inetsrv\appcmd.exe&quot; uninstall module /module.name:&quot;ModSecurityIIS&quot;" />
         <?endif?>
         <?if $(var.Win64) = "yes" ?>
-        <CustomAction Id="InstallModule32" Execute="deferred" Impersonate="no" Return="check" Directory="INSTALLFOLDER" ExeCommand="&quot;[System64Folder]inetsrv\appcmd.exe&quot; install module /name:&quot;ModSecurity IIS (64bits)&quot; /image:&quot;%SystemRoot%\System32\inetsrv\ModSecurityIIS.dll&quot; /preCondition:&quot;bitness64&quot;" />
-        <CustomAction Id="InstallModule64" Execute="deferred" Impersonate="no" Return="check" Directory="INSTALLFOLDER" ExeCommand="&quot;[System64Folder]inetsrv\appcmd.exe&quot; install module /name:&quot;ModSecurity IIS (32bits)&quot; /image:&quot;%SystemRoot%\SysWOW64\inetsrv\ModSecurityIIS.dll&quot; /preCondition:&quot;bitness32&quot;" />
+        <CustomAction Id="InstallModule64" Execute="deferred" Impersonate="no" Return="check" Directory="INSTALLFOLDER" ExeCommand="&quot;[System64Folder]inetsrv\appcmd.exe&quot; install module /name:&quot;ModSecurity IIS (64bits)&quot; /image:&quot;%SystemRoot%\System32\inetsrv\ModSecurityIIS.dll&quot; /preCondition:&quot;bitness64&quot;" />
+        <CustomAction Id="InstallModule32" Execute="deferred" Impersonate="no" Return="check" Directory="INSTALLFOLDER" ExeCommand="&quot;[System64Folder]inetsrv\appcmd.exe&quot; install module /name:&quot;ModSecurity IIS (32bits)&quot; /image:&quot;%SystemRoot%\SysWOW64\inetsrv\ModSecurityIIS.dll&quot; /preCondition:&quot;bitness32&quot;" />
         <?else?>
         <CustomAction Id="InstallModule32" Execute="deferred" Impersonate="no" Return="check" Directory="INSTALLFOLDER" ExeCommand="&quot;[SystemFolder]inetsrv\appcmd.exe&quot; install module /name:&quot;ModSecurity IIS (32bits)&quot; /image:&quot;%SystemRoot%\System32\inetsrv\ModSecurityIIS.dll&quot;" />
         <?endif?>


### PR DESCRIPTION
## what

In `iis/installer.wxs`, within the 64-bit installer path (`Win64=yes`), the two `InstallModule*` `CustomAction` IDs were swapped relative to what they actually install:

- `CustomAction Id="InstallModule32"` installed the **64-bit** module (`System32`, `/preCondition:"bitness64"`)
- `CustomAction Id="InstallModule64"` installed the **32-bit** module (`SysWOW64`, `/preCondition:"bitness32"`)

This swaps the two IDs (and updates the matching `InstallExecuteSequence` references) so each ID now matches its actual bitness, in the exact same relative execution order as before.

## why

Not a functional bug: both actions run unconditionally on every install and are correctly gated by `appcmd`'s own `/preCondition` bitness check rather than by the `CustomAction` ID, and the sequence references already matched their (mis-)named actions consistently. But the naming is misleading to anyone maintaining this file, and inconsistent with the already-correctly-named `UninstallModule32`/`UninstallModule64` pair a few lines below, which don't have this swap.

Rename only — no logic or ordering change. Verified `iis/installer.wxs` is still well-formed XML (`xmllint --noout`) and re-checked every remaining `InstallModule32`/`InstallModule64` reference in the file for consistency after the rename.

## references

Found while reviewing #3491.

## AI Disclosure

Found and fixed with the assistance of Claude Sonnet 5, based on a naming inconsistency I noticed while reviewing PR #3491. Verified by direct inspection of the diff and by checking XML well-formedness; no behavioral change intended or introduced.